### PR TITLE
fix: enable request logging by default

### DIFF
--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -195,7 +195,7 @@ These options apply to the entire client configuration:
 - **dashboard_port**: Local port for the inspector dashboard (default: 7777)
 - **disable_dashboard**: Disable the local inspector dashboard completely (default: false)
 - **disable_update_check**: Disable automatic update checks and notifications (default: false)
-- **enable_request_logging**: Enable detailed HTTP request logging (default: false)
+- **enable_request_logging**: Enable detailed HTTP request logging (default: true)
 - **connection_log_retention_days**: Auto-delete connection logs older than N days (default: 0, disabled)
 - **health_check_interval**: Health check interval in seconds (default: 3)
 - **health_check_max_retries**: Maximum health check retry attempts (default: 10)

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -134,7 +134,7 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 			Tunnel:                          tunnel,
 			UseLocalHost:                    c.config.UseLocalHost,
 			Debug:                           c.config.Debug,
-			EnableRequestLogging:            c.config.EnableRequestLogging,
+			EnableRequestLogging:            *c.config.EnableRequestLogging,
 			HealthCheckInterval:             c.config.HealthCheckInterval,
 			HealthCheckMaxRetries:           c.config.HealthCheckMaxRetries,
 			DisableTUI:                      c.config.DisableTUI,

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	UseVite                         bool     `yaml:"use_vite"`
 	DashboardPort                   int      `yaml:"dashboard_port"`
 	DisableDashboard                bool     `yaml:"disable_dashboard"`
-	EnableRequestLogging            bool     `yaml:"enable_request_logging"`
+	EnableRequestLogging            *bool    `yaml:"enable_request_logging"`
 	ConnectionLogRetentionDays      int      `yaml:"connection_log_retention_days"`
 	HealthCheckInterval             int      `yaml:"health_check_interval"`
 	HealthCheckMaxRetries           int      `yaml:"health_check_max_retries"`
@@ -103,6 +103,11 @@ func (c *Config) SetDefaults() {
 
 	if c.HealthCheckMaxRetries == 0 {
 		c.HealthCheckMaxRetries = 10
+	}
+
+	if c.EnableRequestLogging == nil {
+		defaultValue := true
+		c.EnableRequestLogging = &defaultValue
 	}
 
 	if c.InsecureSkipHostKeyVerification == nil {

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestSetDefaultsAppliesDashboardPort(t *testing.T) {
 	cfg := Config{}
@@ -9,6 +13,38 @@ func TestSetDefaultsAppliesDashboardPort(t *testing.T) {
 
 	if cfg.DashboardPort != DefaultDashboardPort {
 		t.Fatalf("expected dashboard port %d, got %d", DefaultDashboardPort, cfg.DashboardPort)
+	}
+}
+
+func TestSetDefaultsEnablesRequestLoggingByDefault(t *testing.T) {
+	cfg := Config{}
+
+	cfg.SetDefaults()
+
+	if cfg.EnableRequestLogging == nil {
+		t.Fatal("expected request logging default to be set")
+	}
+	if !*cfg.EnableRequestLogging {
+		t.Fatal("expected request logging to default to true")
+	}
+}
+
+func TestLoadPreservesExplicitRequestLoggingFalse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("enable_request_logging: false\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	if cfg.EnableRequestLogging == nil {
+		t.Fatal("expected request logging value to be set")
+	}
+	if *cfg.EnableRequestLogging {
+		t.Fatal("expected explicit request logging false to be preserved")
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `enable_request_logging` nullable in the loaded client config so omitted values can default to `true`
- preserve explicit `enable_request_logging: false` values when users opt out
- update the documented default in the client config template docs

Fixes #242.

## Testing
- `go test ./internal/client/config ./internal/client/client ./internal/client/ssh`
- `go test ./...`
- `go build ./...`