### PR TITLE
Add logs and replay command docs

### DIFF
--- a/docs-v2/content/docs/client/index.mdx
+++ b/docs-v2/content/docs/client/index.mdx
@@ -16,6 +16,12 @@ The Portr client is a command-line tool that allows you to create secure tunnels
   <Card title="HTTP Tunnels" href="/docs/client/http-tunnel">
     Create HTTP tunnels with built-in request inspection.
   </Card>
+  <Card title="Request Logs" href="/docs/client/request-logs">
+    Read locally stored HTTP request logs from the CLI.
+  </Card>
+  <Card title="Request Replay" href="/docs/client/request-replay">
+    Replay stored HTTP requests as-is or with edits.
+  </Card>
   <Card title="TCP Tunnels" href="/docs/client/tcp-tunnel">
     Tunnel raw TCP connections for databases and other services.
   </Card>
@@ -57,6 +63,12 @@ portr logs my-app --count 20
 
 # Emit full stored request records as JSON; body bytes stay base64-encoded and text payloads also include BodyText/ResponseBodyText
 portr logs my-app --json
+
+# Replay a stored request by ID
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ
+
+# Replay the latest matching request with a JSON body override
+portr replay --latest --subdomain my-app --filter /api/orders --method POST --header 'Content-Type: application/json' --body '{"message":"hello"}'
 
 # Get help
 portr --help

--- a/docs-v2/content/docs/client/meta.json
+++ b/docs-v2/content/docs/client/meta.json
@@ -4,6 +4,8 @@
     "index",
     "installation",
     "http-tunnel",
+    "request-logs",
+    "request-replay",
     "tcp-tunnel",
     "websocket-tunnel",
     "templates"

--- a/docs-v2/content/docs/client/request-logs.mdx
+++ b/docs-v2/content/docs/client/request-logs.mdx
@@ -1,0 +1,127 @@
+---
+title: Request Logs
+description: Inspect locally stored HTTP request logs from the Portr CLI
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+`portr logs` reads the local HTTP request log database written by the Portr client.
+Use it when you want to inspect recent traffic for a tunnel subdomain without opening
+the local inspector UI.
+
+## What It Reads
+
+Portr stores HTTP request logs in `~/.portr/db.sqlite`. The `logs` command only
+queries data that has already been captured on the current machine.
+
+<Callout type="info">
+  `portr logs` works with stored HTTP tunnel requests. It does not stream live TCP
+  traffic and it does not require the dashboard UI to be open.
+</Callout>
+
+## Command Shape
+
+```bash
+portr logs <subdomain> [filter]
+```
+
+- `<subdomain>` is required.
+- `[filter]` is an optional case-insensitive URL substring filter.
+- Results are returned newest first.
+- The default result window is `20`.
+
+## Options
+
+| Option | What it does |
+| --- | --- |
+| `--count <n>` | Return up to `<n>` matching requests. |
+| `-n <n>` | Short form for `--count`. |
+| `--since <value>` | Only include requests on or after the given timestamp or date. |
+| `--json` | Emit full stored request records as JSON. |
+
+## Filters and Dates
+
+The optional positional `filter` matches against the stored request URL using a
+case-insensitive substring search.
+
+The `--since` flag accepts either:
+
+- An RFC3339 timestamp such as `2026-04-04T10:30:00Z`
+- A date such as `2026-04-04`
+
+## Examples
+
+Show the latest requests for a subdomain:
+
+```bash
+portr logs my-app
+```
+
+Filter to matching URLs:
+
+```bash
+portr logs my-app /api/orders
+```
+
+Increase the result window:
+
+```bash
+portr logs my-app --count 100
+```
+
+Limit results to a date or timestamp:
+
+```bash
+portr logs my-app --since 2026-04-04
+portr logs my-app --since 2026-04-04T10:30:00Z
+```
+
+Emit full stored records as JSON:
+
+```bash
+portr logs my-app --json
+```
+
+Combine the filters:
+
+```bash
+portr logs my-app /webhooks --count 50 --since 2026-04-01
+```
+
+## Text Output
+
+The default text output prints one line per request:
+
+```text
+2026-04-04T12:00:00Z 3000 POST 200 /api/orders
+2026-04-04T12:01:00Z 3000 POST 202 /api/orders [replayed]
+```
+
+Each line includes:
+
+- Logged timestamp in UTC
+- Local forwarded port
+- HTTP method
+- Response status code
+- Stored request URL
+- `[replayed]` when the request was created by `portr replay`
+
+## JSON Output
+
+`--json` returns the full stored request record, including headers, timestamps,
+response metadata, and replay linkage.
+
+Two fields are important when working with payloads:
+
+- `Body` and `ResponseBody` remain base64-encoded
+- `BodyText` and `ResponseBodyText` are also included when the stored payload is
+  valid UTF-8 text
+
+This makes the JSON safe for binary payloads while still being easy to inspect
+for normal JSON, HTML, and text responses.
+
+## Related Commands
+
+- Use [`portr replay`](/docs/client/request-replay) to resend a stored request.
+- Use [`portr http`](/docs/client/http-tunnel) to start an HTTP tunnel and capture
+  requests in the first place.

--- a/docs-v2/content/docs/client/request-replay.mdx
+++ b/docs-v2/content/docs/client/request-replay.mdx
@@ -1,0 +1,201 @@
+---
+title: Request Replay
+description: Replay stored HTTP requests from the Portr CLI
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+`portr replay` resends a stored HTTP request through the original tunnel host.
+You can replay the request as-is, or override the method, path, headers, and body
+before sending it again.
+
+## How Replay Works
+
+1. Portr looks up a stored request in `~/.portr/db.sqlite`
+2. It rebuilds an outbound HTTP request from the stored method, URL, headers, and body
+3. Any CLI overrides are applied
+4. The request is sent to `https://<original-host><effective-path>`
+5. The replayed request is logged as a new request and linked back to the original
+
+<Callout type="info">
+  Replay depends on the original tunnel host still being routable. If the tunnel is
+  down or the local server is offline, the replay will fail even if the stored
+  request was found successfully.
+</Callout>
+
+## Choose the Request to Replay
+
+Replay a specific stored request by ID:
+
+```bash
+portr replay <request-id>
+```
+
+Replay the newest matching request from a subdomain:
+
+```bash
+portr replay --latest --subdomain <subdomain> [--filter <url-substring>] [--since <value>]
+```
+
+Notes:
+
+- `--latest` selects exactly one request: the newest match in local request logs
+- `--subdomain` is required when using `--latest`
+- `--filter` and `--since` only apply when using `--latest`
+
+## Options
+
+| Option | What it does |
+| --- | --- |
+| `--latest` | Replay the newest matching stored request instead of passing a request ID. |
+| `--subdomain <name>` | Subdomain to search when using `--latest`. |
+| `--filter <value>` | Case-insensitive URL substring filter for `--latest`. |
+| `--since <value>` | Only consider requests on or after the given RFC3339 timestamp or `YYYY-MM-DD` date when using `--latest`. |
+| `--method <value>` | Override the HTTP method before replaying. |
+| `--path <value>` | Override the request path and query. The value must start with `/`. |
+| `--header 'Key: Value'` | Add or override a header. Can be repeated. |
+| `--drop-header <name>` | Remove an inherited header. Can be repeated. |
+| `--body <value>` | Override the request body with an inline value. |
+| `--body-file <path>` | Override the request body with the contents of a file. |
+| `--stdin` | Override the request body with bytes read from standard input. |
+| `--body-encoding <encoding>` | Decode the supplied override body as `utf8` text or `base64`. |
+| `--json` | Emit replay details and the replay response as JSON. |
+
+## Body Sources
+
+You can override the body in exactly one of these ways:
+
+- `--body`
+- `--body-file`
+- `--stdin`
+
+If you provide a body override, `--body-encoding` controls how it is decoded:
+
+- `utf8` for normal text, JSON, HTML, or form data
+- `base64` for binary payloads or exact byte preservation
+
+## Important Caveat About Methods
+
+Changing the body does not change the HTTP method.
+
+If the stored request was a `GET`, this command still sends a `GET` unless you also
+set `--method`. In practice, if you want to replay a request with a JSON payload,
+you usually need both:
+
+```bash
+portr replay <request-id> \
+  --method POST \
+  --header 'Content-Type: application/json' \
+  --body '{"message":"hello"}'
+```
+
+<Callout type="warn">
+  A `GET` replay with `--body` can succeed at the CLI level while the upstream
+  server ignores the payload. Use `--method POST`, `PUT`, or `PATCH` when the body
+  is meant to be meaningful.
+</Callout>
+
+## Examples
+
+Replay a stored request exactly as captured:
+
+```bash
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ
+```
+
+Replay the newest matching request from a subdomain:
+
+```bash
+portr replay --latest --subdomain my-app --filter /api/orders
+```
+
+Replay the newest request after a specific time:
+
+```bash
+portr replay --latest --subdomain my-app --since 2026-04-04T10:30:00Z
+```
+
+Override method, path, and headers:
+
+```bash
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ \
+  --method PUT \
+  --path '/api/orders/42?dry_run=true' \
+  --header 'Content-Type: application/json' \
+  --header 'X-Debug-Replay: true' \
+  --drop-header 'If-None-Match'
+```
+
+Replay with an inline JSON body:
+
+```bash
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ \
+  --method POST \
+  --header 'Content-Type: application/json' \
+  --body '{"message":"hello"}'
+```
+
+Replay with a body loaded from a file:
+
+```bash
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ \
+  --method POST \
+  --header 'Content-Type: application/json' \
+  --body-file ./payload.json
+```
+
+Replay with a body from standard input:
+
+```bash
+cat payload.json | portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ \
+  --method POST \
+  --header 'Content-Type: application/json' \
+  --stdin
+```
+
+Replay binary data supplied as base64:
+
+```bash
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ \
+  --method POST \
+  --header 'Content-Type: application/octet-stream' \
+  --body 'AAEC' \
+  --body-encoding base64
+```
+
+Emit replay details as JSON:
+
+```bash
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ --json
+```
+
+## JSON Output
+
+`--json` is useful for automation and for verifying what was actually sent. The
+JSON output includes:
+
+- The original request ID that was selected
+- Whether it was selected directly or via `--latest`
+- Original and effective method/path values
+- The effective URL, headers, and body
+- The replay response status, headers, and body
+- A structured error object when the replay fails
+
+Like `portr logs`, replay response bodies remain base64-encoded in JSON output, and
+text payloads also include a decoded `*_text` field when possible.
+
+## What Gets Logged
+
+Every successful replay creates a new stored request entry. The new request is:
+
+- Marked as replayed in the dashboard and in `portr logs`
+- Linked back to the original request internally
+- Visible in the request history like any other captured request
+
+This means you can replay a request, inspect the new result, and replay that new
+request again if needed.
+
+## Related Commands
+
+- Use [`portr logs`](/docs/client/request-logs) to find request IDs before replaying.
+- Use [`portr http`](/docs/client/http-tunnel) to capture the original HTTP traffic.

--- a/docs-v2/content/docs/local-development/portr-client.mdx
+++ b/docs-v2/content/docs/local-development/portr-client.mdx
@@ -66,21 +66,36 @@ can read them directly with `portr logs` without opening the inspector UI.
 # Show the latest 20 logs for a subdomain
 portr logs amal-test
 
-# Filter by URL substring
-portr logs amal-test /api/
-
-# Increase the result window or bound it by date
-portr logs amal-test --count 100 --since 2026-03-14
-
-# Emit full stored request records as JSON; body bytes stay base64-encoded and text payloads also include BodyText/ResponseBodyText
+# Emit full stored request records as JSON
 portr logs amal-test --json
 ```
 
 Notes:
 
 - `portr logs <subdomain> [filter]` searches only by request URL substring.
-- `--json` emits the full stored record, including headers, status code, replay metadata, and timestamp. `Body` and `ResponseBody` stay base64-encoded, and valid UTF-8 payloads also include `BodyText` and `ResponseBodyText`.
+- `--json` emits the full stored record, including headers, status code, replay metadata, and timestamp.
 - `--since` accepts either RFC3339 timestamps or `YYYY-MM-DD`.
+- Full CLI documentation lives at [Request Logs](/docs/client/request-logs).
+
+### Replay stored requests from the CLI
+
+The client can also replay a stored HTTP request from the same local request log
+database. This is useful for iterating on handlers without manually reproducing the
+same inbound request each time.
+
+```shell
+# Replay an exact stored request
+portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ
+
+# Replay the latest matching request from a subdomain
+portr replay --latest --subdomain amal-test --filter /api/
+```
+
+Notes:
+
+- `portr replay` only works for stored HTTP requests.
+- If you override the body of a request, the method does not change automatically.
+- Full CLI documentation lives at [Request Replay](/docs/client/request-replay).
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary

Add dedicated client docs for the `portr logs` and `portr replay` commands.

## What Changed

- add a new Request Logs page covering command shape, filters, JSON output, and stored payload behavior
- add a new Request Replay page covering request selection, edit flags, body sources, JSON output, and replay logging behavior
- link both pages from the client docs landing page and the local development client setup page
- document the replay caveat that overriding `--body` does not change the original HTTP method

## Why

The existing docs only mentioned `portr logs` briefly and did not document `portr replay` in a usable level of detail. These commands are user-facing debugging workflows and need dedicated pages instead of scattered references.

## Validation

- `cd docs-v2 && bun run build`