### PR TITLE
Fix TUI reconnect counts

### DIFF
--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -222,6 +222,16 @@ func (s *SshClient) closeTransport() error {
 	return err
 }
 
+func (s *SshClient) closeListenerIfCurrent(listener net.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.listener == listener {
+		_ = s.listener.Close()
+		s.listener = nil
+	}
+}
+
 func (s *SshClient) handleAcceptError(listener net.Listener, err error) error {
 	if err == nil {
 		return nil
@@ -353,16 +363,6 @@ func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready c
 		s.startSSHKeepAlive(clientRef)
 	})
 
-	ctxDone := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = s.closeTransport()
-		case <-ctxDone:
-		}
-	}()
-	defer close(ctxDone)
-
 	localEndpoint := s.config.Tunnel.GetLocalAddr()
 
 	tunnelType := s.config.Tunnel.Type
@@ -398,12 +398,7 @@ func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready c
 	s.mu.Unlock()
 
 	defer func() {
-		s.mu.Lock()
-		if s.listener != nil {
-			s.listener.Close()
-			s.listener = nil
-		}
-		s.mu.Unlock()
+		s.closeListenerIfCurrent(ln)
 	}()
 
 	if s.tui != nil {
@@ -1122,12 +1117,14 @@ func (s *SshClient) Start(ctx context.Context) error {
 
 	case <-timer.C:
 		cancelStartup()
+		_ = s.closeTransport()
 		startErr := s.startError(fmt.Errorf("timed out waiting for tunnel listener after %s", tunnelStartTimeout))
 		s.emitEvent(EventFailed, startErr)
 		return startErr
 
 	case <-ctx.Done():
 		cancelStartup()
+		_ = s.closeTransport()
 		return nil
 	}
 }
@@ -1203,8 +1200,6 @@ func (s *SshClient) Reconnect() error {
 				Port:    fmt.Sprintf("%d", s.config.Tunnel.Port),
 				Healthy: true,
 			})
-			// Increase active count after successful reconnect
-			s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: 1})
 		} else if !s.config.DisableTerminalLogs {
 			// Log successful reconnection when TUI is disabled
 			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())

--- a/internal/client/ssh/ssh_panic_test.go
+++ b/internal/client/ssh/ssh_panic_test.go
@@ -9,11 +9,16 @@ import (
 	"time"
 )
 
-type testListener struct{}
+type testListener struct {
+	closeCount int
+}
 
-func (testListener) Accept() (net.Conn, error) { return nil, nil }
-func (testListener) Close() error              { return nil }
-func (testListener) Addr() net.Addr            { return testAddr("test") }
+func (*testListener) Accept() (net.Conn, error) { return nil, nil }
+func (l *testListener) Close() error {
+	l.closeCount++
+	return nil
+}
+func (*testListener) Addr() net.Addr { return testAddr("test") }
 
 type testAddr string
 
@@ -69,6 +74,35 @@ func TestHandleAcceptErrorIgnoresReplacedListener(t *testing.T) {
 	err := client.handleAcceptError(oldListener, net.ErrClosed)
 	if !errors.Is(err, errClientShuttingDown) {
 		t.Fatalf("expected shutdown sentinel, got %v", err)
+	}
+}
+
+func TestCloseListenerIfCurrentDoesNotCloseReplacement(t *testing.T) {
+	oldListener := &testListener{}
+	newListener := &testListener{}
+	client := &SshClient{
+		listener: newListener,
+	}
+
+	client.closeListenerIfCurrent(oldListener)
+
+	if oldListener.closeCount != 0 {
+		t.Fatalf("expected old listener not to be closed, got %d closes", oldListener.closeCount)
+	}
+	if newListener.closeCount != 0 {
+		t.Fatalf("expected replacement listener not to be closed, got %d closes", newListener.closeCount)
+	}
+	if client.listener != newListener {
+		t.Fatal("expected replacement listener to remain active")
+	}
+
+	client.closeListenerIfCurrent(newListener)
+
+	if newListener.closeCount != 1 {
+		t.Fatalf("expected current listener to be closed once, got %d closes", newListener.closeCount)
+	}
+	if client.listener != nil {
+		t.Fatal("expected current listener to be cleared")
 	}
 }
 

--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -246,6 +246,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if tunnel.active < 0 {
 				tunnel.active = 0
 			}
+			tunnel.active = min(tunnel.active, max(1, tunnel.poolSize))
 		}
 
 	case tea.WindowSizeMsg:
@@ -403,10 +404,10 @@ func (m model) View() string {
 			statusText = "🔴 Unhealthy (0/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
 		} else if tunnel.active < max(1, tunnel.poolSize) {
 			tunnelStyle = unhealthyStyle
-			statusText = "� Partial (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
+			statusText = "🟡 Partial (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
 		} else {
 			tunnelStyle = healthyStyle
-			statusText = "� Healthy (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
+			statusText = "🟢 Healthy (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
 		}
 
 		tunnelInfo := fmt.Sprintf("%s (%s:%d → %s) [%s] %s",

--- a/internal/client/tui/tui_test.go
+++ b/internal/client/tui/tui_test.go
@@ -1,0 +1,80 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+func TestViewRendersStatusIcons(t *testing.T) {
+	tunnel := testTunnel()
+	m := model{
+		tunnels: map[string]*tunnelStatus{
+			"8765": {
+				config:       &tunnel,
+				clientConfig: testClientConfig(tunnel),
+				active:       2,
+				poolSize:     2,
+			},
+		},
+		width: 200,
+	}
+
+	view := m.View()
+	if strings.Contains(view, "�") {
+		t.Fatalf("expected status output without replacement character, got %q", view)
+	}
+	if !strings.Contains(view, "🟢 Healthy (2/2)") {
+		t.Fatalf("expected healthy icon and count, got %q", view)
+	}
+}
+
+func TestUpdateConnCountClampsToPoolSize(t *testing.T) {
+	tunnel := testTunnel()
+	m := model{
+		tunnels: map[string]*tunnelStatus{
+			"8765": {
+				config:       &tunnel,
+				clientConfig: testClientConfig(tunnel),
+				poolSize:     2,
+			},
+		},
+		width: 100,
+	}
+
+	for i := 0; i < 598; i++ {
+		updated, _ := m.Update(UpdateConnCountMsg{Port: "8765", Delta: 1})
+		m = updated.(model)
+	}
+
+	if got := m.tunnels["8765"].active; got != 2 {
+		t.Fatalf("expected active count to clamp to pool size 2, got %d", got)
+	}
+
+	updated, _ := m.Update(UpdateConnCountMsg{Port: "8765", Delta: -5})
+	m = updated.(model)
+	if got := m.tunnels["8765"].active; got != 0 {
+		t.Fatalf("expected active count not to drop below 0, got %d", got)
+	}
+}
+
+func testTunnel() config.Tunnel {
+	return config.Tunnel{
+		Name:      "audio-stream",
+		Type:      constants.Http,
+		Host:      "localhost",
+		Port:      8765,
+		Subdomain: "audio-stream",
+		PoolSize:  2,
+	}
+}
+
+func testClientConfig(tunnel config.Tunnel) *config.ClientConfig {
+	return &config.ClientConfig{
+		Tunnel:       tunnel,
+		TunnelUrl:    "go.portr.dev",
+		UseLocalHost: false,
+	}
+}


### PR DESCRIPTION
## Summary
- keep successful reconnect listeners alive after the reconnect startup context is cancelled
- prevent old listener cleanup from closing a replacement listener
- stop double-counting successful reconnects in the TUI and clamp active counts to the configured pool size
- replace broken status replacement characters with the intended healthy and partial icons

## Root cause
Reconnect used a short-lived startup context, then the listener goroutine watched that same context and closed the transport when it was cancelled after a successful reconnect. Old listener cleanup could also close a newer replacement listener because it did not check listener ownership. Separately, reconnect sent an extra active-count increment after listener startup had already done so.

## Validation
- go test ./...
- go build ./... (passed; Go emitted a non-fatal module stat-cache permission warning outside the repo)