### PR TITLE
update GoReleaser configurations

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,8 @@ builds:
       - -s -w -X main.version={{.Version}}
 
 archives:
-  - format: zip
+  - formats:
+      - zip
     name_template: >-
       {{ .Binary }}_
       {{- .Version }}_
@@ -31,7 +32,7 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 
 release:
   name_template: "v{{ .Version }}"


### PR DESCRIPTION
# Description
Hi, cool repo. 🙌 
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/amalshaji/portr/actions/runs/16782863079/job/47525921615#step:8:27): 
```
DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated release packaging configuration to support multiple archive formats in the future; current artifacts remain available as ZIP with no changes to downloads.
  - Aligned snapshot version templating with current tooling conventions; snapshot version strings remain unchanged.
  - No impact to installation or upgrade workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->