### PR TITLE
feat(admin): support forward-auth remote user headers

### DIFF
--- a/admin/src/portr_admin/config.py
+++ b/admin/src/portr_admin/config.py
@@ -9,8 +9,10 @@ class Settings(BaseSettings):
     use_vite: bool = Field(default=False, alias="PORTR_ADMIN_USE_VITE")
     encryption_key: str = Field(alias="PORTR_ADMIN_ENCRYPTION_KEY")
 
-    github_client_id: str = Field(alias="PORTR_ADMIN_GITHUB_CLIENT_ID")
-    github_client_secret: str = Field(alias="PORTR_ADMIN_GITHUB_CLIENT_SECRET")
+    github_client_id: str = Field(alias="PORTR_ADMIN_GITHUB_CLIENT_ID", default="")
+    github_client_secret: str = Field(alias="PORTR_ADMIN_GITHUB_CLIENT_SECRET", default="")
+
+    remote_user_header: str = Field(alias="PORTR_ADMIN_REMOTE_USER_HEADER", default="")
 
     server_url: str
     ssh_url: str

--- a/admin/src/portr_admin/main.py
+++ b/admin/src/portr_admin/main.py
@@ -1,5 +1,4 @@
-from typing import Annotated
-from fastapi import Cookie, FastAPI, Request
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse, RedirectResponse
 from portr_admin.apis import api as api_v1
 from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore
@@ -41,11 +40,10 @@ scheduler.start()
 
 @app.get("/")
 async def render_index_template(
-    request: Request,
-    portr_session: Annotated[str | None, Cookie()] = None,
+    request: Request
 ):
     try:
-        user: User = await get_current_user(portr_session)
+        user: User = await get_current_user(request)
     except NotAuthenticated:
         return templates.TemplateResponse(
             request=request,
@@ -67,10 +65,9 @@ async def render_index_template(
 @app.get("/instance-settings/{rest:path}")
 async def render_index_template_for_instance_settings_routes(
     request: Request,
-    portr_session: Annotated[str | None, Cookie()] = None,
 ):
     try:
-        user: User = await get_current_user(portr_session)
+        user: User = await get_current_user(request)
     except NotAuthenticated:
         next_url = request.url.path + "?" + request.url.query
         next_url_encoded = urllib.parse.urlencode({"next": next_url})
@@ -98,10 +95,9 @@ async def render_index_template_for_instance_settings_routes(
 async def render_index_template_for_team_routes(
     request: Request,
     team: str,
-    portr_session: Annotated[str | None, Cookie()] = None,
 ):
     try:
-        user: User = await get_current_user(portr_session)
+        user: User = await get_current_user(request)
     except NotAuthenticated:
         next_url = request.url.path + "?" + request.url.query
         next_url_encoded = urllib.parse.urlencode({"next": next_url})

--- a/docs/src/content/docs/server/start-the-tunnel-server.md
+++ b/docs/src/content/docs/server/start-the-tunnel-server.md
@@ -37,6 +37,7 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres
 
 PORTR_ADMIN_ENCRYPTION_KEY=
+PORTR_ADMIN_REMOTE_USER_HEADER=
 ```
 
 Generate an encryption key using the following command
@@ -54,4 +55,29 @@ If you want to run postgres separately and not as a service, you can exclude the
 Run `docker compose up` to start the servers. Once the servers are up, go to example.com and login in to the admin.
 First login will be treated as a superuser.
 
+### Reverse Proxy
 
+#### Configure Auth Proxy Authentication
+
+You can configure portr's admin interface to trust an HTTP reverse proxy
+to handle authentication.  Web servers and reverse proxies have many
+authentication integrations, and any of those can then be used with portr.
+
+Even with auth proxy authentication, users are not automatically provisioned.
+Except for the superuser - which is provisioned automatically - all users
+must be invited to a team to use portr.
+
+> [!WARNING]
+> If you use this feature the portr admin interface **MUST**
+> only be accessible via the appropriate auth proxy.
+>
+> A failure here will allow actors to spoof their identity.
+
+To activate this feature, configure your reverse proxy to authenticate
+and pass the authenticate user's email as a header.  This varies from
+solution to solution, so consult your reverse proxy's documentation on
+how to set it up.
+
+Once you've confirmed that to be working you may set the environment
+variable `PORTR_ADMIN_REMOTE_USER_HEADER` in your `.env` with the
+value of the header that will contain the user's email.


### PR DESCRIPTION
fixes #24 

This adds a new setting for a remote user header.  When this is set, the header with that name is read as the authenticated user's email address.

This is meant to be used with [traefik's forwardAuth](https://doc.traefik.io/traefik/middlewares/http/forwardauth/) or [oauth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy/).  When this is enabled, end users must not have access to the admin interface directly for security reasons, but how to prevent that kind of access is outside the scope of this PR.

This works in a similar way to the GitHub authentication mechanism for creating a new user if they are the first user and no other user exists.