### PR TITLE
Pass GitHub token to docs repo info

### DIFF
--- a/docs-v2/app/(home)/page.tsx
+++ b/docs-v2/app/(home)/page.tsx
@@ -5,8 +5,8 @@ import {
   TypingAnimation,
   AnimatedSpan,
 } from "@/components/magicui/terminal";
-import { GithubInfo } from "fumadocs-ui/components/github-info";
 import { SparklesText } from "@/components/magicui/sparkles-text";
+import { GithubInfo } from "fumadocs-ui/components/github-info";
 import Logo from "@/components/ui/logo";
 
 export const metadata: Metadata = {
@@ -135,6 +135,7 @@ export default function HomePage() {
             <GithubInfo
               owner="amalshaji"
               repo="portr"
+              token={process.env.GITHUB_TOKEN}
               className="w-full md:w-auto px-6 sm:px-8 py-3 sm:py-4 border border-fd-border text-fd-foreground font-semibold rounded-lg hover:bg-fd-accent transition-colors text-base sm:text-lg text-center flex flex-row items-center justify-center gap-2 min-h-[3.5rem]"
             />
             <Link

--- a/docs-v2/app/docs/layout.tsx
+++ b/docs-v2/app/docs/layout.tsx
@@ -15,7 +15,12 @@ const docsOptions: DocsLayoutProps = {
     {
       type: "custom",
       children: (
-        <GithubInfo owner="amalshaji" repo="portr" className="lg:-mx-2" />
+        <GithubInfo
+          owner="amalshaji"
+          repo="portr"
+          token={process.env.GITHUB_TOKEN}
+          className="lg:-mx-2"
+        />
       ),
     },
   ],


### PR DESCRIPTION
## Summary
- keep fumadocs `GithubInfo` and pass `process.env.GITHUB_TOKEN` to authenticated GitHub API calls
- wire the token on both the docs layout and home page GitHub repo widgets
- avoid adding a custom GitHub info replacement component

## Required deploy config
- Set `GITHUB_TOKEN` in Cloudflare Pages build environment
- Fine-grained PAT only needs Metadata: Read for `amalshaji/portr`

## Validation
- `bun run --bun build` from `docs-v2/`