### PR TITLE
Add app-server API and documentation

### DIFF
--- a/cmd/portr/app_server.go
+++ b/cmd/portr/app_server.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/amalshaji/portr/internal/client/appserver"
+	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/client/db"
+	"github.com/urfave/cli/v2"
+)
+
+func appServerCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "app-server",
+		Usage: "Start a local HTTP API for managing tunnels programmatically",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "host",
+				Usage: "Host address to bind the app server",
+				Value: appserver.DefaultHost,
+			},
+			&cli.IntFlag{
+				Name:  "port",
+				Usage: "Port to bind the app server",
+				Value: appserver.DefaultPort,
+			},
+			&cli.StringFlag{
+				Name:    "token",
+				Usage:   "Bearer token required by the app-server API",
+				EnvVars: []string{"PORTR_APP_SERVER_TOKEN"},
+			},
+		},
+		Action: startAppServer,
+	}
+}
+
+func startAppServer(c *cli.Context) error {
+	cfg, err := config.Load(c.String("config"))
+	if err != nil {
+		return err
+	}
+	if err := cfg.Validate(); err != nil {
+		return err
+	}
+
+	manager := appserver.NewManager(cfg, db.New(&cfg))
+	api := appserver.NewServer(manager, c.String("token"))
+	server := &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", c.String("host"), c.Int("port")),
+		Handler:           api.Handler(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		fmt.Printf("Portr app server listening on http://%s\n", server.Addr)
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signalCh)
+
+	select {
+	case <-signalCh:
+	case err := <-errCh:
+		return err
+	case <-c.Context.Done():
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	manager.Shutdown(shutdownCtx)
+	return server.Shutdown(shutdownCtx)
+}

--- a/cmd/portr/app_server.go
+++ b/cmd/portr/app_server.go
@@ -52,16 +52,12 @@ func startAppServer(c *cli.Context) error {
 
 	manager := appserver.NewManager(cfg, db.New(&cfg))
 	api := appserver.NewServer(manager, c.String("token"))
-	server := &http.Server{
-		Addr:              fmt.Sprintf("%s:%d", c.String("host"), c.Int("port")),
-		Handler:           api.Handler(),
-		ReadHeaderTimeout: 5 * time.Second,
-	}
+	addr := fmt.Sprintf("%s:%d", c.String("host"), c.Int("port"))
 
 	errCh := make(chan error, 1)
 	go func() {
-		fmt.Printf("Portr app server listening on http://%s\n", server.Addr)
-		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		fmt.Printf("Portr app server listening on http://%s\n", addr)
+		if err := api.App().Listen(addr); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			errCh <- err
 		}
 	}()
@@ -80,5 +76,5 @@ func startAppServer(c *cli.Context) error {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	manager.Shutdown(shutdownCtx)
-	return server.Shutdown(shutdownCtx)
+	return api.App().ShutdownWithContext(shutdownCtx)
 }

--- a/cmd/portr/http.go
+++ b/cmd/portr/http.go
@@ -30,7 +30,7 @@ func httpCmd() *cli.Command {
 
 			return startTunnels(c, &config.Tunnel{
 				Port:      port,
-				Subdomain: c.Args().Get(2), // temp fix
+				Subdomain: c.String("subdomain"),
 				Type:      constants.Http,
 			})
 		},

--- a/cmd/portr/main.go
+++ b/cmd/portr/main.go
@@ -36,6 +36,7 @@ func main() {
 			logsCmd(),
 			replayCmd(),
 			authCmd(),
+			appServerCmd(),
 		},
 	}
 

--- a/cmd/portr/start.go
+++ b/cmd/portr/start.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/amalshaji/portr/internal/client/client"
 	"github.com/amalshaji/portr/internal/client/config"
@@ -36,10 +37,29 @@ func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 	_c := client.NewClient(&cfg, db)
 	var dash *dashboard.Dashboard
 	var dashErrCh <-chan error
+	runCtx, cancelRun := context.WithCancel(c.Context)
+	defer cancelRun()
+
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(signalCh)
+
+	interrupted := make(chan struct{})
+	go func() {
+		select {
+		case <-signalCh:
+			cancelRun()
+			close(interrupted)
+		case <-runCtx.Done():
+		}
+	}()
 
 	defer func() {
 		if r := recover(); r != nil {
-			_c.Shutdown(context.Background())
+			cancelRun()
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer shutdownCancel()
+			_c.Shutdown(shutdownCtx)
 			if dash != nil {
 				_ = dash.Shutdown()
 			}
@@ -48,13 +68,18 @@ func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 	}()
 
 	if tunnelFromCli != nil {
-		err = _c.Start(c.Context)
+		err = _c.Start(runCtx)
 	} else {
-		err = _c.Start(c.Context, c.Args().Slice()...)
+		err = _c.Start(runCtx, c.Args().Slice()...)
 	}
 
 	if err != nil {
-		_c.Shutdown(c.Context)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer shutdownCancel()
+		_c.Shutdown(shutdownCtx)
+		if runCtx.Err() != nil {
+			return nil
+		}
 		return err
 	}
 
@@ -80,18 +105,17 @@ func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 		}()
 	}
 
-	signalCh := make(chan os.Signal, 1)
-	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
-	defer signal.Stop(signalCh)
-
 	var runErr error
 	select {
-	case <-signalCh:
+	case <-interrupted:
 	case runErr = <-_c.Done():
 	case runErr = <-dashErrCh:
 	}
 
-	_c.Shutdown(c.Context)
+	cancelRun()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer shutdownCancel()
+	_c.Shutdown(shutdownCtx)
 	if dash != nil {
 		if err := dash.Shutdown(); err != nil && runErr == nil {
 			runErr = err

--- a/docs-v2/app/(home)/page.tsx
+++ b/docs-v2/app/(home)/page.tsx
@@ -45,6 +45,31 @@ export const metadata: Metadata = {
 export default function HomePage() {
   return (
     <main className="flex flex-1 flex-col">
+      <Link
+        href="/docs/client/app-server"
+        className="group border-b border-fd-border bg-fd-accent/30 transition-colors hover:bg-fd-accent/50"
+      >
+        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-start gap-3 sm:items-center">
+            <span
+              className="mt-2 h-2 w-2 shrink-0 rounded-full bg-fd-primary sm:mt-0"
+              aria-hidden="true"
+            />
+            <div>
+              <p className="font-semibold text-fd-foreground">
+                Introducing portr app-server: the control plane for your tunnels
+              </p>
+              <p className="text-fd-muted-foreground">
+                Start, stop, inspect, and automate tunnels from your own apps.
+              </p>
+            </div>
+          </div>
+          <span className="font-medium text-fd-foreground transition-transform group-hover:translate-x-0.5 sm:shrink-0">
+            Read the guide <span aria-hidden="true">-&gt;</span>
+          </span>
+        </div>
+      </Link>
+
       {/* Hero Section */}
       <section className="flex flex-col justify-center text-center px-4 py-16 bg-gradient-to-b from-fd-accent/20 to-transparent">
         <div className="max-w-4xl mx-auto">

--- a/docs-v2/app/(home)/page.tsx
+++ b/docs-v2/app/(home)/page.tsx
@@ -49,26 +49,36 @@ export default function HomePage() {
         href="/docs/client/app-server"
         className="group border-b border-fd-border/70 text-fd-muted-foreground transition-colors hover:text-fd-foreground"
       >
-        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-2 text-xs sm:text-sm">
-          <span>
-            Introducing{" "}
-            <span className="font-medium text-fd-foreground">
-              portr app-server
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-2 text-xs sm:justify-center sm:text-sm">
+          <span className="min-w-0 leading-snug">
+            <span className="sm:hidden">
+              New:{" "}
+              <span className="font-medium text-fd-foreground">
+                portr app-server
+              </span>
             </span>
-            : the control plane for your tunnels
+            <span className="hidden sm:inline">
+              Introducing{" "}
+              <span className="font-medium text-fd-foreground">
+                portr app-server
+              </span>
+              : the control plane for your tunnels
+            </span>
           </span>
           <span
-            className="text-fd-foreground/70 transition-colors group-hover:text-fd-foreground"
-            aria-hidden="true"
+            className="shrink-0 text-fd-foreground/70 transition-colors group-hover:text-fd-foreground"
           >
-            -&gt;
+            <span className="sm:hidden">Read guide</span>
+            <span className="hidden sm:inline" aria-hidden="true">
+              -&gt;
+            </span>
           </span>
         </div>
       </Link>
 
       {/* Hero Section */}
       <section className="flex flex-col justify-center text-center px-4 py-16 bg-gradient-to-b from-fd-accent/20 to-transparent">
-        <div className="max-w-4xl mx-auto">
+        <div className="mx-auto w-full max-w-4xl">
           <div className="flex items-center justify-center gap-2 mb-6">
             <Logo className="h-12 w-12 sm:h-16 sm:w-16" />
             <h1 className="text-4xl sm:text-5xl font-bold bg-gradient-to-r from-fd-foreground to-fd-muted-foreground bg-clip-text text-transparent">

--- a/docs-v2/app/(home)/page.tsx
+++ b/docs-v2/app/(home)/page.tsx
@@ -47,25 +47,21 @@ export default function HomePage() {
     <main className="flex flex-1 flex-col">
       <Link
         href="/docs/client/app-server"
-        className="group border-b border-fd-border bg-fd-accent/30 transition-colors hover:bg-fd-accent/50"
+        className="group border-b border-fd-border/70 text-fd-muted-foreground transition-colors hover:text-fd-foreground"
       >
-        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-start gap-3 sm:items-center">
-            <span
-              className="mt-2 h-2 w-2 shrink-0 rounded-full bg-fd-primary sm:mt-0"
-              aria-hidden="true"
-            />
-            <div>
-              <p className="font-semibold text-fd-foreground">
-                Introducing portr app-server: the control plane for your tunnels
-              </p>
-              <p className="text-fd-muted-foreground">
-                Start, stop, inspect, and automate tunnels from your own apps.
-              </p>
-            </div>
-          </div>
-          <span className="font-medium text-fd-foreground transition-transform group-hover:translate-x-0.5 sm:shrink-0">
-            Read the guide <span aria-hidden="true">-&gt;</span>
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-2 text-xs sm:text-sm">
+          <span>
+            Introducing{" "}
+            <span className="font-medium text-fd-foreground">
+              portr app-server
+            </span>
+            : the control plane for your tunnels
+          </span>
+          <span
+            className="text-fd-foreground/70 transition-colors group-hover:text-fd-foreground"
+            aria-hidden="true"
+          >
+            -&gt;
           </span>
         </div>
       </Link>

--- a/docs-v2/bun.lock
+++ b/docs-v2/bun.lock
@@ -11,7 +11,7 @@
         "fumadocs-ui": "15.6.6",
         "geist": "^1.4.2",
         "motion": "^12.23.9",
-        "next": "15.5.15",
+        "next": "15.5.18",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tw-animate-css": "^1.3.6",
@@ -153,23 +153,23 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw=="],
 
-    "@next/env": ["@next/env@15.5.15", "", {}, "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg=="],
+    "@next/env": ["@next/env@15.5.18", "", {}, "sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.18", "", { "os": "linux", "cpu": "x64" }, "sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.18", "", { "os": "linux", "cpu": "x64" }, "sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.15", "", { "os": "win32", "cpu": "x64" }, "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.18", "", { "os": "win32", "cpu": "x64" }, "sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg=="],
 
     "@orama/orama": ["@orama/orama@3.1.11", "", {}, "sha512-Szki0cgFiXE5F9RLx2lUyEtJllnuCSQ4B8RLDwIjXkVit6qZjoDAxH+xhJs29MjKLDz0tbPLdKFa6QrQ/qoGGA=="],
 
@@ -613,7 +613,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "next": ["next@15.5.15", "", { "dependencies": { "@next/env": "15.5.15", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.15", "@next/swc-darwin-x64": "15.5.15", "@next/swc-linux-arm64-gnu": "15.5.15", "@next/swc-linux-arm64-musl": "15.5.15", "@next/swc-linux-x64-gnu": "15.5.15", "@next/swc-linux-x64-musl": "15.5.15", "@next/swc-win32-arm64-msvc": "15.5.15", "@next/swc-win32-x64-msvc": "15.5.15", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ=="],
+    "next": ["next@15.5.18", "", { "dependencies": { "@next/env": "15.5.18", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.18", "@next/swc-darwin-x64": "15.5.18", "@next/swc-linux-arm64-gnu": "15.5.18", "@next/swc-linux-arm64-musl": "15.5.18", "@next/swc-linux-x64-gnu": "15.5.18", "@next/swc-linux-x64-musl": "15.5.18", "@next/swc-win32-arm64-msvc": "15.5.18", "@next/swc-win32-x64-msvc": "15.5.18", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 

--- a/docs-v2/bun.lock
+++ b/docs-v2/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "docs-v2",
@@ -10,7 +11,7 @@
         "fumadocs-ui": "15.6.6",
         "geist": "^1.4.2",
         "motion": "^12.23.9",
-        "next": "15.4.4",
+        "next": "15.5.15",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tw-animate-css": "^1.3.6",
@@ -152,23 +153,23 @@
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-/QxEhPAvGwbQmy1Px8F899L5Uc2KZ6JtXwlCgJmjSTBedwOZkByYcBG4GceIGPXRDsmfxhHazuS+hlOShRLeDw=="],
 
-    "@next/env": ["@next/env@15.4.4", "", {}, "sha512-SJKOOkULKENyHSYXE5+KiFU6itcIb6wSBjgM92meK0HVKpo94dNOLZVdLLuS7/BxImROkGoPsjR4EnuDucqiiA=="],
+    "@next/env": ["@next/env@15.5.15", "", {}, "sha512-vcmyu5/MyFzN7CdqRHO3uHO44p/QPCZkuTUXroeUmhNP8bL5PHFEhik22JUazt+CDDoD6EpBYRCaS2pISL+/hg=="],
 
-    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.4.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eVG55dnGwfUuG+TtnUCt+mEJ+8TGgul6nHEvdb8HEH7dmJIFYOCApAaFrIrxwtEq2Cdf+0m5sG1Np8cNpw9EAw=="],
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.5.15", "", { "os": "darwin", "cpu": "arm64" }, "sha512-6PvFO2Tzt10GFK2Ro9tAVEtacMqRmTarYMFKAnV2vYMdwWc73xzmDQyAV7SwEdMhzmiRoo7+m88DuiXlJlGeaw=="],
 
-    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.4.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-zqG+/8apsu49CltEj4NAmCGZvHcZbOOOsNoTVeIXphYWIbE4l6A/vuQHyqll0flU2o3dmYCXsBW5FmbrGDgljQ=="],
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.5.15", "", { "os": "darwin", "cpu": "x64" }, "sha512-G+YNV+z6FDZTp/+IdGyIMFqalBTaQSnvAA+X/hrt+eaTRFSznRMz9K7rTmzvM6tDmKegNtyzgufZW0HwVzEqaQ=="],
 
-    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-LRD4l2lq4R+2QCHBQVC0wjxxkLlALGJCwigaJ5FSRSqnje+MRKHljQNZgDCaKUZQzO/TXxlmUdkZP/X3KNGZaw=="],
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-eVkrMcVIBqGfXB+QUC7jjZ94Z6uX/dNStbQFabewAnk13Uy18Igd1YZ/GtPRzdhtm7QwC0e6o7zOQecul4iC1w=="],
 
-    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.4.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-LsGUCTvuZ0690fFWerA4lnQvjkYg9gHo12A3wiPUR4kCxbx/d+SlwmonuTH2SWZI+RVGA9VL3N0S03WTYv6bYg=="],
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.5.15", "", { "os": "linux", "cpu": "arm64" }, "sha512-RwSHKMQ7InLy5GfkY2/n5PcFycKA08qI1VST78n09nN36nUPqCvGSMiLXlfUmzmpQpF6XeBYP2KRWHi0UW3uNg=="],
 
-    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-aOy5yNRpLL3wNiJVkFYl6w22hdREERNjvegE6vvtix8LHRdsTHhWTpgvcYdCK7AIDCQW5ATmzr9XkPHvSoAnvg=="],
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-nplqvY86LakS+eeiuWsNWvfmK8pFcOEW7ZtVRt4QH70lL+0x6LG/m1OpJ/tvrbwjmR8HH9/fH2jzW1GlL03TIg=="],
 
-    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.4.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FL7OAn4UkR8hKQRGBmlHiHinzOb07tsfARdGh7v0Z0jEJ3sz8/7L5bR23ble9E6DZMabSStqlATHlSxv1fuzAg=="],
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.5.15", "", { "os": "linux", "cpu": "x64" }, "sha512-eAgl9NKQ84/sww0v81DQINl/vL2IBxD7sMybd0cWRw6wqgouVI53brVRBrggqBRP/NWeIAE1dm5cbKYoiMlqDQ=="],
 
-    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.4.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-eEdNW/TXwjYhOulQh0pffTMMItWVwKCQpbziSBmgBNFZIIRn2GTXrhrewevs8wP8KXWYMx8Z+mNU0X+AfvtrRg=="],
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.5.15", "", { "os": "win32", "cpu": "arm64" }, "sha512-GJVZC86lzSquh0MtvZT+L7G8+jMnJcldloOjA8Kf3wXvBrvb6OGe2MzPuALxFshSm/IpwUtD2mIoof39ymf52A=="],
 
-    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-SE5pYNbn/xZKMy1RE3pAs+4xD32OI4rY6mzJa4XUkp/ItZY+OMjIgilskmErt8ls/fVJ+Ihopi2QIeW6O3TrMw=="],
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.5.15", "", { "os": "win32", "cpu": "x64" }, "sha512-nFucjVdwlFqxh/JG3hWSJ4p8+YJV7Ii8aPDuBQULB6DzUF4UNZETXLfEUk+oI2zEznWWULPt7MeuTE6xtK1HSA=="],
 
     "@orama/orama": ["@orama/orama@3.1.11", "", {}, "sha512-Szki0cgFiXE5F9RLx2lUyEtJllnuCSQ4B8RLDwIjXkVit6qZjoDAxH+xhJs29MjKLDz0tbPLdKFa6QrQ/qoGGA=="],
 
@@ -612,7 +613,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "next": ["next@15.4.4", "", { "dependencies": { "@next/env": "15.4.4", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.4.4", "@next/swc-darwin-x64": "15.4.4", "@next/swc-linux-arm64-gnu": "15.4.4", "@next/swc-linux-arm64-musl": "15.4.4", "@next/swc-linux-x64-gnu": "15.4.4", "@next/swc-linux-x64-musl": "15.4.4", "@next/swc-win32-arm64-msvc": "15.4.4", "@next/swc-win32-x64-msvc": "15.4.4", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-kNcubvJjOL9yUOfwtZF3HfDhuhp+kVD+FM2A6Tyua1eI/xfmY4r/8ZS913MMz+oWKDlbps/dQOWdDricuIkXLw=="],
+    "next": ["next@15.5.15", "", { "dependencies": { "@next/env": "15.5.15", "@swc/helpers": "0.5.15", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.5.15", "@next/swc-darwin-x64": "15.5.15", "@next/swc-linux-arm64-gnu": "15.5.15", "@next/swc-linux-arm64-musl": "15.5.15", "@next/swc-linux-x64-gnu": "15.5.15", "@next/swc-linux-x64-musl": "15.5.15", "@next/swc-win32-arm64-msvc": "15.5.15", "@next/swc-win32-x64-msvc": "15.5.15", "sharp": "^0.34.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VSqCrJwtLVGwAVE0Sb/yikrQfkwkZW9p+lL/J4+xe+G3ZA+QnWPqgcfH1tDUEuk9y+pthzzVFp4L/U8JerMfMQ=="],
 
     "next-themes": ["next-themes@0.4.6", "", { "peerDependencies": { "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc", "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc" } }, "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA=="],
 

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -1,0 +1,459 @@
+---
+title: App Server
+description: Run the Portr client as a local HTTP API for programmatic tunnel management
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+`portr app-server` starts a local HTTP API around the Portr client. Use it when
+another process needs to create, inspect, and shut down tunnels without launching
+one CLI command per tunnel.
+
+The app server uses the same client configuration and tunnel implementation as
+the regular CLI commands. It reads your configured `server_url`, `ssh_url`,
+`tunnel_url`, `secret_key`, request logging settings, health check settings, and
+host key verification settings from the Portr client config file.
+
+<Callout type="info">
+  The app server is a local control plane. Tunnels live inside the running
+  `portr app-server` process and stop when that process exits.
+</Callout>
+
+## When to use it
+
+Use app-server when you want another local program to own tunnel lifecycle:
+
+- Test runners that need a temporary public URL for a local service
+- CI-style scripts running on a developer machine
+- Desktop apps or local automation tools that need to open and close tunnels
+- Integrations that need disconnect and reconnect notifications
+
+For one-off terminal workflows, `portr http`, `portr tcp`, and `portr start`
+remain simpler. For inspecting HTTP traffic already captured on disk, use
+[`portr logs`](/docs/client/request-logs) or the local inspector dashboard.
+
+## Runtime model
+
+The app server has two responsibilities:
+
+1. It exposes a local HTTP API on the machine where Portr is running.
+2. It starts and supervises tunnel workers in that same process.
+
+It does not persist desired tunnel state. If the app-server process exits, the
+tunnels it owns are closed. If you restart app-server, recreate the tunnels with
+the API.
+
+Each successful `POST /api/v1/tunnels` call returns an app-server tunnel ID. That
+ID is local to the running process and is different from any server-side
+connection ID used internally by Portr.
+
+## Start the app server
+
+Start the API server on the default loopback address:
+
+```bash
+portr app-server
+```
+
+By default it listens on:
+
+```text
+http://127.0.0.1:7778
+```
+
+Bind a different host or port:
+
+```bash
+portr app-server --host 127.0.0.1 --port 7780
+```
+
+Use a specific client config:
+
+```bash
+portr --config ~/.portr/config.yaml app-server
+```
+
+Command flags:
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| `--host` | `127.0.0.1` | Address the local API server binds to. |
+| `--port` | `7778` | Port the local API server listens on. |
+| `--token` | none | Bearer token required for API requests. Can also be supplied with `PORTR_APP_SERVER_TOKEN`. |
+
+## Authentication
+
+The app-server API is unauthenticated unless you pass a token. For local-only
+development that may be enough, but any shared or non-loopback binding should
+use a token.
+
+```bash
+PORTR_APP_SERVER_TOKEN="change-me" portr app-server
+```
+
+Or:
+
+```bash
+portr app-server --token "change-me"
+```
+
+When a token is configured, every API request must include:
+
+```http
+Authorization: Bearer change-me
+```
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer change-me" \
+  http://127.0.0.1:7778/api/v1/tunnels
+```
+
+## API conventions
+
+All request and response bodies are JSON unless the endpoint is a simple health
+check. Request bodies should use `Content-Type: application/json`.
+
+Successful responses use:
+
+- `200 OK` for reads and tunnel shutdown
+- `201 Created` when a tunnel is accepted and started or is still starting
+
+Error responses have a stable shape:
+
+```json
+{
+  "message": "port must be between 1 and 65535"
+}
+```
+
+Common error statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `400 Bad Request` | The request body is invalid, required fields are missing, or a tunnel cannot be started from the supplied parameters. |
+| `401 Unauthorized` | A token is configured and the request did not include the expected bearer token. |
+| `404 Not Found` | The requested tunnel ID is not known to this app-server process. |
+| `405 Method Not Allowed` | The path exists, but the HTTP method is not supported for that path. |
+| `500 Internal Server Error` | The app server failed while handling a known tunnel operation. |
+
+## Start an HTTP tunnel
+
+Create a tunnel with a generated subdomain:
+
+```bash
+curl -X POST http://127.0.0.1:7778/api/v1/tunnels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "web",
+    "type": "http",
+    "host": "localhost",
+    "port": 3000
+  }'
+```
+
+Create a tunnel with a fixed subdomain:
+
+```bash
+curl -X POST http://127.0.0.1:7778/api/v1/tunnels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "web",
+    "type": "http",
+    "host": "localhost",
+    "port": 3000,
+    "subdomain": "my-app"
+  }'
+```
+
+Successful responses include the app-server tunnel ID and current status:
+
+```json
+{
+  "id": "01HZYR9VK2C0G6KTX4TK9Z5T6S",
+  "name": "web",
+  "status": "running",
+  "type": "http",
+  "host": "localhost",
+  "port": 3000,
+  "subdomain": "my-app",
+  "tunnel_url": "https://my-app.example.com",
+  "callback_urls": [],
+  "started_at": "2026-05-15T10:00:00Z",
+  "updated_at": "2026-05-15T10:00:05Z"
+}
+```
+
+Save the returned `id`; you use it for status checks, shutdown, and event
+filtering.
+
+## Start a TCP tunnel
+
+TCP tunnels use the same endpoint with `type: "tcp"`:
+
+```bash
+curl -X POST http://127.0.0.1:7778/api/v1/tunnels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "postgres",
+    "type": "tcp",
+    "host": "localhost",
+    "port": 5432
+  }'
+```
+
+TCP responses include `remote_port` once the remote listener is allocated:
+
+```json
+{
+  "id": "01HZYRA72P4R8PQVG0YSQXJK64",
+  "name": "postgres",
+  "status": "running",
+  "type": "tcp",
+  "host": "localhost",
+  "port": 5432,
+  "remote_port": 49160,
+  "tunnel_url": "example.com:49160",
+  "started_at": "2026-05-15T10:05:00Z",
+  "updated_at": "2026-05-15T10:05:04Z"
+}
+```
+
+## Request fields
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | No | Human-readable label returned in status and event payloads. |
+| `type` | string | No | `http` or `tcp`. Defaults to `http` when omitted. |
+| `host` | string | No | Local host to forward to. Defaults to `localhost`. |
+| `port` | number | Yes | Local port to forward to. Must be between `1` and `65535`. |
+| `subdomain` | string | HTTP only | Fixed HTTP subdomain. If omitted for HTTP, Portr generates one. |
+| `pool_size` | number | HTTP only | Number of HTTP tunnel workers. Defaults to the client tunnel default. Falls back to one worker when the Portr server does not support pooled HTTP tunnels. |
+| `callback_url` | string | No | Single webhook URL for lifecycle events. |
+| `callback_urls` | string[] | No | Additional webhook URLs for lifecycle events. Duplicate URLs are ignored. |
+
+## Response fields
+
+Tunnel status responses use this shape:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | string | App-server tunnel ID used by the local API. |
+| `name` | string | Optional name supplied when the tunnel was created. |
+| `status` | string | Current lifecycle status. |
+| `type` | string | `http` or `tcp`. |
+| `host` | string | Local host forwarded by the tunnel. |
+| `port` | number | Local port forwarded by the tunnel. |
+| `subdomain` | string | HTTP subdomain, when the tunnel is HTTP. |
+| `remote_port` | number | Remote TCP port, when the tunnel is TCP and the server has allocated one. |
+| `tunnel_url` | string | Public HTTP URL or TCP host/port once available. |
+| `callback_urls` | string[] | Callback URLs registered for this tunnel. |
+| `started_at` | string | RFC3339 timestamp for tunnel creation inside app-server. |
+| `updated_at` | string | RFC3339 timestamp for the last status change. |
+| `stopped_at` | string | RFC3339 timestamp set after shutdown. |
+| `last_error` | string | Last known startup, worker, or health error. |
+
+## Check status
+
+List all tunnels managed by the running app server:
+
+```bash
+curl http://127.0.0.1:7778/api/v1/tunnels
+```
+
+Response:
+
+```json
+{
+  "tunnels": [
+    {
+      "id": "01HZYR9VK2C0G6KTX4TK9Z5T6S",
+      "name": "web",
+      "status": "running",
+      "type": "http",
+      "host": "localhost",
+      "port": 3000,
+      "subdomain": "my-app",
+      "tunnel_url": "https://my-app.example.com",
+      "started_at": "2026-05-15T10:00:00Z",
+      "updated_at": "2026-05-15T10:00:05Z"
+    }
+  ]
+}
+```
+
+Inspect one tunnel:
+
+```bash
+curl http://127.0.0.1:7778/api/v1/tunnels/01HZYR9VK2C0G6KTX4TK9Z5T6S
+```
+
+Possible status values:
+
+| Status | Meaning |
+| --- | --- |
+| `starting` | The app server accepted the request and is starting the tunnel. |
+| `running` | The tunnel started and has a public tunnel address. |
+| `unhealthy` | A health check detected a disconnected or unregistered HTTP tunnel and Portr is attempting to reconnect. |
+| `failed` | Tunnel startup or a worker failed. Check `last_error`. |
+| `stopped` | The tunnel was shut down through the API or app-server shutdown. |
+
+## Shut down a tunnel
+
+Stop a tunnel with `DELETE`:
+
+```bash
+curl -X DELETE \
+  http://127.0.0.1:7778/api/v1/tunnels/01HZYR9VK2C0G6KTX4TK9Z5T6S
+```
+
+You can also use the explicit shutdown endpoint:
+
+```bash
+curl -X POST \
+  http://127.0.0.1:7778/api/v1/tunnels/01HZYR9VK2C0G6KTX4TK9Z5T6S/shutdown
+```
+
+The tunnel remains visible in `GET /api/v1/tunnels` with `status: "stopped"` so
+callers can reconcile their own state after a shutdown.
+
+## Events
+
+The app server records recent lifecycle events in memory.
+
+List all recent events:
+
+```bash
+curl http://127.0.0.1:7778/api/v1/events
+```
+
+Filter to one tunnel:
+
+```bash
+curl "http://127.0.0.1:7778/api/v1/events?tunnel_id=01HZYR9VK2C0G6KTX4TK9Z5T6S"
+```
+
+Response:
+
+```json
+{
+  "events": [
+    {
+      "id": "01HZYRBYT1DD8W7GK8RJ0QYTS4",
+      "tunnel_id": "01HZYR9VK2C0G6KTX4TK9Z5T6S",
+      "type": "started",
+      "name": "web",
+      "connection_type": "http",
+      "host": "localhost",
+      "port": 3000,
+      "subdomain": "my-app",
+      "tunnel_url": "https://my-app.example.com",
+      "at": "2026-05-15T10:00:05Z"
+    }
+  ]
+}
+```
+
+Event types:
+
+| Event | When it is emitted |
+| --- | --- |
+| `started` | A tunnel worker starts and receives its tunnel address. |
+| `unhealthy` | An HTTP tunnel health check detects a disconnect or missing server registration. |
+| `reconnected` | A tunnel reconnect attempt succeeds. |
+| `failed` | Startup or a tunnel worker fails. |
+| `stopped` | A tunnel is shut down. |
+
+<Callout type="info">
+  Disconnect-style lifecycle changes are reported as `unhealthy`, `failed`, or
+  `stopped` depending on what happened. Successful reconnects are reported as
+  `reconnected`.
+</Callout>
+
+## Callback webhooks
+
+Pass `callback_url` or `callback_urls` when creating a tunnel to receive the same
+event payloads over HTTP.
+
+```bash
+curl -X POST http://127.0.0.1:7778/api/v1/tunnels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "web",
+    "type": "http",
+    "host": "localhost",
+    "port": 3000,
+    "subdomain": "my-app",
+    "callback_url": "http://127.0.0.1:9000/portr-events",
+    "callback_urls": [
+      "https://automation.example.com/webhooks/portr"
+    ]
+  }'
+```
+
+Each callback receives a `POST` request with `Content-Type: application/json`:
+
+```json
+{
+  "id": "01HZYRBYT1DD8W7GK8RJ0QYTS4",
+  "tunnel_id": "01HZYR9VK2C0G6KTX4TK9Z5T6S",
+  "type": "reconnected",
+  "name": "web",
+  "connection_type": "http",
+  "host": "localhost",
+  "port": 3000,
+  "subdomain": "my-app",
+  "tunnel_url": "https://my-app.example.com",
+  "at": "2026-05-15T10:10:00Z"
+}
+```
+
+Callback delivery is best-effort. If your receiver is down, the app server logs
+the delivery failure and continues managing the tunnel.
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/health` | Health check for the local app-server process. |
+| `POST` | `/api/v1/tunnels` | Start a new tunnel. |
+| `GET` | `/api/v1/tunnels` | List tunnels managed by this app-server process. |
+| `GET` | `/api/v1/tunnels/{id}` | Get one tunnel's status. |
+| `DELETE` | `/api/v1/tunnels/{id}` | Shut down one tunnel. |
+| `POST` | `/api/v1/tunnels/{id}/shutdown` | Shut down one tunnel. |
+| `GET` | `/api/v1/events` | List recent lifecycle events. Add `?tunnel_id={id}` to filter. |
+
+## Automation example
+
+This shell snippet starts an app server, creates a tunnel, waits for automation,
+then shuts the tunnel down:
+
+```bash
+APP_SERVER=http://127.0.0.1:7778
+
+TUNNEL_ID=$(
+  curl -sS -X POST "$APP_SERVER/api/v1/tunnels" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"preview","type":"http","host":"localhost","port":3000}' |
+    jq -r '.id'
+)
+
+curl -sS "$APP_SERVER/api/v1/tunnels/$TUNNEL_ID"
+
+# Run your automated workflow here.
+
+curl -sS -X DELETE "$APP_SERVER/api/v1/tunnels/$TUNNEL_ID"
+```
+
+## Operational notes
+
+- Run one app-server process per local machine that owns the tunnels.
+- Bind to `127.0.0.1` unless another trusted machine must call the API.
+- Use `--token` or `PORTR_APP_SERVER_TOKEN` before binding anywhere other than
+  loopback.
+- Tunnels are in-memory runtime state. Restarting the app server does not
+  restore previously running tunnels.
+- The local inspector dashboard is not started by app-server. Use the app-server
+  APIs for lifecycle control and [`portr logs`](/docs/client/request-logs) for
+  locally captured HTTP request logs.

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -546,6 +546,13 @@ main().catch((error) => {
 });
 ```
 
+## FastAPI example
+
+For a runnable FastAPI app that starts a local server, creates a tunnel through
+the app-server API, prints the public URL, and deletes the tunnel during
+shutdown, see
+[`examples/app-server-fastapi`](https://github.com/amalshaji/portr/tree/main/examples/app-server-fastapi).
+
 ## Operational notes
 
 - Run one app-server process per local machine that owns the tunnels.

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -446,6 +446,105 @@ curl -sS "$APP_SERVER/api/v1/tunnels/$TUNNEL_ID"
 curl -sS -X DELETE "$APP_SERVER/api/v1/tunnels/$TUNNEL_ID"
 ```
 
+## Python example
+
+This example uses only Python's standard library. It creates an HTTP tunnel,
+prints the public URL, waits for input, then shuts the tunnel down.
+
+```python
+import json
+import os
+import urllib.request
+
+APP_SERVER = os.getenv("PORTR_APP_SERVER", "http://127.0.0.1:7778")
+TOKEN = os.getenv("PORTR_APP_SERVER_TOKEN")
+
+
+def api(method, path, payload=None):
+    data = json.dumps(payload).encode("utf-8") if payload else None
+    headers = {"Content-Type": "application/json"}
+    if TOKEN:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+
+    request = urllib.request.Request(
+        f"{APP_SERVER}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+
+    with urllib.request.urlopen(request) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+tunnel = api(
+    "POST",
+    "/api/v1/tunnels",
+    {
+        "name": "python-preview",
+        "type": "http",
+        "host": "localhost",
+        "port": 3000,
+    },
+)
+
+print("Tunnel URL:", tunnel.get("tunnel_url"))
+input("Press Enter to stop the tunnel...")
+
+api("DELETE", f"/api/v1/tunnels/{tunnel['id']}")
+```
+
+## Node.js example
+
+Node.js 18 and newer include `fetch`, so no extra HTTP client is required.
+
+```js
+const APP_SERVER = process.env.PORTR_APP_SERVER ?? "http://127.0.0.1:7778";
+const TOKEN = process.env.PORTR_APP_SERVER_TOKEN;
+
+async function api(method, path, payload) {
+  const headers = { "Content-Type": "application/json" };
+  if (TOKEN) {
+    headers.Authorization = `Bearer ${TOKEN}`;
+  }
+
+  const response = await fetch(`${APP_SERVER}${path}`, {
+    method,
+    headers,
+    body: payload ? JSON.stringify(payload) : undefined,
+  });
+
+  const body = await response.json();
+  if (!response.ok) {
+    throw new Error(body.message ?? `Request failed with ${response.status}`);
+  }
+  return body;
+}
+
+async function main() {
+  const tunnel = await api("POST", "/api/v1/tunnels", {
+    name: "node-preview",
+    type: "http",
+    host: "localhost",
+    port: 3000,
+  });
+
+  console.log("Tunnel URL:", tunnel.tunnel_url);
+  console.log("Press Ctrl+C when you are done.");
+
+  try {
+    await new Promise((resolve) => process.once("SIGINT", resolve));
+  } finally {
+    await api("DELETE", `/api/v1/tunnels/${tunnel.id}`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+```
+
 ## Operational notes
 
 - Run one app-server process per local machine that owns the tunnels.

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -320,7 +320,8 @@ callers can reconcile their own state after a shutdown.
 
 ## Events
 
-The app server records recent lifecycle events in memory.
+The app server records recent lifecycle events in memory and logs each recorded
+event to the terminal running `portr app-server`.
 
 List all recent events:
 

--- a/docs-v2/content/docs/client/index.mdx
+++ b/docs-v2/content/docs/client/index.mdx
@@ -22,6 +22,9 @@ The Portr client is a command-line tool that allows you to create secure tunnels
   <Card title="Request Replay" href="/docs/client/request-replay">
     Replay stored HTTP requests as-is or with edits.
   </Card>
+  <Card title="App Server" href="/docs/client/app-server">
+    Manage tunnels programmatically through a local HTTP API.
+  </Card>
   <Card title="TCP Tunnels" href="/docs/client/tcp-tunnel">
     Tunnel raw TCP connections for databases and other services.
   </Card>
@@ -69,6 +72,9 @@ portr replay 01KNAAZ6QTV77WBH91A5Z63BZZ
 
 # Replay the latest matching request with a JSON body override
 portr replay --latest --subdomain my-app --filter /api/orders --method POST --header 'Content-Type: application/json' --body '{"message":"hello"}'
+
+# Start a local API for programmatic tunnel lifecycle management
+portr app-server
 
 # Get help
 portr --help

--- a/docs-v2/content/docs/client/meta.json
+++ b/docs-v2/content/docs/client/meta.json
@@ -6,6 +6,7 @@
     "http-tunnel",
     "request-logs",
     "request-replay",
+    "app-server",
     "tcp-tunnel",
     "websocket-tunnel",
     "templates"

--- a/examples/app-server-fastapi/README.md
+++ b/examples/app-server-fastapi/README.md
@@ -1,0 +1,39 @@
+# FastAPI app-server example
+
+This example starts a basic FastAPI app, creates an HTTP tunnel through a
+running `portr app-server`, prints the public tunnel URL, and deletes the tunnel
+when the app shuts down.
+
+Start the app server first:
+
+```bash
+portr app-server
+```
+
+Then run the example:
+
+```bash
+cd examples/app-server-fastapi
+uv run main.py
+```
+
+If your app server requires a local API token, pass the same token to the
+example:
+
+```bash
+PORTR_APP_SERVER_TOKEN="change-me" uv run main.py
+```
+
+Optional environment variables:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `PORTR_APP_SERVER` | `http://127.0.0.1:7778` | App-server API base URL. |
+| `PORTR_APP_SERVER_TOKEN` | unset | Bearer token for the app-server API. |
+| `FASTAPI_HOST` | `127.0.0.1` | Local host for the FastAPI server. |
+| `FASTAPI_PORT` | `8000` | Local port for the FastAPI server and tunnel. |
+| `PORTR_TUNNEL_NAME` | `fastapi-example` | Name sent to the app server. |
+| `PORTR_TUNNEL_SUBDOMAIN` | unset | Optional fixed HTTP tunnel subdomain. |
+
+Press `Ctrl+C` to stop the FastAPI server. The lifespan shutdown hook deletes
+the tunnel from the app server before the process exits.

--- a/examples/app-server-fastapi/main.py
+++ b/examples/app-server-fastapi/main.py
@@ -1,0 +1,144 @@
+# /// script
+# dependencies = [
+#   "fastapi>=0.115.0",
+#   "uvicorn>=0.30.0",
+# ]
+# ///
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI
+
+
+APP_SERVER = os.getenv("PORTR_APP_SERVER", "http://127.0.0.1:7778").rstrip("/")
+APP_SERVER_TOKEN = os.getenv("PORTR_APP_SERVER_TOKEN")
+FASTAPI_HOST = os.getenv("FASTAPI_HOST", "127.0.0.1")
+FASTAPI_PORT = int(os.getenv("FASTAPI_PORT", "8000"))
+TUNNEL_NAME = os.getenv("PORTR_TUNNEL_NAME", "fastapi-example")
+TUNNEL_SUBDOMAIN = os.getenv("PORTR_TUNNEL_SUBDOMAIN")
+
+
+def app_server_request(
+    method: str,
+    path: str,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    headers = {"Content-Type": "application/json"}
+    if APP_SERVER_TOKEN:
+        headers["Authorization"] = f"Bearer {APP_SERVER_TOKEN}"
+
+    request = urllib.request.Request(
+        f"{APP_SERVER}{path}",
+        data=data,
+        headers=headers,
+        method=method,
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        body = error.read().decode("utf-8")
+        raise RuntimeError(
+            f"app-server {method} {path} failed with {error.code}: {body}"
+        ) from error
+    except urllib.error.URLError as error:
+        raise RuntimeError(
+            f"could not reach portr app-server at {APP_SERVER}: {error.reason}"
+        ) from error
+
+    if not body:
+        return {}
+    return json.loads(body)
+
+
+def create_tunnel() -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": TUNNEL_NAME,
+        "type": "http",
+        "host": FASTAPI_HOST,
+        "port": FASTAPI_PORT,
+    }
+    if TUNNEL_SUBDOMAIN:
+        payload["subdomain"] = TUNNEL_SUBDOMAIN
+
+    tunnel = app_server_request("POST", "/api/v1/tunnels", payload)
+    try:
+        return wait_for_tunnel_url(tunnel["id"])
+    except Exception:
+        delete_tunnel(tunnel["id"])
+        raise
+
+
+def wait_for_tunnel_url(tunnel_id: str) -> dict[str, Any]:
+    deadline = time.monotonic() + 20
+    latest: dict[str, Any] = {}
+
+    while time.monotonic() < deadline:
+        latest = app_server_request("GET", f"/api/v1/tunnels/{tunnel_id}")
+        if latest.get("status") == "failed":
+            raise RuntimeError(
+                f"tunnel failed: {latest.get('last_error', 'unknown error')}"
+            )
+        if latest.get("status") == "running" and latest.get("tunnel_url"):
+            return latest
+        time.sleep(0.5)
+
+    raise RuntimeError(f"tunnel did not become ready in time: {latest}")
+
+
+def delete_tunnel(tunnel_id: str) -> None:
+    try:
+        app_server_request("DELETE", f"/api/v1/tunnels/{tunnel_id}")
+    except Exception as error:
+        print(f"Failed to delete tunnel {tunnel_id}: {error}", flush=True)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    tunnel = await asyncio.to_thread(create_tunnel)
+    app.state.tunnel = tunnel
+
+    print(f"FastAPI local URL: http://{FASTAPI_HOST}:{FASTAPI_PORT}", flush=True)
+    print(f"Portr tunnel URL: {tunnel['tunnel_url']}", flush=True)
+
+    try:
+        yield
+    finally:
+        tunnel_id = app.state.tunnel["id"]
+        print(f"Deleting Portr tunnel: {tunnel_id}", flush=True)
+        await asyncio.to_thread(delete_tunnel, tunnel_id)
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+@app.get("/")
+def read_root() -> dict[str, Any]:
+    tunnel = getattr(app.state, "tunnel", {})
+    return {
+        "message": "Hello from FastAPI through Portr",
+        "tunnel_url": tunnel.get("tunnel_url"),
+    }
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    print("Make sure `portr app-server` is running before starting this example.")
+    uvicorn.run(app, host=FASTAPI_HOST, port=FASTAPI_PORT)

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -122,10 +122,6 @@ func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (
 		failedCh:  make(chan error, 1),
 	}
 
-	m.mu.Lock()
-	m.tunnels[id] = runtime
-	m.mu.Unlock()
-
 	for i := 0; i < workers; i++ {
 		workerCfg := cfg
 		sshc := sshclient.New(workerCfg, m.db, nil, nil)
@@ -133,7 +129,13 @@ func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (
 			m.handleSSHEvent(id, event)
 		})
 		runtime.clients = append(runtime.clients, sshc)
+	}
 
+	m.mu.Lock()
+	m.tunnels[id] = runtime
+	m.mu.Unlock()
+
+	for _, sshc := range runtime.clients {
 		go func(client *sshclient.SshClient) {
 			if err := client.Start(runCtx); err != nil {
 				m.handleStartFailure(id, err)

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -44,6 +44,7 @@ type tunnelRuntime struct {
 	failedCh     chan error
 	startOnce    sync.Once
 	failOnce     sync.Once
+	stopping     bool
 }
 
 type Manager struct {
@@ -90,7 +91,7 @@ func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (
 	cfg := m.clientConfigForTunnel(tunnel)
 	workers := m.desiredWorkers(cfg)
 	if cfg.Tunnel.Type == constants.Http && workers > 1 && cfg.ConnectionID == "" {
-		connID, err := sshclient.CreateNewConnection(cfg)
+		connID, err := sshclient.CreateNewConnectionWithContext(ctx, cfg)
 		if err != nil {
 			return TunnelStatus{}, fmt.Errorf("failed to create shared connection for pool: %w", err)
 		}
@@ -187,6 +188,10 @@ func (m *Manager) StopTunnel(ctx context.Context, id string) (TunnelStatus, erro
 	if !ok {
 		return TunnelStatus{}, ErrTunnelNotFound
 	}
+
+	m.mu.Lock()
+	tunnel.stopping = true
+	m.mu.Unlock()
 
 	tunnel.cancel()
 	for _, client := range tunnel.clients {
@@ -287,6 +292,10 @@ func (m *Manager) handleSSHEvent(id string, event sshclient.Event) {
 
 	shouldRecord := true
 	m.mu.Lock()
+	if (tunnel.stopping || tunnel.status.Status == statusStopped) && event.Type != sshclient.EventStopped {
+		m.mu.Unlock()
+		return
+	}
 	switch event.Type {
 	case sshclient.EventStarted:
 		if tunnel.status.Status == statusRunning {

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -1,0 +1,494 @@
+package appserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Masterminds/semver"
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/client/db"
+	sshclient "github.com/amalshaji/portr/internal/client/ssh"
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/charmbracelet/log"
+	"github.com/oklog/ulid/v2"
+)
+
+const (
+	statusStarting  = "starting"
+	statusRunning   = "running"
+	statusUnhealthy = "unhealthy"
+	statusStopped   = "stopped"
+	statusFailed    = "failed"
+
+	maxStoredEvents = 200
+)
+
+var ErrTunnelNotFound = errors.New("tunnel not found")
+
+type tunnelRuntime struct {
+	id           string
+	cancel       context.CancelFunc
+	clients      []*sshclient.SshClient
+	callbackURLs []string
+	status       TunnelStatus
+	startedCh    chan struct{}
+	failedCh     chan error
+	startOnce    sync.Once
+	failOnce     sync.Once
+}
+
+type Manager struct {
+	baseConfig clientcfg.Config
+	db         *db.Db
+	httpClient *http.Client
+
+	mu      sync.RWMutex
+	tunnels map[string]*tunnelRuntime
+	events  []TunnelEvent
+}
+
+func NewManager(baseConfig clientcfg.Config, database *db.Db) *Manager {
+	baseConfig.DisableTUI = true
+	baseConfig.DisableDashboard = true
+
+	return &Manager{
+		baseConfig: baseConfig,
+		db:         database,
+		httpClient: &http.Client{
+			Timeout: 3 * time.Second,
+		},
+		tunnels: make(map[string]*tunnelRuntime),
+		events:  make([]TunnelEvent, 0),
+	}
+}
+
+func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (TunnelStatus, error) {
+	tunnel := clientcfg.Tunnel{
+		Name:      request.Name,
+		Subdomain: request.Subdomain,
+		Port:      request.Port,
+		Host:      request.Host,
+		Type:      request.Type,
+		PoolSize:  request.PoolSize,
+	}
+	tunnel.SetDefaults()
+	if err := validateTunnelRequest(tunnel, request.CallbackURL, request.CallbackURLs); err != nil {
+		return TunnelStatus{}, err
+	}
+
+	cfg := m.clientConfigForTunnel(tunnel)
+	workers := m.desiredWorkers(cfg)
+	if cfg.Tunnel.Type == constants.Http && workers > 1 && cfg.ConnectionID == "" {
+		connID, err := sshclient.CreateNewConnection(cfg)
+		if err != nil {
+			return TunnelStatus{}, fmt.Errorf("failed to create shared connection for pool: %w", err)
+		}
+		cfg.ConnectionID = connID
+	}
+
+	id := ulid.Make().String()
+	runCtx, cancel := context.WithCancel(context.Background())
+	callbackURLs := normalizeCallbackURLs(request.CallbackURL, request.CallbackURLs)
+	now := time.Now().UTC()
+	runtime := &tunnelRuntime{
+		id:           id,
+		cancel:       cancel,
+		callbackURLs: callbackURLs,
+		status: TunnelStatus{
+			ID:           id,
+			Name:         tunnel.Name,
+			Status:       statusStarting,
+			Type:         tunnel.Type,
+			Host:         tunnel.Host,
+			Port:         tunnel.Port,
+			Subdomain:    tunnel.Subdomain,
+			CallbackURLs: callbackURLs,
+			StartedAt:    now,
+			UpdatedAt:    now,
+		},
+		startedCh: make(chan struct{}),
+		failedCh:  make(chan error, 1),
+	}
+
+	m.mu.Lock()
+	m.tunnels[id] = runtime
+	m.mu.Unlock()
+
+	for i := 0; i < workers; i++ {
+		workerCfg := cfg
+		sshc := sshclient.New(workerCfg, m.db, nil, nil)
+		sshc.SetEventHandler(func(event sshclient.Event) {
+			m.handleSSHEvent(id, event)
+		})
+		runtime.clients = append(runtime.clients, sshc)
+
+		go func(client *sshclient.SshClient) {
+			if err := client.Start(runCtx); err != nil {
+				m.handleStartFailure(id, err)
+			}
+		}(sshc)
+	}
+
+	select {
+	case <-runtime.startedCh:
+		return m.GetTunnel(id)
+	case err := <-runtime.failedCh:
+		cancel()
+		return TunnelStatus{}, err
+	case <-time.After(7 * time.Second):
+		return m.GetTunnel(id)
+	case <-ctx.Done():
+		cancel()
+		return TunnelStatus{}, ctx.Err()
+	}
+}
+
+func (m *Manager) ListTunnels() []TunnelStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	statuses := make([]TunnelStatus, 0, len(m.tunnels))
+	for _, tunnel := range m.tunnels {
+		statuses = append(statuses, tunnel.status)
+	}
+
+	slices.SortFunc(statuses, func(a, b TunnelStatus) int {
+		return b.StartedAt.Compare(a.StartedAt)
+	})
+	return statuses
+}
+
+func (m *Manager) GetTunnel(id string) (TunnelStatus, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	tunnel, ok := m.tunnels[id]
+	if !ok {
+		return TunnelStatus{}, ErrTunnelNotFound
+	}
+	return tunnel.status, nil
+}
+
+func (m *Manager) StopTunnel(ctx context.Context, id string) (TunnelStatus, error) {
+	m.mu.RLock()
+	tunnel, ok := m.tunnels[id]
+	m.mu.RUnlock()
+	if !ok {
+		return TunnelStatus{}, ErrTunnelNotFound
+	}
+
+	tunnel.cancel()
+	for _, client := range tunnel.clients {
+		_ = client.Shutdown(ctx)
+	}
+
+	now := time.Now().UTC()
+	m.mu.Lock()
+	tunnel.status.Status = statusStopped
+	tunnel.status.UpdatedAt = now
+	tunnel.status.StoppedAt = &now
+	status := tunnel.status
+	m.mu.Unlock()
+
+	return status, nil
+}
+
+func (m *Manager) Events(tunnelID string) []TunnelEvent {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	events := make([]TunnelEvent, 0, len(m.events))
+	for _, event := range m.events {
+		if tunnelID == "" || event.TunnelID == tunnelID {
+			events = append(events, event)
+		}
+	}
+	return events
+}
+
+func (m *Manager) Shutdown(ctx context.Context) {
+	m.mu.RLock()
+	ids := make([]string, 0, len(m.tunnels))
+	for id := range m.tunnels {
+		ids = append(ids, id)
+	}
+	m.mu.RUnlock()
+
+	for _, id := range ids {
+		_, _ = m.StopTunnel(ctx, id)
+	}
+}
+
+func (m *Manager) clientConfigForTunnel(tunnel clientcfg.Tunnel) clientcfg.ClientConfig {
+	return clientcfg.ClientConfig{
+		ServerUrl:                       m.baseConfig.ServerUrl,
+		SshUrl:                          m.baseConfig.SshUrl,
+		TunnelUrl:                       m.baseConfig.TunnelUrl,
+		SecretKey:                       m.baseConfig.SecretKey,
+		Tunnel:                          tunnel,
+		UseLocalHost:                    m.baseConfig.UseLocalHost,
+		Debug:                           m.baseConfig.Debug,
+		EnableRequestLogging:            *m.baseConfig.EnableRequestLogging,
+		HealthCheckInterval:             m.baseConfig.HealthCheckInterval,
+		HealthCheckMaxRetries:           m.baseConfig.HealthCheckMaxRetries,
+		DisableTUI:                      true,
+		EnableHttpReverseProxy:          m.baseConfig.EnableHttpReverseProxy,
+		InsecureSkipHostKeyVerification: *m.baseConfig.InsecureSkipHostKeyVerification,
+	}
+}
+
+func (m *Manager) handleStartFailure(id string, err error) {
+	m.mu.RLock()
+	tunnel, ok := m.tunnels[id]
+	m.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	tunnel.failOnce.Do(func() {
+		select {
+		case tunnel.failedCh <- err:
+		default:
+		}
+	})
+
+	m.handleSSHEvent(id, sshclient.Event{
+		Type:  sshclient.EventFailed,
+		Error: err.Error(),
+		At:    time.Now().UTC(),
+	})
+}
+
+func (m *Manager) handleSSHEvent(id string, event sshclient.Event) {
+	m.mu.RLock()
+	tunnel, ok := m.tunnels[id]
+	m.mu.RUnlock()
+	if !ok {
+		return
+	}
+
+	now := event.At
+	if now.IsZero() {
+		now = time.Now().UTC()
+		event.At = now
+	}
+
+	shouldRecord := true
+	m.mu.Lock()
+	switch event.Type {
+	case sshclient.EventStarted:
+		if tunnel.status.Status == statusRunning {
+			shouldRecord = false
+			break
+		}
+		tunnel.status.Status = statusRunning
+		tunnel.status.RemotePort = event.Tunnel.RemotePort
+		tunnel.status.TunnelURL = event.TunnelAddr
+		tunnel.status.LastError = ""
+		tunnel.startOnce.Do(func() {
+			close(tunnel.startedCh)
+		})
+	case sshclient.EventUnhealthy:
+		if tunnel.status.Status == statusUnhealthy && tunnel.status.LastError == event.Error {
+			shouldRecord = false
+			break
+		}
+		tunnel.status.Status = statusUnhealthy
+		tunnel.status.LastError = event.Error
+	case sshclient.EventReconnected:
+		tunnel.status.Status = statusRunning
+		tunnel.status.RemotePort = event.Tunnel.RemotePort
+		tunnel.status.TunnelURL = event.TunnelAddr
+		tunnel.status.LastError = ""
+	case sshclient.EventStopped:
+		if tunnel.status.Status == statusStopped {
+			shouldRecord = false
+			break
+		}
+		stoppedAt := now
+		tunnel.status.Status = statusStopped
+		tunnel.status.StoppedAt = &stoppedAt
+	case sshclient.EventFailed:
+		if tunnel.status.Status == statusFailed && tunnel.status.LastError == event.Error {
+			shouldRecord = false
+			break
+		}
+		tunnel.status.Status = statusFailed
+		tunnel.status.LastError = event.Error
+	}
+	tunnel.status.UpdatedAt = now
+	m.mu.Unlock()
+
+	if shouldRecord {
+		m.recordEvent(tunnel, event)
+	}
+}
+
+func (m *Manager) recordEvent(tunnel *tunnelRuntime, event sshclient.Event) {
+	m.mu.RLock()
+	status := tunnel.status
+	m.mu.RUnlock()
+
+	tunnelEvent := TunnelEvent{
+		ID:         ulid.Make().String(),
+		TunnelID:   tunnel.id,
+		Type:       string(event.Type),
+		Name:       status.Name,
+		Connection: status.Type,
+		Host:       status.Host,
+		Port:       status.Port,
+		Subdomain:  status.Subdomain,
+		RemotePort: status.RemotePort,
+		TunnelURL:  status.TunnelURL,
+		Error:      event.Error,
+		At:         event.At,
+	}
+	if tunnelEvent.At.IsZero() {
+		tunnelEvent.At = time.Now().UTC()
+	}
+
+	m.mu.Lock()
+	m.events = append(m.events, tunnelEvent)
+	if len(m.events) > maxStoredEvents {
+		m.events = m.events[len(m.events)-maxStoredEvents:]
+	}
+	m.mu.Unlock()
+
+	m.dispatchCallbacks(tunnel.callbackURLs, tunnelEvent)
+}
+
+func (m *Manager) dispatchCallbacks(callbackURLs []string, event TunnelEvent) {
+	if len(callbackURLs) == 0 {
+		return
+	}
+
+	body, err := json.Marshal(event)
+	if err != nil {
+		return
+	}
+
+	for _, callbackURL := range callbackURLs {
+		callbackURL := callbackURL
+		go func() {
+			req, err := http.NewRequest(http.MethodPost, callbackURL, bytes.NewReader(body))
+			if err != nil {
+				return
+			}
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := m.httpClient.Do(req)
+			if err != nil {
+				log.Error("Failed to dispatch app-server callback", "url", callbackURL, "error", err)
+				return
+			}
+			_ = resp.Body.Close()
+		}()
+	}
+}
+
+func validateTunnelRequest(tunnel clientcfg.Tunnel, callbackURL string, callbackURLs []string) error {
+	if tunnel.Port <= 0 || tunnel.Port > 65535 {
+		return fmt.Errorf("port must be between 1 and 65535")
+	}
+	if tunnel.Type != constants.Http && tunnel.Type != constants.Tcp {
+		return fmt.Errorf("type must be either http or tcp")
+	}
+	if err := tunnel.Validate(); err != nil {
+		return err
+	}
+	for _, rawURL := range normalizeCallbackURLs(callbackURL, callbackURLs) {
+		parsed, err := url.Parse(rawURL)
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return fmt.Errorf("callback_url must be a valid absolute URL")
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return fmt.Errorf("callback_url must use http or https")
+		}
+	}
+	return nil
+}
+
+func normalizeCallbackURLs(callbackURL string, callbackURLs []string) []string {
+	seen := make(map[string]struct{})
+	urls := make([]string, 0, len(callbackURLs)+1)
+	for _, rawURL := range append([]string{callbackURL}, callbackURLs...) {
+		rawURL = strings.TrimSpace(rawURL)
+		if rawURL == "" {
+			continue
+		}
+		if _, ok := seen[rawURL]; ok {
+			continue
+		}
+		seen[rawURL] = struct{}{}
+		urls = append(urls, rawURL)
+	}
+	return urls
+}
+
+func (m *Manager) desiredWorkers(cfg clientcfg.ClientConfig) int {
+	if cfg.Tunnel.Type != constants.Http {
+		return 1
+	}
+	if cfg.Tunnel.PoolSize <= 1 {
+		return 1
+	}
+	if !supportsHTTPPooling(cfg.ServerUrl, cfg.UseLocalHost, m.httpClient) {
+		return 1
+	}
+	return cfg.Tunnel.PoolSize
+}
+
+func supportsHTTPPooling(serverURL string, useLocalHost bool, client *http.Client) bool {
+	var response struct {
+		Version string `json:"version"`
+	}
+
+	resp, err := client.Get(serverBaseURL(serverURL, useLocalHost) + "/api/v1/version")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		return false
+	}
+
+	return supportsHTTPPoolingVersion(response.Version)
+}
+
+func supportsHTTPPoolingVersion(rawVersion string) bool {
+	version, err := semver.NewVersion(strings.TrimPrefix(rawVersion, "v"))
+	if err != nil {
+		return false
+	}
+
+	minVersion, err := semver.NewVersion("1.0.0")
+	if err != nil {
+		return false
+	}
+
+	return !version.LessThan(minVersion)
+}
+
+func serverBaseURL(serverURL string, useLocalHost bool) string {
+	if strings.HasPrefix(serverURL, "http://") || strings.HasPrefix(serverURL, "https://") {
+		return strings.TrimRight(serverURL, "/")
+	}
+
+	protocol := "http"
+	if !useLocalHost {
+		protocol = "https"
+	}
+
+	return protocol + "://" + strings.TrimRight(serverURL, "/")
+}

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -50,6 +50,7 @@ type Manager struct {
 	baseConfig clientcfg.Config
 	db         *db.Db
 	httpClient *http.Client
+	logger     *log.Logger
 
 	mu      sync.RWMutex
 	tunnels map[string]*tunnelRuntime
@@ -66,6 +67,7 @@ func NewManager(baseConfig clientcfg.Config, database *db.Db) *Manager {
 		httpClient: &http.Client{
 			Timeout: 3 * time.Second,
 		},
+		logger:  log.WithPrefix("app-server"),
 		tunnels: make(map[string]*tunnelRuntime),
 		events:  make([]TunnelEvent, 0),
 	}
@@ -241,6 +243,7 @@ func (m *Manager) clientConfigForTunnel(tunnel clientcfg.Tunnel) clientcfg.Clien
 		HealthCheckInterval:             m.baseConfig.HealthCheckInterval,
 		HealthCheckMaxRetries:           m.baseConfig.HealthCheckMaxRetries,
 		DisableTUI:                      true,
+		DisableTerminalLogs:             true,
 		EnableHttpReverseProxy:          m.baseConfig.EnableHttpReverseProxy,
 		InsecureSkipHostKeyVerification: *m.baseConfig.InsecureSkipHostKeyVerification,
 	}
@@ -363,7 +366,55 @@ func (m *Manager) recordEvent(tunnel *tunnelRuntime, event sshclient.Event) {
 	}
 	m.mu.Unlock()
 
+	m.logEvent(tunnelEvent)
 	m.dispatchCallbacks(tunnel.callbackURLs, tunnelEvent)
+}
+
+func (m *Manager) logEvent(event TunnelEvent) {
+	logger := m.appLogger()
+	fields := tunnelEventLogFields(event)
+
+	switch event.Type {
+	case string(sshclient.EventFailed):
+		logger.Error("App-server tunnel event", fields...)
+	case string(sshclient.EventUnhealthy):
+		logger.Warn("App-server tunnel event", fields...)
+	default:
+		logger.Info("App-server tunnel event", fields...)
+	}
+}
+
+func (m *Manager) appLogger() *log.Logger {
+	if m.logger != nil {
+		return m.logger
+	}
+	return log.Default()
+}
+
+func tunnelEventLogFields(event TunnelEvent) []interface{} {
+	fields := []interface{}{
+		"event", event.Type,
+		"tunnel_id", event.TunnelID,
+		"connection_type", event.Connection,
+		"host", event.Host,
+		"port", event.Port,
+	}
+	if event.Name != "" {
+		fields = append(fields, "name", event.Name)
+	}
+	if event.Subdomain != "" {
+		fields = append(fields, "subdomain", event.Subdomain)
+	}
+	if event.RemotePort != 0 {
+		fields = append(fields, "remote_port", event.RemotePort)
+	}
+	if event.TunnelURL != "" {
+		fields = append(fields, "tunnel_url", event.TunnelURL)
+	}
+	if event.Error != "" {
+		fields = append(fields, "error", event.Error)
+	}
+	return fields
 }
 
 func (m *Manager) dispatchCallbacks(callbackURLs []string, event TunnelEvent) {
@@ -386,7 +437,7 @@ func (m *Manager) dispatchCallbacks(callbackURLs []string, event TunnelEvent) {
 			req.Header.Set("Content-Type", "application/json")
 			resp, err := m.httpClient.Do(req)
 			if err != nil {
-				log.Error("Failed to dispatch app-server callback", "url", callbackURL, "error", err)
+				m.appLogger().Error("Failed to dispatch app-server callback", "url", callbackURL, "error", err)
 				return
 			}
 			_ = resp.Body.Close()

--- a/internal/client/appserver/manager_test.go
+++ b/internal/client/appserver/manager_test.go
@@ -116,3 +116,45 @@ func TestRecordEventLogsTerminalEvent(t *testing.T) {
 		}
 	}
 }
+
+func TestHandleSSHEventIgnoresLateUnhealthyAfterStopped(t *testing.T) {
+	cfg := clientcfg.Config{}
+	cfg.SetDefaults()
+
+	manager := NewManager(cfg, nil)
+	stoppedAt := time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC)
+	manager.tunnels["tun_1"] = &tunnelRuntime{
+		id: "tun_1",
+		status: TunnelStatus{
+			ID:        "tun_1",
+			Name:      "web",
+			Status:    statusStopped,
+			Type:      constants.Http,
+			Host:      "localhost",
+			Port:      3000,
+			StartedAt: stoppedAt.Add(-time.Minute),
+			UpdatedAt: stoppedAt,
+			StoppedAt: &stoppedAt,
+		},
+	}
+
+	manager.handleSSHEvent("tun_1", sshclient.Event{
+		Type:  sshclient.EventUnhealthy,
+		Error: "unhealthy tunnel",
+		At:    stoppedAt.Add(time.Second),
+	})
+
+	status, err := manager.GetTunnel("tun_1")
+	if err != nil {
+		t.Fatalf("expected tunnel, got %v", err)
+	}
+	if status.Status != statusStopped {
+		t.Fatalf("expected stopped status, got %q", status.Status)
+	}
+	if status.LastError != "" {
+		t.Fatalf("expected no late error after stop, got %q", status.LastError)
+	}
+	if len(manager.Events("tun_1")) != 0 {
+		t.Fatalf("expected late unhealthy event to be ignored, got %#v", manager.Events("tun_1"))
+	}
+}

--- a/internal/client/appserver/manager_test.go
+++ b/internal/client/appserver/manager_test.go
@@ -1,10 +1,15 @@
 package appserver
 
 import (
+	"bytes"
+	"strings"
 	"testing"
+	"time"
 
 	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	sshclient "github.com/amalshaji/portr/internal/client/ssh"
 	"github.com/amalshaji/portr/internal/constants"
+	"github.com/charmbracelet/log"
 )
 
 func TestNormalizeCallbackURLsDeduplicates(t *testing.T) {
@@ -50,5 +55,64 @@ func TestSupportsHTTPPoolingVersion(t *testing.T) {
 	}
 	if supportsHTTPPoolingVersion("not-a-version") {
 		t.Fatal("expected invalid versions to disable HTTP pooling")
+	}
+}
+
+func TestClientConfigForTunnelDisablesSSHClientTerminalLogs(t *testing.T) {
+	cfg := clientcfg.Config{}
+	cfg.SetDefaults()
+
+	manager := NewManager(cfg, nil)
+	tunnel := clientcfg.Tunnel{
+		Type: constants.Http,
+		Host: "localhost",
+		Port: 3000,
+	}
+	tunnel.SetDefaults()
+
+	clientConfig := manager.clientConfigForTunnel(tunnel)
+	if !clientConfig.DisableTerminalLogs {
+		t.Fatal("expected app-server tunnel client terminal logs to be disabled")
+	}
+}
+
+func TestRecordEventLogsTerminalEvent(t *testing.T) {
+	var output bytes.Buffer
+	manager := &Manager{
+		logger: log.NewWithOptions(&output, log.Options{}),
+		events: make([]TunnelEvent, 0),
+	}
+	tunnel := &tunnelRuntime{
+		id: "01HZYR9VK2C0G6KTX4TK9Z5T6S",
+		status: TunnelStatus{
+			Name:      "web",
+			Type:      constants.Http,
+			Host:      "localhost",
+			Port:      3000,
+			Subdomain: "my-app",
+			TunnelURL: "https://my-app.example.com",
+		},
+	}
+
+	manager.recordEvent(tunnel, sshclient.Event{
+		Type: sshclient.EventStarted,
+		At:   time.Date(2026, 5, 16, 10, 0, 0, 0, time.UTC),
+	})
+
+	logLine := output.String()
+	for _, want := range []string{
+		"App-server tunnel event",
+		"event=started",
+		"tunnel_id=01HZYR9VK2C0G6KTX4TK9Z5T6S",
+		"connection_type=http",
+		"host=localhost",
+		"port=3000",
+		"name=web",
+		"subdomain=my-app",
+		"tunnel_url=https://my-app.example.com",
+	} {
+		if !strings.Contains(logLine, want) {
+			t.Fatalf("expected terminal log to contain %q, got %q", want, logLine)
+		}
 	}
 }

--- a/internal/client/appserver/manager_test.go
+++ b/internal/client/appserver/manager_test.go
@@ -1,0 +1,54 @@
+package appserver
+
+import (
+	"testing"
+
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+func TestNormalizeCallbackURLsDeduplicates(t *testing.T) {
+	got := normalizeCallbackURLs("http://example.test/a", []string{"http://example.test/a", " http://example.test/b "})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 callback URLs, got %#v", got)
+	}
+	if got[0] != "http://example.test/a" || got[1] != "http://example.test/b" {
+		t.Fatalf("unexpected callback URLs: %#v", got)
+	}
+}
+
+func TestValidateTunnelRequestRejectsInvalidPort(t *testing.T) {
+	tunnel := clientcfg.Tunnel{
+		Type: constants.Http,
+		Port: 0,
+	}
+	tunnel.SetDefaults()
+
+	if err := validateTunnelRequest(tunnel, "", nil); err == nil {
+		t.Fatal("expected invalid port error")
+	}
+}
+
+func TestValidateTunnelRequestRejectsInvalidCallbackURL(t *testing.T) {
+	tunnel := clientcfg.Tunnel{
+		Type: constants.Tcp,
+		Port: 5432,
+	}
+	tunnel.SetDefaults()
+
+	if err := validateTunnelRequest(tunnel, "ftp://example.test/hook", nil); err == nil {
+		t.Fatal("expected invalid callback URL error")
+	}
+}
+
+func TestSupportsHTTPPoolingVersion(t *testing.T) {
+	if !supportsHTTPPoolingVersion("v1.0.0") {
+		t.Fatal("expected v1.0.0 to support HTTP pooling")
+	}
+	if supportsHTTPPoolingVersion("0.9.9") {
+		t.Fatal("expected 0.9.9 to disable HTTP pooling")
+	}
+	if supportsHTTPPoolingVersion("not-a-version") {
+		t.Fatal("expected invalid versions to disable HTTP pooling")
+	}
+}

--- a/internal/client/appserver/server.go
+++ b/internal/client/appserver/server.go
@@ -2,12 +2,13 @@ package appserver
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/recover"
 )
 
 type tunnelService interface {
@@ -19,153 +20,119 @@ type tunnelService interface {
 }
 
 type Server struct {
+	app     *fiber.App
 	service tunnelService
 	token   string
 }
 
 func NewServer(service tunnelService, token string) *Server {
-	return &Server{
+	server := &Server{
 		service: service,
 		token:   strings.TrimSpace(token),
 	}
+	server.app = server.buildApp()
+	return server
 }
 
-func (s *Server) Handler() http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/health", s.handleHealth)
-	mux.HandleFunc("/api/v1/tunnels", s.handleTunnels)
-	mux.HandleFunc("/api/v1/tunnels/", s.handleTunnel)
-	mux.HandleFunc("/api/v1/events", s.handleEvents)
-
-	return s.withAuth(mux)
+func (s *Server) App() *fiber.App {
+	return s.app
 }
 
-func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeMethodNotAllowed(w, http.MethodGet)
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+func (s *Server) buildApp() *fiber.App {
+	app := fiber.New(fiber.Config{
+		DisableStartupMessage: true,
+	})
+
+	app.Use(recover.New())
+	app.Use(s.authMiddleware)
+
+	app.Get("/api/v1/health", s.handleHealth)
+	app.Get("/api/v1/tunnels", s.handleListTunnels)
+	app.Post("/api/v1/tunnels", s.handleCreateTunnel)
+	app.All("/api/v1/tunnels", methodNotAllowed(fiber.MethodGet, fiber.MethodPost))
+	app.Get("/api/v1/tunnels/:id", s.handleGetTunnel)
+	app.Delete("/api/v1/tunnels/:id", s.handleStopTunnel)
+	app.All("/api/v1/tunnels/:id", methodNotAllowed(fiber.MethodGet, fiber.MethodDelete))
+	app.Post("/api/v1/tunnels/:id/shutdown", s.handleStopTunnel)
+	app.All("/api/v1/tunnels/:id/shutdown", methodNotAllowed(fiber.MethodPost))
+	app.Get("/api/v1/events", s.handleEvents)
+	app.All("/api/v1/events", methodNotAllowed(fiber.MethodGet))
+
+	return app
 }
 
-func (s *Server) handleTunnels(w http.ResponseWriter, r *http.Request) {
-	switch r.Method {
-	case http.MethodGet:
-		writeJSON(w, http.StatusOK, map[string]any{"tunnels": s.service.ListTunnels()})
-	case http.MethodPost:
-		var request StartTunnelRequest
-		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid JSON body")
-			return
-		}
-		status, err := s.service.StartTunnel(r.Context(), request)
-		if err != nil {
-			writeError(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		writeJSON(w, http.StatusCreated, status)
-	default:
-		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
-	}
+func (s *Server) handleHealth(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{"status": "ok"})
 }
 
-func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
-	id, action, ok := parseTunnelPath(strings.TrimPrefix(r.URL.Path, "/api/v1/tunnels/"))
-	if !ok {
-		writeError(w, http.StatusNotFound, "not found")
-		return
-	}
-
-	if action == "shutdown" {
-		if r.Method != http.MethodPost {
-			writeMethodNotAllowed(w, http.MethodPost)
-			return
-		}
-		s.stopTunnel(w, r, id)
-		return
-	}
-
-	switch r.Method {
-	case http.MethodGet:
-		status, err := s.service.GetTunnel(id)
-		if err != nil {
-			writeServiceError(w, err)
-			return
-		}
-		writeJSON(w, http.StatusOK, status)
-	case http.MethodDelete:
-		s.stopTunnel(w, r, id)
-	default:
-		writeMethodNotAllowed(w, http.MethodGet, http.MethodDelete)
-	}
+func (s *Server) handleListTunnels(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{"tunnels": s.service.ListTunnels()})
 }
 
-func (s *Server) stopTunnel(w http.ResponseWriter, r *http.Request, id string) {
-	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+func (s *Server) handleCreateTunnel(c *fiber.Ctx) error {
+	var request StartTunnelRequest
+	if err := c.BodyParser(&request); err != nil {
+		return writeError(c, fiber.StatusBadRequest, "invalid JSON body")
+	}
+
+	status, err := s.service.StartTunnel(c.UserContext(), request)
+	if err != nil {
+		return writeError(c, fiber.StatusBadRequest, err.Error())
+	}
+
+	return c.Status(fiber.StatusCreated).JSON(status)
+}
+
+func (s *Server) handleGetTunnel(c *fiber.Ctx) error {
+	status, err := s.service.GetTunnel(c.Params("id"))
+	if err != nil {
+		return writeServiceError(c, err)
+	}
+	return c.JSON(status)
+}
+
+func (s *Server) handleStopTunnel(c *fiber.Ctx) error {
+	ctx, cancel := context.WithTimeout(c.UserContext(), 10*time.Second)
 	defer cancel()
 
-	status, err := s.service.StopTunnel(ctx, id)
+	status, err := s.service.StopTunnel(ctx, c.Params("id"))
 	if err != nil {
-		writeServiceError(w, err)
-		return
+		return writeServiceError(c, err)
 	}
-	writeJSON(w, http.StatusOK, status)
+	return c.JSON(status)
 }
 
-func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		writeMethodNotAllowed(w, http.MethodGet)
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"events": s.service.Events(r.URL.Query().Get("tunnel_id")),
+func (s *Server) handleEvents(c *fiber.Ctx) error {
+	return c.JSON(fiber.Map{
+		"events": s.service.Events(c.Query("tunnel_id")),
 	})
 }
 
-func (s *Server) withAuth(next http.Handler) http.Handler {
+func (s *Server) authMiddleware(c *fiber.Ctx) error {
 	if s.token == "" {
-		return next
+		return c.Next()
 	}
 
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("Authorization") != "Bearer "+s.token {
-			writeError(w, http.StatusUnauthorized, "unauthorized")
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
+	if c.Get("Authorization") != "Bearer "+s.token {
+		return writeError(c, fiber.StatusUnauthorized, "unauthorized")
+	}
+	return c.Next()
 }
 
-func parseTunnelPath(path string) (id string, action string, ok bool) {
-	parts := strings.Split(strings.Trim(path, "/"), "/")
-	if len(parts) == 1 && parts[0] != "" {
-		return parts[0], "", true
-	}
-	if len(parts) == 2 && parts[0] != "" && parts[1] == "shutdown" {
-		return parts[0], parts[1], true
-	}
-	return "", "", false
-}
-
-func writeServiceError(w http.ResponseWriter, err error) {
+func writeServiceError(c *fiber.Ctx, err error) error {
 	if errors.Is(err, ErrTunnelNotFound) {
-		writeError(w, http.StatusNotFound, err.Error())
-		return
+		return writeError(c, fiber.StatusNotFound, err.Error())
 	}
-	writeError(w, http.StatusInternalServerError, err.Error())
+	return writeError(c, fiber.StatusInternalServerError, err.Error())
 }
 
-func writeJSON(w http.ResponseWriter, status int, payload any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(payload)
+func writeError(c *fiber.Ctx, status int, message string) error {
+	return c.Status(status).JSON(fiber.Map{"message": message})
 }
 
-func writeError(w http.ResponseWriter, status int, message string) {
-	writeJSON(w, status, map[string]string{"message": message})
-}
-
-func writeMethodNotAllowed(w http.ResponseWriter, methods ...string) {
-	w.Header().Set("Allow", strings.Join(methods, ", "))
-	writeError(w, http.StatusMethodNotAllowed, fmt.Sprintf("method must be one of: %s", strings.Join(methods, ", ")))
+func methodNotAllowed(methods ...string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		c.Set(fiber.HeaderAllow, strings.Join(methods, ", "))
+		return writeError(c, fiber.StatusMethodNotAllowed, fmt.Sprintf("method must be one of: %s", strings.Join(methods, ", ")))
+	}
 }

--- a/internal/client/appserver/server.go
+++ b/internal/client/appserver/server.go
@@ -1,0 +1,171 @@
+package appserver
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type tunnelService interface {
+	StartTunnel(context.Context, StartTunnelRequest) (TunnelStatus, error)
+	ListTunnels() []TunnelStatus
+	GetTunnel(string) (TunnelStatus, error)
+	StopTunnel(context.Context, string) (TunnelStatus, error)
+	Events(string) []TunnelEvent
+}
+
+type Server struct {
+	service tunnelService
+	token   string
+}
+
+func NewServer(service tunnelService, token string) *Server {
+	return &Server{
+		service: service,
+		token:   strings.TrimSpace(token),
+	}
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/health", s.handleHealth)
+	mux.HandleFunc("/api/v1/tunnels", s.handleTunnels)
+	mux.HandleFunc("/api/v1/tunnels/", s.handleTunnel)
+	mux.HandleFunc("/api/v1/events", s.handleEvents)
+
+	return s.withAuth(mux)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleTunnels(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, map[string]any{"tunnels": s.service.ListTunnels()})
+	case http.MethodPost:
+		var request StartTunnelRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+		status, err := s.service.StartTunnel(r.Context(), request)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		writeJSON(w, http.StatusCreated, status)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodPost)
+	}
+}
+
+func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
+	id, action, ok := parseTunnelPath(strings.TrimPrefix(r.URL.Path, "/api/v1/tunnels/"))
+	if !ok {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	if action == "shutdown" {
+		if r.Method != http.MethodPost {
+			writeMethodNotAllowed(w, http.MethodPost)
+			return
+		}
+		s.stopTunnel(w, r, id)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		status, err := s.service.GetTunnel(id)
+		if err != nil {
+			writeServiceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, status)
+	case http.MethodDelete:
+		s.stopTunnel(w, r, id)
+	default:
+		writeMethodNotAllowed(w, http.MethodGet, http.MethodDelete)
+	}
+}
+
+func (s *Server) stopTunnel(w http.ResponseWriter, r *http.Request, id string) {
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
+	status, err := s.service.StopTunnel(ctx, id)
+	if err != nil {
+		writeServiceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, status)
+}
+
+func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeMethodNotAllowed(w, http.MethodGet)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"events": s.service.Events(r.URL.Query().Get("tunnel_id")),
+	})
+}
+
+func (s *Server) withAuth(next http.Handler) http.Handler {
+	if s.token == "" {
+		return next
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+s.token {
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func parseTunnelPath(path string) (id string, action string, ok bool) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	if len(parts) == 1 && parts[0] != "" {
+		return parts[0], "", true
+	}
+	if len(parts) == 2 && parts[0] != "" && parts[1] == "shutdown" {
+		return parts[0], parts[1], true
+	}
+	return "", "", false
+}
+
+func writeServiceError(w http.ResponseWriter, err error) {
+	if errors.Is(err, ErrTunnelNotFound) {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeError(w, http.StatusInternalServerError, err.Error())
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, map[string]string{"message": message})
+}
+
+func writeMethodNotAllowed(w http.ResponseWriter, methods ...string) {
+	w.Header().Set("Allow", strings.Join(methods, ", "))
+	writeError(w, http.StatusMethodNotAllowed, fmt.Sprintf("method must be one of: %s", strings.Join(methods, ", ")))
+}

--- a/internal/client/appserver/server_test.go
+++ b/internal/client/appserver/server_test.go
@@ -1,0 +1,177 @@
+package appserver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+type fakeTunnelService struct {
+	startRequest StartTunnelRequest
+	startStatus  TunnelStatus
+	tunnels      []TunnelStatus
+	events       []TunnelEvent
+}
+
+func (f *fakeTunnelService) StartTunnel(_ context.Context, request StartTunnelRequest) (TunnelStatus, error) {
+	f.startRequest = request
+	if f.startStatus.ID == "" {
+		f.startStatus = TunnelStatus{
+			ID:        "tun_1",
+			Status:    statusRunning,
+			Type:      request.Type,
+			Host:      request.Host,
+			Port:      request.Port,
+			Subdomain: request.Subdomain,
+			StartedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}
+	}
+	return f.startStatus, nil
+}
+
+func (f *fakeTunnelService) ListTunnels() []TunnelStatus {
+	return f.tunnels
+}
+
+func (f *fakeTunnelService) GetTunnel(id string) (TunnelStatus, error) {
+	for _, tunnel := range f.tunnels {
+		if tunnel.ID == id {
+			return tunnel, nil
+		}
+	}
+	return TunnelStatus{}, ErrTunnelNotFound
+}
+
+func (f *fakeTunnelService) StopTunnel(_ context.Context, id string) (TunnelStatus, error) {
+	for _, tunnel := range f.tunnels {
+		if tunnel.ID == id {
+			tunnel.Status = statusStopped
+			return tunnel, nil
+		}
+	}
+	return TunnelStatus{}, ErrTunnelNotFound
+}
+
+func (f *fakeTunnelService) Events(tunnelID string) []TunnelEvent {
+	if tunnelID == "" {
+		return f.events
+	}
+	filtered := make([]TunnelEvent, 0)
+	for _, event := range f.events {
+		if event.TunnelID == tunnelID {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered
+}
+
+func TestServerCreatesTunnel(t *testing.T) {
+	service := &fakeTunnelService{}
+	server := httptest.NewServer(NewServer(service, "").Handler())
+	defer server.Close()
+
+	body := bytes.NewBufferString(`{"name":"api","type":"http","host":"127.0.0.1","port":3000,"subdomain":"demo","callback_url":"http://example.test/hook"}`)
+	resp, err := http.Post(server.URL+"/api/v1/tunnels", "application/json", body)
+	if err != nil {
+		t.Fatalf("expected request to succeed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("expected status %d, got %d", http.StatusCreated, resp.StatusCode)
+	}
+	if service.startRequest.Name != "api" {
+		t.Fatalf("expected request to be passed to service, got %#v", service.startRequest)
+	}
+	if service.startRequest.Type != constants.Http {
+		t.Fatalf("expected http tunnel type, got %q", service.startRequest.Type)
+	}
+	if service.startRequest.CallbackURL != "http://example.test/hook" {
+		t.Fatalf("expected callback URL to be preserved")
+	}
+}
+
+func TestServerListsAndStopsTunnels(t *testing.T) {
+	service := &fakeTunnelService{
+		tunnels: []TunnelStatus{{
+			ID:        "tun_1",
+			Status:    statusRunning,
+			Type:      constants.Tcp,
+			Host:      "localhost",
+			Port:      5432,
+			StartedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}},
+	}
+	server := httptest.NewServer(NewServer(service, "").Handler())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/tunnels")
+	if err != nil {
+		t.Fatalf("expected list request to succeed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var listBody struct {
+		Tunnels []TunnelStatus `json:"tunnels"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listBody); err != nil {
+		t.Fatalf("failed to decode list response: %v", err)
+	}
+	if len(listBody.Tunnels) != 1 || listBody.Tunnels[0].ID != "tun_1" {
+		t.Fatalf("unexpected tunnels response: %#v", listBody)
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, server.URL+"/api/v1/tunnels/tun_1", nil)
+	if err != nil {
+		t.Fatalf("failed to build delete request: %v", err)
+	}
+	stopResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("expected stop request to succeed: %v", err)
+	}
+	defer stopResp.Body.Close()
+
+	if stopResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected stop status %d, got %d", http.StatusOK, stopResp.StatusCode)
+	}
+}
+
+func TestServerRequiresBearerTokenWhenConfigured(t *testing.T) {
+	service := &fakeTunnelService{}
+	server := httptest.NewServer(NewServer(service, "secret").Handler())
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/api/v1/health")
+	if err != nil {
+		t.Fatalf("expected request to succeed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized status, got %d", resp.StatusCode)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/health", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer secret")
+
+	authedResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("expected authenticated request to succeed: %v", err)
+	}
+	defer authedResp.Body.Close()
+
+	if authedResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected OK status, got %d", authedResp.StatusCode)
+	}
+}

--- a/internal/client/appserver/server_test.go
+++ b/internal/client/appserver/server_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/amalshaji/portr/internal/constants"
+	"github.com/gofiber/fiber/v2"
 )
 
 type fakeTunnelService struct {
@@ -74,14 +75,12 @@ func (f *fakeTunnelService) Events(tunnelID string) []TunnelEvent {
 
 func TestServerCreatesTunnel(t *testing.T) {
 	service := &fakeTunnelService{}
-	server := httptest.NewServer(NewServer(service, "").Handler())
-	defer server.Close()
+	app := NewServer(service, "").App()
 
 	body := bytes.NewBufferString(`{"name":"api","type":"http","host":"127.0.0.1","port":3000,"subdomain":"demo","callback_url":"http://example.test/hook"}`)
-	resp, err := http.Post(server.URL+"/api/v1/tunnels", "application/json", body)
-	if err != nil {
-		t.Fatalf("expected request to succeed: %v", err)
-	}
+	req := newRequest(t, http.MethodPost, "/api/v1/tunnels", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp := doRequest(t, app, req)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
@@ -110,13 +109,9 @@ func TestServerListsAndStopsTunnels(t *testing.T) {
 			UpdatedAt: time.Now().UTC(),
 		}},
 	}
-	server := httptest.NewServer(NewServer(service, "").Handler())
-	defer server.Close()
+	app := NewServer(service, "").App()
 
-	resp, err := http.Get(server.URL + "/api/v1/tunnels")
-	if err != nil {
-		t.Fatalf("expected list request to succeed: %v", err)
-	}
+	resp := doRequest(t, app, newRequest(t, http.MethodGet, "/api/v1/tunnels", nil))
 	defer resp.Body.Close()
 
 	var listBody struct {
@@ -129,14 +124,7 @@ func TestServerListsAndStopsTunnels(t *testing.T) {
 		t.Fatalf("unexpected tunnels response: %#v", listBody)
 	}
 
-	req, err := http.NewRequest(http.MethodDelete, server.URL+"/api/v1/tunnels/tun_1", nil)
-	if err != nil {
-		t.Fatalf("failed to build delete request: %v", err)
-	}
-	stopResp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("expected stop request to succeed: %v", err)
-	}
+	stopResp := doRequest(t, app, newRequest(t, http.MethodDelete, "/api/v1/tunnels/tun_1", nil))
 	defer stopResp.Body.Close()
 
 	if stopResp.StatusCode != http.StatusOK {
@@ -146,32 +134,42 @@ func TestServerListsAndStopsTunnels(t *testing.T) {
 
 func TestServerRequiresBearerTokenWhenConfigured(t *testing.T) {
 	service := &fakeTunnelService{}
-	server := httptest.NewServer(NewServer(service, "secret").Handler())
-	defer server.Close()
+	app := NewServer(service, "secret").App()
 
-	resp, err := http.Get(server.URL + "/api/v1/health")
-	if err != nil {
-		t.Fatalf("expected request to succeed: %v", err)
-	}
+	resp := doRequest(t, app, newRequest(t, http.MethodGet, "/api/v1/health", nil))
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected unauthorized status, got %d", resp.StatusCode)
 	}
 
-	req, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/health", nil)
-	if err != nil {
-		t.Fatalf("failed to build request: %v", err)
-	}
+	req := newRequest(t, http.MethodGet, "/api/v1/health", nil)
 	req.Header.Set("Authorization", "Bearer secret")
 
-	authedResp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("expected authenticated request to succeed: %v", err)
-	}
+	authedResp := doRequest(t, app, req)
 	defer authedResp.Body.Close()
 
 	if authedResp.StatusCode != http.StatusOK {
 		t.Fatalf("expected OK status, got %d", authedResp.StatusCode)
 	}
+}
+
+func newRequest(t *testing.T, method, target string, body io.Reader) *http.Request {
+	t.Helper()
+
+	req, err := http.NewRequest(method, target, body)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	return req
+}
+
+func doRequest(t *testing.T, app *fiber.App, req *http.Request) *http.Response {
+	t.Helper()
+
+	resp, err := app.Test(req, -1)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	return resp
 }

--- a/internal/client/appserver/types.go
+++ b/internal/client/appserver/types.go
@@ -1,0 +1,55 @@
+package appserver
+
+import (
+	"time"
+
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+const (
+	DefaultHost = "127.0.0.1"
+	DefaultPort = 7778
+)
+
+type StartTunnelRequest struct {
+	Name         string                   `json:"name"`
+	Type         constants.ConnectionType `json:"type"`
+	Host         string                   `json:"host"`
+	Port         int                      `json:"port"`
+	Subdomain    string                   `json:"subdomain"`
+	PoolSize     int                      `json:"pool_size"`
+	CallbackURL  string                   `json:"callback_url"`
+	CallbackURLs []string                 `json:"callback_urls"`
+}
+
+type TunnelStatus struct {
+	ID           string                   `json:"id"`
+	Name         string                   `json:"name,omitempty"`
+	Status       string                   `json:"status"`
+	Type         constants.ConnectionType `json:"type"`
+	Host         string                   `json:"host"`
+	Port         int                      `json:"port"`
+	Subdomain    string                   `json:"subdomain,omitempty"`
+	RemotePort   int                      `json:"remote_port,omitempty"`
+	TunnelURL    string                   `json:"tunnel_url,omitempty"`
+	CallbackURLs []string                 `json:"callback_urls,omitempty"`
+	StartedAt    time.Time                `json:"started_at"`
+	UpdatedAt    time.Time                `json:"updated_at"`
+	StoppedAt    *time.Time               `json:"stopped_at,omitempty"`
+	LastError    string                   `json:"last_error,omitempty"`
+}
+
+type TunnelEvent struct {
+	ID         string                   `json:"id"`
+	TunnelID   string                   `json:"tunnel_id"`
+	Type       string                   `json:"type"`
+	Name       string                   `json:"name,omitempty"`
+	Connection constants.ConnectionType `json:"connection_type"`
+	Host       string                   `json:"host"`
+	Port       int                      `json:"port"`
+	Subdomain  string                   `json:"subdomain,omitempty"`
+	RemotePort int                      `json:"remote_port,omitempty"`
+	TunnelURL  string                   `json:"tunnel_url,omitempty"`
+	Error      string                   `json:"error,omitempty"`
+	At         time.Time                `json:"at"`
+}

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -168,7 +168,7 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 		workers := desiredWorkers(clientConfig, poolingSupported)
 
 		if clientConfig.Tunnel.Type == constants.Http && workers > 1 && clientConfig.ConnectionID == "" {
-			connID, err := sshclient.CreateNewConnection(clientConfig)
+			connID, err := sshclient.CreateNewConnectionWithContext(ctx, clientConfig)
 			if err != nil {
 				return fmt.Errorf("failed to create shared connection for pool: %w", err)
 			}

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -176,6 +176,7 @@ type ClientConfig struct {
 	HealthCheckInterval             int
 	HealthCheckMaxRetries           int
 	DisableTUI                      bool
+	DisableTerminalLogs             bool
 	EnableHttpReverseProxy          bool
 	InsecureSkipHostKeyVerification bool
 }

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -360,7 +360,7 @@ func (s *SshClient) startListenerForClient() error {
 			ClientConfig: &s.config,
 			Healthy:      true,
 		})
-	} else {
+	} else if !s.config.DisableTerminalLogs {
 		tunnelAddr := s.config.GetTunnelAddr()
 		fmt.Printf("✅ Tunnel started: %s → %s\n", s.config.Tunnel.GetLocalAddr(), tunnelAddr)
 	}
@@ -910,7 +910,7 @@ func (s *SshClient) logHttpRequest(
 			Status: req.ResponseStatusCode,
 			URL:    req.Url,
 		})
-	} else {
+	} else if !s.config.DisableTerminalLogs {
 		fmt.Printf("[%s] %s %s → %d\n",
 			req.LoggedAt.Local().Format("15:04:05"),
 			req.Method,
@@ -985,7 +985,7 @@ func (s *SshClient) StartHealthCheck(ctx context.Context) error {
 				Port:    fmt.Sprintf("%d", s.config.Tunnel.Port),
 				Healthy: false,
 			})
-		} else {
+		} else if !s.config.DisableTerminalLogs {
 			// Log unhealthy status when TUI is disabled
 			fmt.Printf("❌ Tunnel unhealthy: %s (attempting reconnect)\n", s.config.GetTunnelAddr())
 		}
@@ -1125,7 +1125,7 @@ func (s *SshClient) Reconnect() error {
 			})
 			// Increase active count after successful reconnect
 			s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: 1})
-		} else {
+		} else if !s.config.DisableTerminalLogs {
 			// Log successful reconnection when TUI is disabled
 			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())
 		}
@@ -1138,7 +1138,7 @@ func (s *SshClient) Reconnect() error {
 				Port:    fmt.Sprintf("%d", s.config.Tunnel.Port),
 				Healthy: true,
 			})
-		} else {
+		} else if !s.config.DisableTerminalLogs {
 			// Log successful reconnection when TUI is disabled
 			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())
 		}

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -202,6 +202,26 @@ func (s *SshClient) forwardListenerErrors(ctx context.Context, errChan <-chan er
 	}()
 }
 
+func (s *SshClient) closeTransport() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var err error
+	if s.listener != nil {
+		err = s.listener.Close()
+		s.listener = nil
+	}
+
+	if s.client != nil {
+		if clientErr := s.client.Close(); clientErr != nil && err == nil {
+			err = clientErr
+		}
+		s.client = nil
+	}
+
+	return err
+}
+
 func (s *SshClient) handleAcceptError(listener net.Listener, err error) error {
 	if err == nil {
 		return nil
@@ -304,7 +324,18 @@ func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready c
 		_ = tcp.SetNoDelay(true)
 	}
 
+	handshakeDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = rawConn.Close()
+		case <-handshakeDone:
+		}
+	}()
+	_ = rawConn.SetDeadline(time.Now().Add(10 * time.Second))
 	cc, chans, reqs, err := ssh.NewClientConn(rawConn, s.config.SshUrl, sshConfig)
+	close(handshakeDone)
+	_ = rawConn.SetDeadline(time.Time{})
 	if err != nil {
 		_ = rawConn.Close()
 		if s.config.Debug {
@@ -321,6 +352,16 @@ func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready c
 	s.goSafe("ssh keepalive", func() {
 		s.startSSHKeepAlive(clientRef)
 	})
+
+	ctxDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = s.closeTransport()
+		case <-ctxDone:
+		}
+	}()
+	defer close(ctxDone)
 
 	localEndpoint := s.config.Tunnel.GetLocalAddr()
 
@@ -946,24 +987,12 @@ func (s *SshClient) tcpTunnel(src, dst net.Conn) {
 func (s *SshClient) Shutdown(ctx context.Context) error {
 	atomic.StoreInt32(&s.shutdown, 1)
 
-	s.mu.Lock()
-	var err error
-	if s.listener != nil {
-		err = s.listener.Close()
-		s.listener = nil
-	}
-
-	if s.client != nil {
-		if clientErr := s.client.Close(); clientErr != nil && err == nil {
-			err = clientErr
-		}
-		s.client = nil
-	}
-
+	err := s.closeTransport()
+	s.mu.RLock()
 	tuiProgram := s.tui
 	port := fmt.Sprintf("%d", s.config.Tunnel.Port)
 	address := s.config.GetTunnelAddr()
-	s.mu.Unlock()
+	s.mu.RUnlock()
 
 	if tuiProgram != nil {
 		tuiProgram.Send(tui.UpdateConnCountMsg{Port: port, Delta: -1})
@@ -1057,6 +1086,7 @@ func (s *SshClient) startError(err error) error {
 func (s *SshClient) Start(ctx context.Context) error {
 	errChan := make(chan error, 1)
 	readyChan := make(chan struct{})
+	startupCtx, cancelStartup := context.WithCancel(ctx)
 	timer := time.NewTimer(tunnelStartTimeout)
 	defer timer.Stop()
 
@@ -1066,7 +1096,7 @@ func (s *SshClient) Start(ctx context.Context) error {
 				errChan <- fmt.Errorf("tunnel listener panic: %v", r)
 			}
 		}()
-		if err := s.startListenerForClientWithReady(ctx, readyChan); err != nil {
+		if err := s.startListenerForClientWithReady(startupCtx, readyChan); err != nil {
 			errChan <- err
 		}
 	}()
@@ -1082,19 +1112,22 @@ func (s *SshClient) Start(ctx context.Context) error {
 		return startErr
 
 	case <-readyChan:
-		s.forwardListenerErrors(ctx, errChan)
+		s.forwardListenerErrors(startupCtx, errChan)
 
 		if s.config.Tunnel.Type == constants.Http {
-			return s.StartHealthCheck(ctx)
+			defer cancelStartup()
+			return s.StartHealthCheck(startupCtx)
 		}
 		return nil
 
 	case <-timer.C:
+		cancelStartup()
 		startErr := s.startError(fmt.Errorf("timed out waiting for tunnel listener after %s", tunnelStartTimeout))
 		s.emitEvent(EventFailed, startErr)
 		return startErr
 
 	case <-ctx.Done():
+		cancelStartup()
 		return nil
 	}
 }

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -933,8 +933,6 @@ func (s *SshClient) Shutdown(ctx context.Context) error {
 	atomic.StoreInt32(&s.shutdown, 1)
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	var err error
 	if s.listener != nil {
 		err = s.listener.Close()
@@ -948,11 +946,16 @@ func (s *SshClient) Shutdown(ctx context.Context) error {
 		s.client = nil
 	}
 
-	if s.tui != nil {
-		s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: -1})
+	tuiProgram := s.tui
+	port := fmt.Sprintf("%d", s.config.Tunnel.Port)
+	address := s.config.GetTunnelAddr()
+	s.mu.Unlock()
+
+	if tuiProgram != nil {
+		tuiProgram.Send(tui.UpdateConnCountMsg{Port: port, Delta: -1})
 	}
 	s.emitEvent(EventStopped, nil)
-	log.Info("Stopped tunnel connection", "address", s.config.GetTunnelAddr())
+	log.Info("Stopped tunnel connection", "address", address)
 	return err
 }
 

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -35,6 +35,7 @@ var (
 	ErrLocalSetupIncomplete = fmt.Errorf("local setup incomplete")
 	errClientShuttingDown   = errors.New("client is shutting down")
 	newRestyClient          = resty.New
+	tunnelStartTimeout      = 20 * time.Second
 )
 
 type requestLogContextKey struct{}
@@ -195,7 +196,7 @@ func (s *SshClient) forwardListenerErrors(ctx context.Context, errChan <-chan er
 			if s.shouldIgnoreListenerError(ctx, err) {
 				return
 			}
-			s.reportFatal(err)
+			s.reportFatal(s.startError(err))
 		case <-ctx.Done():
 		}
 	}()
@@ -218,7 +219,11 @@ func (s *SshClient) handleAcceptError(listener net.Listener, err error) error {
 }
 
 func CreateNewConnection(cfg config.ClientConfig) (string, error) {
-	client := newRestyClient()
+	return CreateNewConnectionWithContext(context.Background(), cfg)
+}
+
+func CreateNewConnectionWithContext(ctx context.Context, cfg config.ClientConfig) (string, error) {
+	client := newRestyClient().SetTimeout(10 * time.Second)
 	var reqErr struct {
 		Message string `json:"message"`
 	}
@@ -239,27 +244,33 @@ func CreateNewConnection(cfg config.ClientConfig) (string, error) {
 		payload["subdomain"] = cfg.Tunnel.Subdomain
 	}
 
-	resp, err := request.SetBody(payload).Post(cfg.GetServerAddr() + "/api/v1/connections/")
+	resp, err := request.SetContext(ctx).SetBody(payload).Post(cfg.GetServerAddr() + "/api/v1/connections/")
 
 	if err != nil {
 		return "", err
 	}
 
 	if resp.StatusCode() != 200 {
-		log.Error("Failed to create new connection", "error", reqErr)
+		if reqErr.Message == "" {
+			reqErr.Message = resp.Status()
+		}
 		return "", fmt.Errorf("server error: %s", reqErr.Message)
 	}
 	return response.ConnectionId, nil
 }
 
-func (s *SshClient) createNewConnection() (string, error) {
+func (s *SshClient) createNewConnection(ctx context.Context) (string, error) {
 	if s.config.ConnectionID != "" {
 		return s.config.ConnectionID, nil
 	}
-	return CreateNewConnection(s.config)
+	return CreateNewConnectionWithContext(ctx, s.config)
 }
 
-func (s *SshClient) startListenerForClient() error {
+func (s *SshClient) startListenerForClient(ctx context.Context) error {
+	return s.startListenerForClientWithReady(ctx, nil)
+}
+
+func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready chan<- struct{}) error {
 	if atomic.LoadInt32(&s.shutdown) == 1 {
 		return errClientShuttingDown
 	}
@@ -267,7 +278,7 @@ func (s *SshClient) startListenerForClient() error {
 	var err error
 	var connectionId string
 
-	if connectionId, err = s.createNewConnection(); err != nil {
+	if connectionId, err = s.createNewConnection(ctx); err != nil {
 		return err
 	}
 
@@ -280,7 +291,7 @@ func (s *SshClient) startListenerForClient() error {
 	}
 
 	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 15 * time.Second}
-	rawConn, err := dialer.Dial("tcp", s.config.SshUrl)
+	rawConn, err := dialer.DialContext(ctx, "tcp", s.config.SshUrl)
 	if err != nil {
 		if s.config.Debug {
 			s.logDebug("Failed to dial ssh tcp", err)
@@ -366,6 +377,9 @@ func (s *SshClient) startListenerForClient() error {
 	}
 
 	s.emitEvent(EventStarted, nil)
+	if ready != nil {
+		close(ready)
+	}
 
 	if s.tui != nil {
 		s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: 1})
@@ -971,16 +985,28 @@ func (s *SshClient) StartHealthCheck(ctx context.Context) error {
 		case <-ticker.C:
 		}
 
+		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+			return nil
+		}
+
 		err := s.HealthCheck()
 		if err == nil {
 			retryAttempts = 0
 			continue
 		}
 
+		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+			return nil
+		}
+
 		retryAttempts++
 
 		if s.config.Debug {
 			s.logDebug("Health check failed", err)
+		}
+
+		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+			return nil
 		}
 
 		if s.tui != nil {
@@ -993,28 +1019,46 @@ func (s *SshClient) StartHealthCheck(ctx context.Context) error {
 			fmt.Printf("❌ Tunnel unhealthy: %s (attempting reconnect)\n", s.config.GetTunnelAddr())
 		}
 
+		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+			return nil
+		}
+
 		s.emitEvent(EventUnhealthy, err)
 
 		reconnectErr := s.Reconnect()
-		if reconnectErr != nil {
-			if s.config.Debug {
-				s.logDebug(fmt.Sprintf("Failed to reconnect to ssh tunnel (attempt %d)", retryAttempts), reconnectErr)
-			}
-			if retryAttempts > s.config.HealthCheckMaxRetries {
-				tunnelName := s.config.Tunnel.Name
-				if tunnelName == "" {
-					tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
-				}
-				return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", tunnelName, retryAttempts, reconnectErr)
-			}
-		} else {
+		if reconnectErr == nil {
 			retryAttempts = 0
+			continue
+		}
+		if errors.Is(reconnectErr, errClientShuttingDown) || ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+			return nil
+		}
+		if s.config.Debug {
+			s.logDebug(fmt.Sprintf("Failed to reconnect to ssh tunnel (attempt %d)", retryAttempts), reconnectErr)
+		}
+		if retryAttempts > s.config.HealthCheckMaxRetries {
+			tunnelName := s.config.Tunnel.Name
+			if tunnelName == "" {
+				tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
+			}
+			return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", tunnelName, retryAttempts, reconnectErr)
 		}
 	}
 }
 
+func (s *SshClient) startError(err error) error {
+	tunnelName := s.config.Tunnel.Name
+	if tunnelName == "" {
+		tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
+	}
+	return fmt.Errorf("failed to start tunnel '%s': %w", tunnelName, err)
+}
+
 func (s *SshClient) Start(ctx context.Context) error {
 	errChan := make(chan error, 1)
+	readyChan := make(chan struct{})
+	timer := time.NewTimer(tunnelStartTimeout)
+	defer timer.Stop()
 
 	go func() {
 		defer func() {
@@ -1022,7 +1066,7 @@ func (s *SshClient) Start(ctx context.Context) error {
 				errChan <- fmt.Errorf("tunnel listener panic: %v", r)
 			}
 		}()
-		if err := s.startListenerForClient(); err != nil {
+		if err := s.startListenerForClientWithReady(ctx, readyChan); err != nil {
 			errChan <- err
 		}
 	}()
@@ -1033,21 +1077,22 @@ func (s *SshClient) Start(ctx context.Context) error {
 			return nil
 		}
 
-		tunnelName := s.config.Tunnel.Name
-		if tunnelName == "" {
-			tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
-		}
-		startErr := fmt.Errorf("failed to start tunnel '%s': %w", tunnelName, err)
+		startErr := s.startError(err)
 		s.emitEvent(EventFailed, startErr)
 		return startErr
 
-	case <-time.After(5 * time.Second):
+	case <-readyChan:
 		s.forwardListenerErrors(ctx, errChan)
 
 		if s.config.Tunnel.Type == constants.Http {
 			return s.StartHealthCheck(ctx)
 		}
 		return nil
+
+	case <-timer.C:
+		startErr := s.startError(fmt.Errorf("timed out waiting for tunnel listener after %s", tunnelStartTimeout))
+		s.emitEvent(EventFailed, startErr)
+		return startErr
 
 	case <-ctx.Done():
 		return nil
@@ -1093,7 +1138,7 @@ func (s *SshClient) Reconnect() error {
 
 	// Channel to receive errors from the goroutine
 	errChan := make(chan error, 1)
-	done := make(chan struct{})
+	readyChan := make(chan struct{})
 
 	// Start the listener in a goroutine with context
 	go func() {
@@ -1106,8 +1151,7 @@ func (s *SshClient) Reconnect() error {
 				}
 			}
 		}()
-		defer close(done)
-		if err := s.startListenerForClient(); err != nil {
+		if err := s.startListenerForClientWithReady(ctx, readyChan); err != nil {
 			select {
 			case errChan <- err:
 			case <-ctx.Done():
@@ -1119,7 +1163,7 @@ func (s *SshClient) Reconnect() error {
 	select {
 	case err := <-errChan:
 		return err
-	case <-done:
+	case <-readyChan:
 		// Connection successful, update health status
 		if s.tui != nil {
 			s.tui.Send(tui.UpdateHealthMsg{
@@ -1128,19 +1172,6 @@ func (s *SshClient) Reconnect() error {
 			})
 			// Increase active count after successful reconnect
 			s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: 1})
-		} else if !s.config.DisableTerminalLogs {
-			// Log successful reconnection when TUI is disabled
-			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())
-		}
-		s.emitEvent(EventReconnected, nil)
-		return nil
-	case <-time.After(5 * time.Second):
-		// Fallback timeout in case done channel doesn't signal
-		if s.tui != nil {
-			s.tui.Send(tui.UpdateHealthMsg{
-				Port:    fmt.Sprintf("%d", s.config.Tunnel.Port),
-				Healthy: true,
-			})
 		} else if !s.config.DisableTerminalLogs {
 			// Log successful reconnection when TUI is disabled
 			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -84,9 +84,28 @@ type SshClient struct {
 	client       *ssh.Client
 	tui          *tea.Program
 	fatal        func(error)
+	eventHandler func(Event)
 	mu           sync.RWMutex
 	reconnecting int32 // atomic flag to prevent concurrent reconnects
 	shutdown     int32 // atomic flag for shutdown state
+}
+
+type EventType string
+
+const (
+	EventStarted     EventType = "started"
+	EventStopped     EventType = "stopped"
+	EventUnhealthy   EventType = "unhealthy"
+	EventReconnected EventType = "reconnected"
+	EventFailed      EventType = "failed"
+)
+
+type Event struct {
+	Type       EventType     `json:"type"`
+	Tunnel     config.Tunnel `json:"tunnel"`
+	TunnelAddr string        `json:"tunnel_addr"`
+	Error      string        `json:"error,omitempty"`
+	At         time.Time     `json:"at"`
 }
 
 func New(config config.ClientConfig, db *db.Db, tui *tea.Program, fatal func(error)) *SshClient {
@@ -100,10 +119,46 @@ func New(config config.ClientConfig, db *db.Db, tui *tea.Program, fatal func(err
 	}
 }
 
+func (s *SshClient) SetEventHandler(handler func(Event)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.eventHandler = handler
+}
+
+func (s *SshClient) ConfigSnapshot() config.ClientConfig {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.config
+}
+
+func (s *SshClient) emitEvent(eventType EventType, err error) {
+	s.mu.RLock()
+	handler := s.eventHandler
+	cfg := s.config
+	s.mu.RUnlock()
+
+	if handler == nil {
+		return
+	}
+
+	event := Event{
+		Type:       eventType,
+		Tunnel:     cfg.Tunnel,
+		TunnelAddr: cfg.GetTunnelAddr(),
+		At:         time.Now().UTC(),
+	}
+	if err != nil {
+		event.Error = err.Error()
+	}
+	handler(event)
+}
+
 func (s *SshClient) reportFatal(err error) {
 	if err == nil {
 		return
 	}
+
+	s.emitEvent(EventFailed, err)
 
 	if s.fatal != nil {
 		s.fatal(err)
@@ -309,6 +364,8 @@ func (s *SshClient) startListenerForClient() error {
 		tunnelAddr := s.config.GetTunnelAddr()
 		fmt.Printf("✅ Tunnel started: %s → %s\n", s.config.Tunnel.GetLocalAddr(), tunnelAddr)
 	}
+
+	s.emitEvent(EventStarted, nil)
 
 	if s.tui != nil {
 		s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: 1})
@@ -894,6 +951,7 @@ func (s *SshClient) Shutdown(ctx context.Context) error {
 	if s.tui != nil {
 		s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: -1})
 	}
+	s.emitEvent(EventStopped, nil)
 	log.Info("Stopped tunnel connection", "address", s.config.GetTunnelAddr())
 	return err
 }
@@ -931,6 +989,8 @@ func (s *SshClient) StartHealthCheck(ctx context.Context) error {
 			// Log unhealthy status when TUI is disabled
 			fmt.Printf("❌ Tunnel unhealthy: %s (attempting reconnect)\n", s.config.GetTunnelAddr())
 		}
+
+		s.emitEvent(EventUnhealthy, err)
 
 		reconnectErr := s.Reconnect()
 		if reconnectErr != nil {
@@ -974,7 +1034,9 @@ func (s *SshClient) Start(ctx context.Context) error {
 		if tunnelName == "" {
 			tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
 		}
-		return fmt.Errorf("failed to start tunnel '%s': %w", tunnelName, err)
+		startErr := fmt.Errorf("failed to start tunnel '%s': %w", tunnelName, err)
+		s.emitEvent(EventFailed, startErr)
+		return startErr
 
 	case <-time.After(5 * time.Second):
 		s.forwardListenerErrors(ctx, errChan)
@@ -1067,6 +1129,7 @@ func (s *SshClient) Reconnect() error {
 			// Log successful reconnection when TUI is disabled
 			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())
 		}
+		s.emitEvent(EventReconnected, nil)
 		return nil
 	case <-time.After(5 * time.Second):
 		// Fallback timeout in case done channel doesn't signal
@@ -1079,6 +1142,7 @@ func (s *SshClient) Reconnect() error {
 			// Log successful reconnection when TUI is disabled
 			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())
 		}
+		s.emitEvent(EventReconnected, nil)
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("reconnect timeout")

--- a/internal/client/ssh/ssh_create_conn_test.go
+++ b/internal/client/ssh/ssh_create_conn_test.go
@@ -1,7 +1,9 @@
 package ssh
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -74,6 +76,71 @@ func TestCreateNewConnection_Error(t *testing.T) {
 	_, err := CreateNewConnection(cfg)
 	if err == nil {
 		t.Fatalf("expected error, got nil")
+	}
+}
+
+func TestCreateNewConnectionWithContext_Canceled(t *testing.T) {
+	newRestyClient = func() *resty.Client {
+		return resty.NewWithClient(&http.Client{
+			Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				<-r.Context().Done()
+				return nil, r.Context().Err()
+			}),
+		})
+	}
+	defer func() { newRestyClient = resty.New }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cfg := clientcfg.ClientConfig{
+		ServerUrl:    "localhost:8001",
+		SecretKey:    "sk",
+		UseLocalHost: true,
+		Tunnel:       clientcfg.Tunnel{Type: constants.Http, Subdomain: "x"},
+	}
+
+	_, err := CreateNewConnectionWithContext(ctx, cfg)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context canceled error, got %v", err)
+	}
+}
+
+func TestStartReturnsServerConnectionError(t *testing.T) {
+	newRestyClient = func() *resty.Client {
+		return resty.NewWithClient(&http.Client{
+			Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				body, _ := json.Marshal(map[string]string{"message": "Invalid secret key"})
+				return &http.Response{
+					StatusCode: http.StatusBadRequest,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(string(body))),
+				}, nil
+			}),
+		})
+	}
+	defer func() { newRestyClient = resty.New }()
+
+	client := New(clientcfg.ClientConfig{
+		ServerUrl:           "localhost:8001",
+		SecretKey:           "bad",
+		UseLocalHost:        true,
+		DisableTerminalLogs: true,
+		Tunnel: clientcfg.Tunnel{
+			Name:      "demo",
+			Type:      constants.Http,
+			Host:      "localhost",
+			Port:      3000,
+			Subdomain: "demo",
+		},
+	}, nil, nil, nil)
+
+	err := client.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected startup error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to start tunnel 'demo': server error: Invalid secret key") {
+		t.Fatalf("unexpected startup error: %v", err)
 	}
 }
 

--- a/internal/client/ssh/ssh_shutdown_test.go
+++ b/internal/client/ssh/ssh_shutdown_test.go
@@ -1,0 +1,51 @@
+package ssh
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+func TestShutdownEmitsStoppedEventWithoutDeadlock(t *testing.T) {
+	client := New(clientcfg.ClientConfig{
+		UseLocalHost: true,
+		TunnelUrl:    "example.test",
+		Tunnel: clientcfg.Tunnel{
+			Type:      constants.Http,
+			Host:      "localhost",
+			Port:      3000,
+			Subdomain: "demo",
+		},
+	}, nil, nil, nil)
+
+	eventCh := make(chan Event, 1)
+	client.SetEventHandler(func(event Event) {
+		eventCh <- event
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- client.Shutdown(context.Background())
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected shutdown without error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("shutdown deadlocked")
+	}
+
+	select {
+	case event := <-eventCh:
+		if event.Type != EventStopped {
+			t.Fatalf("expected stopped event, got %q", event.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("expected stopped event")
+	}
+}


### PR DESCRIPTION
## Summary
- add `portr app-server`, a local Fiber-based HTTP API for starting, listing, inspecting, and shutting down HTTP/TCP tunnels
- add app-server lifecycle events, structured terminal event logs, and callback webhook dispatch for started, unhealthy, reconnected, failed, and stopped tunnel states
- make tunnel startup cancellable so Ctrl+C works while the CLI is still connecting, bound SSH handshake/startup work, and surface server auth failures as one clear startup error
- keep stopped app-server tunnels terminal by ignoring late unhealthy/reconnect/failure events while shutdown is in progress
- document app-server usage, authentication, API conventions, request/response fields, events, callbacks, Python/Node examples, terminal logging, and operational notes in the client docs
- add a runnable FastAPI example under `examples/app-server-fastapi` that creates a tunnel, prints the URL, serves FastAPI, and deletes the tunnel on shutdown
- add a homepage banner linking to the app-server guide with the control-plane headline
- rebase onto latest `origin/main` and refresh `docs-v2/bun.lock` for `next@15.5.18`

## Validation
- `go test ./internal/client/ssh ./internal/client/appserver ./internal/client/client ./cmd/portr`
- `go test ./...`
- `go build ./...` (completed successfully; Go printed a non-fatal stat-cache permission warning)
- `go build -o portr ./cmd/portr` (completed successfully; Go printed the same non-fatal stat-cache permission warning)
- `python3 -m py_compile examples/app-server-fastapi/main.py`
- `bun install` from `docs-v2/`
- `bun run --bun build` from `docs-v2/` (completed successfully with expected offline GitHub API fetch warnings during static generation)