### PR TITLE
Add stub tunnels

### DIFF
--- a/cmd/portr/main.go
+++ b/cmd/portr/main.go
@@ -32,6 +32,7 @@ func main() {
 			startCmd(),
 			configCmd(),
 			httpCmd(),
+			stubCmd(),
 			tcpCmd(),
 			logsCmd(),
 			replayCmd(),

--- a/cmd/portr/start.go
+++ b/cmd/portr/start.go
@@ -23,6 +23,9 @@ func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 
 	if tunnelFromCli != nil {
 		tunnelFromCli.SetDefaults()
+		if err := tunnelFromCli.ResolveStubTemplate("."); err != nil {
+			return err
+		}
 		if err := tunnelFromCli.Validate(); err != nil {
 			return err
 		}

--- a/cmd/portr/stub.go
+++ b/cmd/portr/stub.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/urfave/cli/v2"
+)
+
+func stubCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "stub",
+		Usage: "Serve a stubbed templated response through a Portr HTTP tunnel",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "subdomain",
+				Aliases:  []string{"s"},
+				Usage:    "Subdomain to serve the stub response from",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "response-format",
+				Usage:    "Response Content-Type, for example application/json",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "response-tmpl",
+				Usage: "Inline response template",
+			},
+			&cli.StringFlag{
+				Name:  "response-tmpl-file",
+				Usage: "Path to a response template file",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			return startTunnels(c, &config.Tunnel{
+				Subdomain:            c.String("subdomain"),
+				Type:                 constants.Stub,
+				ResponseFormat:       c.String("response-format"),
+				ResponseTemplate:     c.String("response-tmpl"),
+				ResponseTemplateFile: c.String("response-tmpl-file"),
+			})
+		},
+	}
+}

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -28,8 +28,8 @@ Use app-server when you want another local program to own tunnel lifecycle:
 - Desktop apps or local automation tools that need to open and close tunnels
 - Integrations that need disconnect and reconnect notifications
 
-For one-off terminal workflows, `portr http`, `portr tcp`, and `portr start`
-remain simpler. For inspecting HTTP traffic already captured on disk, use
+For one-off terminal workflows, `portr http`, `portr tcp`, `portr stub`, and
+`portr start` remain simpler. For inspecting HTTP traffic already captured on disk, use
 [`portr logs`](/docs/client/request-logs) or the local inspector dashboard.
 
 ## Runtime model
@@ -220,16 +220,37 @@ TCP responses include `remote_port` once the remote listener is allocated:
 }
 ```
 
+## Start a stub tunnel
+
+Stub tunnels use the same endpoint with `type: "stub"`. They do not require
+`host` or `port`; the app-server process starts a shared local stub responder
+and exposes it through the existing HTTP tunnel path.
+
+```bash
+curl -X POST http://127.0.0.1:7778/api/v1/tunnels \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "yaml",
+    "type": "stub",
+    "subdomain": "yaml",
+    "response_format": "application/yml",
+    "response_tmpl": "message: {{message}}\n"
+  }'
+```
+
 ## Request fields
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
 | `name` | string | No | Human-readable label returned in status and event payloads. |
-| `type` | string | No | `http` or `tcp`. Defaults to `http` when omitted. |
-| `host` | string | No | Local host to forward to. Defaults to `localhost`. |
-| `port` | number | Yes | Local port to forward to. Must be between `1` and `65535`. |
-| `subdomain` | string | HTTP only | Fixed HTTP subdomain. If omitted for HTTP, Portr generates one. |
+| `type` | string | No | `http`, `tcp`, or `stub`. Defaults to `http` when omitted. |
+| `host` | string | HTTP/TCP | Local host to forward to. Defaults to `localhost`. |
+| `port` | number | HTTP/TCP | Local port to forward to. Must be between `1` and `65535`. |
+| `subdomain` | string | HTTP/stub | Fixed HTTP subdomain. If omitted for HTTP, Portr generates one. Stub tunnels require it. |
 | `pool_size` | number | HTTP only | Number of HTTP tunnel workers. Defaults to the client tunnel default. Falls back to one worker when the Portr server does not support pooled HTTP tunnels. |
+| `response_format` | string | Stub only | Response `Content-Type`, such as `application/json` or `application/yml`. |
+| `response_tmpl` | string | Stub only | Inline stub response template. Use exactly one of `response_tmpl` or `response_tmpl_file`. |
+| `response_tmpl_file` | string | Stub only | Stub response template file path, resolved from the app-server process working directory. |
 | `callback_url` | string | No | Single webhook URL for lifecycle events. |
 | `callback_urls` | string[] | No | Additional webhook URLs for lifecycle events. Duplicate URLs are ignored. |
 
@@ -242,12 +263,13 @@ Tunnel status responses use this shape:
 | `id` | string | App-server tunnel ID used by the local API. |
 | `name` | string | Optional name supplied when the tunnel was created. |
 | `status` | string | Current lifecycle status. |
-| `type` | string | `http` or `tcp`. |
+| `type` | string | `http`, `tcp`, or `stub`. |
 | `host` | string | Local host forwarded by the tunnel. |
 | `port` | number | Local port forwarded by the tunnel. |
-| `subdomain` | string | HTTP subdomain, when the tunnel is HTTP. |
+| `subdomain` | string | HTTP subdomain, when the tunnel is HTTP or stub. |
 | `remote_port` | number | Remote TCP port, when the tunnel is TCP and the server has allocated one. |
 | `tunnel_url` | string | Public HTTP URL or TCP host/port once available. |
+| `response_format` | string | Stub response `Content-Type`, when the tunnel is stub. |
 | `callback_urls` | string[] | Callback URLs registered for this tunnel. |
 | `started_at` | string | RFC3339 timestamp for tunnel creation inside app-server. |
 | `updated_at` | string | RFC3339 timestamp for the last status change. |

--- a/docs-v2/content/docs/client/index.mdx
+++ b/docs-v2/content/docs/client/index.mdx
@@ -28,6 +28,9 @@ The Portr client is a command-line tool that allows you to create secure tunnels
   <Card title="TCP Tunnels" href="/docs/client/tcp-tunnel">
     Tunnel raw TCP connections for databases and other services.
   </Card>
+  <Card title="Stub Tunnels" href="/docs/client/stub-tunnel">
+    Serve templated responses without a separate local web server.
+  </Card>
   <Card title="WebSocket Tunnels" href="/docs/client/websocket-tunnel">
     Enable real-time WebSocket connections through tunnels.
   </Card>
@@ -54,6 +57,9 @@ portr http 3000
 
 # Create a TCP tunnel
 portr tcp 5432
+
+# Create a stub response tunnel
+portr stub --subdomain yaml --response-format application/yml --response-tmpl 'message: {{message}}'
 
 # Create tunnel with custom subdomain
 portr http 3000 --subdomain my-app

--- a/docs-v2/content/docs/client/meta.json
+++ b/docs-v2/content/docs/client/meta.json
@@ -8,6 +8,7 @@
     "request-replay",
     "app-server",
     "tcp-tunnel",
+    "stub-tunnel",
     "websocket-tunnel",
     "templates"
   ]

--- a/docs-v2/content/docs/client/stub-tunnel.mdx
+++ b/docs-v2/content/docs/client/stub-tunnel.mdx
@@ -1,0 +1,122 @@
+---
+title: Stub Tunnel
+description: Serve templated responses through a local Portr responder
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+Stub tunnels let the Portr client return a templated response without you
+running a separate local web server. The client starts one local stub responder
+inside the Portr process and exposes each stub subdomain through the existing
+HTTP tunnel path.
+
+```bash
+portr stub \
+  --subdomain yaml \
+  --response-format application/yml \
+  --response-tmpl 'message: {{message}}'
+```
+
+You can also read the response template from a file:
+
+```bash
+portr stub \
+  --subdomain json \
+  --response-format application/json \
+  --response-tmpl-file ./response.json
+```
+
+`--response-tmpl` and `--response-tmpl-file` are mutually exclusive, and one of them is required.
+
+<Callout type="info">
+  Stub tunnels use the existing HTTP tunnel protocol, so they work with
+  existing Portr servers and do not require a server migration or stub-specific
+  heartbeat endpoint.
+</Callout>
+
+## Template Values
+
+Use `{{name}}` placeholders in the response template. When a request hits the stub tunnel, Portr fills placeholders from request values in this order:
+
+1. Query parameters
+2. JSON body fields or form fields
+3. Empty string when no value exists
+
+For example:
+
+```bash
+curl 'https://yaml.example.com?message=hello'
+```
+
+With this template:
+
+```yaml
+message: {{message}}
+missing: {{missing}}
+```
+
+Portr returns:
+
+```yaml
+message: hello
+missing:
+```
+
+The request body can be a JSON object, `application/x-www-form-urlencoded`, or
+`multipart/form-data`. Invalid JSON or form bodies return `400 Bad Request`.
+
+## Value Casting
+
+Use `{{key|int}}`, `{{key|bool}}`, or `{{key|float}}` when a placeholder should
+render as a typed value. If the value cannot be parsed as that type, Portr keeps
+the original string value.
+
+For JSON templates, wrap typed placeholders in quotes so failed casts still
+produce valid JSON strings:
+
+```json
+{
+  "id": "{{id}}",
+  "status": "{{status|int}}",
+  "enabled": "{{enabled|bool}}",
+  "score": "{{score|float}}",
+  "message": "{{message}}",
+  "source": "portr-stub"
+}
+```
+
+With `?status=200&enabled=true&score=12.5`, Portr renders:
+
+```json
+{
+  "id": "",
+  "status": 200,
+  "enabled": true,
+  "score": 12.5,
+  "message": "",
+  "source": "portr-stub"
+}
+```
+
+## Config Template
+
+Stub tunnels can be defined in your Portr config with `type: stub` and started with `portr start`:
+
+```yaml
+tunnels:
+  - name: yaml
+    type: stub
+    subdomain: yaml
+    response_format: application/yml
+    response_tmpl_file: ./response.yml
+```
+
+Template file paths in config are resolved relative to the config file.
+
+## Examples
+
+Example templates are available in:
+
+- `examples/stub-response.json`
+- `examples/stub-response.yaml`
+- `examples/stub-response.xml`

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -150,6 +150,11 @@ tunnels:
     subdomain: api-dev
     port: 3000
     type: http
+  - name: yaml
+    type: stub
+    subdomain: yaml
+    response_format: application/yml
+    response_tmpl_file: ./response.yml
 ```
 
 ## Using Templates
@@ -200,6 +205,17 @@ These options apply to the entire client configuration:
 - **health_check_interval**: Health check interval in seconds (default: 3)
 - **health_check_max_retries**: Maximum health check retry attempts (default: 10)
 - **insecure_skip_host_key_verification**: Skip SSH host key verification (default: true)
+
+### Stub Tunnel Options
+
+These options apply to stub tunnel entries with `type: stub`:
+
+- **subdomain**: Public subdomain that serves the stub response
+- **response_format**: Response `Content-Type`, such as `application/json` or `application/yml`
+- **response_tmpl**: Inline response template
+- **response_tmpl_file**: Path to a response template file, resolved relative to the config file
+
+Use exactly one of `response_tmpl` or `response_tmpl_file`.
 
 ### SSH Host Key Verification
 

--- a/examples/stub-response.json
+++ b/examples/stub-response.json
@@ -1,0 +1,6 @@
+{
+  "id": "{{id}}",
+  "status": "{{status|int}}",
+  "message": "{{message}}",
+  "source": "portr-stub"
+}

--- a/examples/stub-response.xml
+++ b/examples/stub-response.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<response>
+  <id>{{id}}</id>
+  <status>{{status}}</status>
+  <message>{{message}}</message>
+  <source>portr-stub</source>
+</response>

--- a/examples/stub-response.yaml
+++ b/examples/stub-response.yaml
@@ -1,0 +1,4 @@
+id: "{{id}}"
+status: "{{status}}"
+message: "{{message}}"
+source: portr-stub

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -17,6 +17,7 @@ import (
 	clientcfg "github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
 	sshclient "github.com/amalshaji/portr/internal/client/ssh"
+	"github.com/amalshaji/portr/internal/client/stubresponder"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/charmbracelet/log"
 	"github.com/oklog/ulid/v2"
@@ -53,9 +54,11 @@ type Manager struct {
 	httpClient *http.Client
 	logger     *log.Logger
 
-	mu      sync.RWMutex
-	tunnels map[string]*tunnelRuntime
-	events  []TunnelEvent
+	mu            sync.RWMutex
+	stubMu        sync.Mutex
+	stubResponder *stubresponder.Responder
+	tunnels       map[string]*tunnelRuntime
+	events        []TunnelEvent
 }
 
 func NewManager(baseConfig clientcfg.Config, database *db.Db) *Manager {
@@ -76,15 +79,26 @@ func NewManager(baseConfig clientcfg.Config, database *db.Db) *Manager {
 
 func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (TunnelStatus, error) {
 	tunnel := clientcfg.Tunnel{
-		Name:      request.Name,
-		Subdomain: request.Subdomain,
-		Port:      request.Port,
-		Host:      request.Host,
-		Type:      request.Type,
-		PoolSize:  request.PoolSize,
+		Name:                 request.Name,
+		Subdomain:            request.Subdomain,
+		Port:                 request.Port,
+		Host:                 request.Host,
+		Type:                 request.Type,
+		PoolSize:             request.PoolSize,
+		ResponseFormat:       request.ResponseFormat,
+		ResponseTemplate:     request.ResponseTemplate,
+		ResponseTemplateFile: request.ResponseTemplateFile,
 	}
 	tunnel.SetDefaults()
+	if err := tunnel.ResolveStubTemplate("."); err != nil {
+		return TunnelStatus{}, err
+	}
 	if err := validateTunnelRequest(tunnel, request.CallbackURL, request.CallbackURLs); err != nil {
+		return TunnelStatus{}, err
+	}
+
+	statusTunnel := tunnel
+	if err := m.prepareStubTunnel(&tunnel); err != nil {
 		return TunnelStatus{}, err
 	}
 
@@ -107,16 +121,17 @@ func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (
 		cancel:       cancel,
 		callbackURLs: callbackURLs,
 		status: TunnelStatus{
-			ID:           id,
-			Name:         tunnel.Name,
-			Status:       statusStarting,
-			Type:         tunnel.Type,
-			Host:         tunnel.Host,
-			Port:         tunnel.Port,
-			Subdomain:    tunnel.Subdomain,
-			CallbackURLs: callbackURLs,
-			StartedAt:    now,
-			UpdatedAt:    now,
+			ID:             id,
+			Name:           tunnel.Name,
+			Status:         statusStarting,
+			Type:           tunnel.Type,
+			Host:           statusTunnel.Host,
+			Port:           statusTunnel.Port,
+			Subdomain:      tunnel.Subdomain,
+			ResponseFormat: tunnel.ResponseFormat,
+			CallbackURLs:   callbackURLs,
+			StartedAt:      now,
+			UpdatedAt:      now,
 		},
 		startedCh: make(chan struct{}),
 		failedCh:  make(chan error, 1),
@@ -148,11 +163,13 @@ func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (
 		return m.GetTunnel(id)
 	case err := <-runtime.failedCh:
 		cancel()
+		m.unregisterStubTunnel(tunnel)
 		return TunnelStatus{}, err
 	case <-time.After(7 * time.Second):
 		return m.GetTunnel(id)
 	case <-ctx.Done():
 		cancel()
+		m.unregisterStubTunnel(tunnel)
 		return TunnelStatus{}, ctx.Err()
 	}
 }
@@ -199,6 +216,10 @@ func (m *Manager) StopTunnel(ctx context.Context, id string) (TunnelStatus, erro
 	for _, client := range tunnel.clients {
 		_ = client.Shutdown(ctx)
 	}
+	m.unregisterStubTunnel(clientcfg.Tunnel{
+		Type:      tunnel.status.Type,
+		Subdomain: tunnel.status.Subdomain,
+	})
 
 	now := time.Now().UTC()
 	m.mu.Lock()
@@ -209,6 +230,49 @@ func (m *Manager) StopTunnel(ctx context.Context, id string) (TunnelStatus, erro
 	m.mu.Unlock()
 
 	return status, nil
+}
+
+func (m *Manager) prepareStubTunnel(tunnel *clientcfg.Tunnel) error {
+	if tunnel.Type != constants.Stub {
+		return nil
+	}
+
+	m.stubMu.Lock()
+	defer m.stubMu.Unlock()
+
+	if m.stubResponder == nil {
+		responder := stubresponder.New()
+		if err := responder.Start(); err != nil {
+			return err
+		}
+		m.stubResponder = responder
+	}
+
+	if err := m.stubResponder.Register(stubresponder.Route{
+		Subdomain:        tunnel.Subdomain,
+		ResponseFormat:   tunnel.ResponseFormat,
+		ResponseTemplate: tunnel.ResponseTemplate,
+	}); err != nil {
+		return err
+	}
+
+	tunnel.Host = "127.0.0.1"
+	tunnel.Port = m.stubResponder.Port()
+	tunnel.PoolSize = 1
+	return nil
+}
+
+func (m *Manager) unregisterStubTunnel(tunnel clientcfg.Tunnel) {
+	if tunnel.Type != constants.Stub {
+		return
+	}
+
+	m.stubMu.Lock()
+	defer m.stubMu.Unlock()
+
+	if m.stubResponder != nil {
+		m.stubResponder.Unregister(tunnel.Subdomain)
+	}
 }
 
 func (m *Manager) Events(tunnelID string) []TunnelEvent {
@@ -235,6 +299,13 @@ func (m *Manager) Shutdown(ctx context.Context) {
 	for _, id := range ids {
 		_, _ = m.StopTunnel(ctx, id)
 	}
+
+	m.stubMu.Lock()
+	if m.stubResponder != nil {
+		_ = m.stubResponder.Shutdown(ctx)
+		m.stubResponder = nil
+	}
+	m.stubMu.Unlock()
 }
 
 func (m *Manager) clientConfigForTunnel(tunnel clientcfg.Tunnel) clientcfg.ClientConfig {
@@ -263,6 +334,11 @@ func (m *Manager) handleStartFailure(id string, err error) {
 	if !ok {
 		return
 	}
+
+	m.unregisterStubTunnel(clientcfg.Tunnel{
+		Type:      tunnel.status.Type,
+		Subdomain: tunnel.status.Subdomain,
+	})
 
 	tunnel.failOnce.Do(func() {
 		select {
@@ -457,11 +533,11 @@ func (m *Manager) dispatchCallbacks(callbackURLs []string, event TunnelEvent) {
 }
 
 func validateTunnelRequest(tunnel clientcfg.Tunnel, callbackURL string, callbackURLs []string) error {
-	if tunnel.Port <= 0 || tunnel.Port > 65535 {
+	if tunnel.Type != constants.Stub && (tunnel.Port <= 0 || tunnel.Port > 65535) {
 		return fmt.Errorf("port must be between 1 and 65535")
 	}
-	if tunnel.Type != constants.Http && tunnel.Type != constants.Tcp {
-		return fmt.Errorf("type must be either http or tcp")
+	if tunnel.Type != constants.Http && tunnel.Type != constants.Tcp && tunnel.Type != constants.Stub {
+		return fmt.Errorf("type must be http, tcp, or stub")
 	}
 	if err := tunnel.Validate(); err != nil {
 		return err

--- a/internal/client/appserver/manager_test.go
+++ b/internal/client/appserver/manager_test.go
@@ -2,6 +2,10 @@ package appserver
 
 import (
 	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -73,6 +77,60 @@ func TestClientConfigForTunnelDisablesSSHClientTerminalLogs(t *testing.T) {
 	clientConfig := manager.clientConfigForTunnel(tunnel)
 	if !clientConfig.DisableTerminalLogs {
 		t.Fatal("expected app-server tunnel client terminal logs to be disabled")
+	}
+}
+
+func TestPrepareStubTunnelUsesSharedLocalResponder(t *testing.T) {
+	cfg := clientcfg.Config{}
+	cfg.SetDefaults()
+
+	manager := NewManager(cfg, nil)
+	t.Cleanup(func() {
+		manager.Shutdown(context.Background())
+	})
+
+	first := clientcfg.Tunnel{
+		Type:             constants.Stub,
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"name":"{{name}}"}`,
+	}
+	second := clientcfg.Tunnel{
+		Type:             constants.Stub,
+		Subdomain:        "yaml",
+		ResponseFormat:   "application/yml",
+		ResponseTemplate: "name: {{name}}\n",
+	}
+
+	if err := manager.prepareStubTunnel(&first); err != nil {
+		t.Fatalf("prepare first stub tunnel: %v", err)
+	}
+	if err := manager.prepareStubTunnel(&second); err != nil {
+		t.Fatalf("prepare second stub tunnel: %v", err)
+	}
+
+	if first.Port == 0 || second.Port == 0 || first.Port != second.Port {
+		t.Fatalf("expected stub tunnels to share one responder port, got %d and %d", first.Port, second.Port)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/?name=portr", first.Port), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = "yaml.example.test"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request stub responder: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if string(body) != "name: portr\n" {
+		t.Fatalf("unexpected response body: %q", string(body))
 	}
 }
 

--- a/internal/client/appserver/types.go
+++ b/internal/client/appserver/types.go
@@ -12,31 +12,35 @@ const (
 )
 
 type StartTunnelRequest struct {
-	Name         string                   `json:"name"`
-	Type         constants.ConnectionType `json:"type"`
-	Host         string                   `json:"host"`
-	Port         int                      `json:"port"`
-	Subdomain    string                   `json:"subdomain"`
-	PoolSize     int                      `json:"pool_size"`
-	CallbackURL  string                   `json:"callback_url"`
-	CallbackURLs []string                 `json:"callback_urls"`
+	Name                 string                   `json:"name"`
+	Type                 constants.ConnectionType `json:"type"`
+	Host                 string                   `json:"host"`
+	Port                 int                      `json:"port"`
+	Subdomain            string                   `json:"subdomain"`
+	PoolSize             int                      `json:"pool_size"`
+	ResponseFormat       string                   `json:"response_format"`
+	ResponseTemplate     string                   `json:"response_tmpl"`
+	ResponseTemplateFile string                   `json:"response_tmpl_file"`
+	CallbackURL          string                   `json:"callback_url"`
+	CallbackURLs         []string                 `json:"callback_urls"`
 }
 
 type TunnelStatus struct {
-	ID           string                   `json:"id"`
-	Name         string                   `json:"name,omitempty"`
-	Status       string                   `json:"status"`
-	Type         constants.ConnectionType `json:"type"`
-	Host         string                   `json:"host"`
-	Port         int                      `json:"port"`
-	Subdomain    string                   `json:"subdomain,omitempty"`
-	RemotePort   int                      `json:"remote_port,omitempty"`
-	TunnelURL    string                   `json:"tunnel_url,omitempty"`
-	CallbackURLs []string                 `json:"callback_urls,omitempty"`
-	StartedAt    time.Time                `json:"started_at"`
-	UpdatedAt    time.Time                `json:"updated_at"`
-	StoppedAt    *time.Time               `json:"stopped_at,omitempty"`
-	LastError    string                   `json:"last_error,omitempty"`
+	ID             string                   `json:"id"`
+	Name           string                   `json:"name,omitempty"`
+	Status         string                   `json:"status"`
+	Type           constants.ConnectionType `json:"type"`
+	Host           string                   `json:"host"`
+	Port           int                      `json:"port"`
+	Subdomain      string                   `json:"subdomain,omitempty"`
+	RemotePort     int                      `json:"remote_port,omitempty"`
+	TunnelURL      string                   `json:"tunnel_url,omitempty"`
+	ResponseFormat string                   `json:"response_format,omitempty"`
+	CallbackURLs   []string                 `json:"callback_urls,omitempty"`
+	StartedAt      time.Time                `json:"started_at"`
+	UpdatedAt      time.Time                `json:"updated_at"`
+	StoppedAt      *time.Time               `json:"stopped_at,omitempty"`
+	LastError      string                   `json:"last_error,omitempty"`
 }
 
 type TunnelEvent struct {

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
 	sshclient "github.com/amalshaji/portr/internal/client/ssh"
+	"github.com/amalshaji/portr/internal/client/stubresponder"
 	"github.com/amalshaji/portr/internal/client/tui"
 	"github.com/amalshaji/portr/internal/constants"
 	tea "github.com/charmbracelet/bubbletea"
@@ -29,6 +30,7 @@ type Client struct {
 	tuiStart        chan struct{}
 	tuiDone         chan struct{}
 	tuiStopOnce     sync.Once
+	stubResponder   *stubresponder.Responder
 }
 
 func NewClient(config *config.Config, db *db.Db) *Client {
@@ -147,6 +149,12 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 		return fmt.Errorf("please enter a valid service name")
 	}
 
+	var err error
+	clientConfigs, err = c.prepareStubTunnels(clientConfigs)
+	if err != nil {
+		return err
+	}
+
 	poolingSupported := true
 	for _, clientConfig := range clientConfigs {
 		if desiredWorkers(clientConfig, true) > 1 {
@@ -158,11 +166,19 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 	for _, clientConfig := range clientConfigs {
 		tunnelName := clientConfig.Tunnel.Name
 		if tunnelName == "" {
-			tunnelName = fmt.Sprintf("%d", clientConfig.Tunnel.Port)
+			if clientConfig.Tunnel.Type == constants.Stub {
+				tunnelName = clientConfig.Tunnel.Subdomain
+			} else {
+				tunnelName = fmt.Sprintf("%d", clientConfig.Tunnel.Port)
+			}
 		}
 
 		if c.config.DisableTUI {
-			fmt.Printf("🚀 Starting tunnel: %s (%s:%d)\n", tunnelName, clientConfig.Tunnel.Host, clientConfig.Tunnel.Port)
+			if clientConfig.Tunnel.Type == constants.Stub {
+				fmt.Printf("🚀 Starting stub tunnel: %s (%s)\n", tunnelName, clientConfig.GetTunnelAddr())
+			} else {
+				fmt.Printf("🚀 Starting tunnel: %s (%s:%d)\n", tunnelName, clientConfig.Tunnel.Host, clientConfig.Tunnel.Port)
+			}
 		}
 
 		workers := desiredWorkers(clientConfig, poolingSupported)
@@ -190,6 +206,46 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 	return nil
 }
 
+func (c *Client) prepareStubTunnels(clientConfigs []config.ClientConfig) ([]config.ClientConfig, error) {
+	hasStub := false
+	for _, clientConfig := range clientConfigs {
+		if clientConfig.Tunnel.Type == constants.Stub {
+			hasStub = true
+			break
+		}
+	}
+	if !hasStub {
+		return clientConfigs, nil
+	}
+
+	if c.stubResponder == nil {
+		c.stubResponder = stubresponder.New()
+		if err := c.stubResponder.Start(); err != nil {
+			return nil, err
+		}
+	}
+
+	for i := range clientConfigs {
+		if clientConfigs[i].Tunnel.Type != constants.Stub {
+			continue
+		}
+
+		if err := c.stubResponder.Register(stubresponder.Route{
+			Subdomain:        clientConfigs[i].Tunnel.Subdomain,
+			ResponseFormat:   clientConfigs[i].Tunnel.ResponseFormat,
+			ResponseTemplate: clientConfigs[i].Tunnel.ResponseTemplate,
+		}); err != nil {
+			return nil, err
+		}
+
+		clientConfigs[i].Tunnel.Host = "127.0.0.1"
+		clientConfigs[i].Tunnel.Port = c.stubResponder.Port()
+		clientConfigs[i].Tunnel.PoolSize = 1
+	}
+
+	return clientConfigs, nil
+}
+
 func (c *Client) Add(sshc *sshclient.SshClient) {
 	c.sshcs = append(c.sshcs, sshc)
 }
@@ -212,6 +268,11 @@ func (c *Client) Shutdown(ctx context.Context) {
 
 	for _, sshc := range c.sshcs {
 		sshc.Shutdown(ctx)
+	}
+
+	if c.stubResponder != nil {
+		_ = c.stubResponder.Shutdown(ctx)
+		c.stubResponder = nil
 	}
 }
 

--- a/internal/client/client/stub_tunnel_test.go
+++ b/internal/client/client/stub_tunnel_test.go
@@ -1,0 +1,83 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+func TestPrepareStubTunnelsUsesOneLocalResponder(t *testing.T) {
+	c := &Client{
+		config: &clientcfg.Config{
+			DisableTUI: true,
+		},
+	}
+	t.Cleanup(func() {
+		c.Shutdown(t.Context())
+	})
+
+	prepared, err := c.prepareStubTunnels([]clientcfg.ClientConfig{
+		{
+			Tunnel: clientcfg.Tunnel{
+				Type:             constants.Stub,
+				Subdomain:        "json",
+				ResponseFormat:   "application/json",
+				ResponseTemplate: `{"name":"{{name}}"}`,
+			},
+		},
+		{
+			Tunnel: clientcfg.Tunnel{
+				Type:             constants.Stub,
+				Subdomain:        "yaml",
+				ResponseFormat:   "application/yml",
+				ResponseTemplate: "name: {{name}}\n",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare stub tunnels: %v", err)
+	}
+
+	if len(prepared) != 2 {
+		t.Fatalf("expected 2 prepared configs, got %d", len(prepared))
+	}
+	firstPort := prepared[0].Tunnel.Port
+	if firstPort == 0 {
+		t.Fatal("expected first stub tunnel to receive responder port")
+	}
+	for _, cfg := range prepared {
+		if cfg.Tunnel.Type != constants.Stub {
+			t.Fatalf("expected public tunnel type to remain stub, got %s", cfg.Tunnel.Type)
+		}
+		if cfg.Tunnel.Host != "127.0.0.1" {
+			t.Fatalf("expected local responder host, got %q", cfg.Tunnel.Host)
+		}
+		if cfg.Tunnel.Port != firstPort {
+			t.Fatalf("expected shared responder port %d, got %d", firstPort, cfg.Tunnel.Port)
+		}
+	}
+
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/?name=portr", firstPort), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = "yaml.example.test"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request stub responder: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if string(body) != "name: portr\n" {
+		t.Fatalf("unexpected response body: %q", string(body))
+	}
+}

--- a/internal/client/client/version_test.go
+++ b/internal/client/client/version_test.go
@@ -83,4 +83,15 @@ func TestDesiredWorkers(t *testing.T) {
 	if got := desiredWorkers(tcpCfg, true); got != 1 {
 		t.Fatalf("expected tcp tunnels to use a single worker, got %d", got)
 	}
+
+	stubCfg := clientcfg.ClientConfig{
+		Tunnel: clientcfg.Tunnel{
+			Type:     constants.Stub,
+			PoolSize: 4,
+		},
+	}
+
+	if got := desiredWorkers(stubCfg, true); got != 1 {
+		t.Fatalf("expected stub tunnels to use a single worker, got %d", got)
+	}
 }

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -18,13 +19,16 @@ import (
 var UNABLE_TO_OPEN_EDITOR = color.Yellow("Unable to open editor. Please edit the config file manually at " + DefaultConfigPath)
 
 type Tunnel struct {
-	Name       string                   `yaml:"name"`
-	Subdomain  string                   `yaml:"subdomain"`
-	Port       int                      `yaml:"port"`
-	Host       string                   `yaml:"host"`
-	Type       constants.ConnectionType `yaml:"type"`
-	RemotePort int
-	PoolSize   int `yaml:"pool_size"`
+	Name                 string                   `yaml:"name"`
+	Subdomain            string                   `yaml:"subdomain"`
+	Port                 int                      `yaml:"port"`
+	Host                 string                   `yaml:"host"`
+	Type                 constants.ConnectionType `yaml:"type"`
+	ResponseFormat       string                   `yaml:"response_format"`
+	ResponseTemplate     string                   `yaml:"response_tmpl"`
+	ResponseTemplateFile string                   `yaml:"response_tmpl_file"`
+	RemotePort           int
+	PoolSize             int `yaml:"pool_size"`
 }
 
 func (t *Tunnel) SetDefaults() {
@@ -36,19 +40,34 @@ func (t *Tunnel) SetDefaults() {
 		t.Subdomain = utils.GenerateTunnelSubdomain()
 	}
 
-	if t.Host == "" {
+	if t.Host == "" && t.Type != constants.Stub {
 		t.Host = "localhost"
 	}
 
-	if t.PoolSize <= 0 {
+	if t.Type == constants.Stub {
+		t.PoolSize = 1
+	} else if t.PoolSize <= 0 {
 		t.PoolSize = 2
 	}
 }
 
 func (t *Tunnel) Validate() error {
-	if t.Type == constants.Http {
+	if t.Type == constants.Stub && strings.TrimSpace(t.Subdomain) == "" {
+		return fmt.Errorf("subdomain is required for stub tunnels")
+	}
+
+	if t.Type == constants.Http || t.Type == constants.Stub {
 		if err := utils.ValidateSubdomain(t.Subdomain); err != nil {
 			return err
+		}
+	}
+
+	if t.Type == constants.Stub {
+		if strings.TrimSpace(t.ResponseFormat) == "" {
+			return fmt.Errorf("response_format is required for stub tunnels")
+		}
+		if strings.TrimSpace(t.ResponseTemplate) == "" {
+			return fmt.Errorf("response_tmpl or response_tmpl_file is required for stub tunnels")
 		}
 	}
 
@@ -57,6 +76,58 @@ func (t *Tunnel) Validate() error {
 
 func (t *Tunnel) GetLocalAddr() string {
 	return t.Host + ":" + fmt.Sprint(t.Port)
+}
+
+func (t *Tunnel) ValidateStubTemplateSource() error {
+	if t.Type != constants.Stub {
+		return nil
+	}
+
+	hasInline := strings.TrimSpace(t.ResponseTemplate) != ""
+	hasFile := strings.TrimSpace(t.ResponseTemplateFile) != ""
+
+	switch {
+	case hasInline && hasFile:
+		return fmt.Errorf("only one of response_tmpl or response_tmpl_file can be provided for stub tunnels")
+	case !hasInline && !hasFile:
+		return fmt.Errorf("response_tmpl or response_tmpl_file is required for stub tunnels")
+	default:
+		return nil
+	}
+}
+
+func (t *Tunnel) ResolveStubTemplate(baseDir string) error {
+	if t.Type != constants.Stub {
+		return nil
+	}
+
+	if err := t.ValidateStubTemplateSource(); err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(t.ResponseTemplateFile) == "" {
+		return nil
+	}
+
+	templatePath := t.ResponseTemplateFile
+	if !filepath.IsAbs(templatePath) {
+		if baseDir == "" {
+			baseDir = "."
+		}
+		templatePath = filepath.Join(baseDir, templatePath)
+	}
+
+	templateBytes, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("failed to read response_tmpl_file %q: %w", t.ResponseTemplateFile, err)
+	}
+
+	t.ResponseTemplate = string(templateBytes)
+	if strings.TrimSpace(t.ResponseTemplate) == "" {
+		return fmt.Errorf("response_tmpl_file %q is empty", t.ResponseTemplateFile)
+	}
+
+	return nil
 }
 
 type Config struct {
@@ -192,13 +263,17 @@ func (c *ClientConfig) GetHttpTunnelAddr() string {
 	return protocol + "://" + c.Tunnel.Subdomain + "." + c.TunnelUrl
 }
 
+func (c *ClientConfig) GetStubTunnelAddr() string {
+	return c.GetHttpTunnelAddr()
+}
+
 func (c *ClientConfig) GetTcpTunnelAddr() string {
 	split := strings.Split(c.TunnelUrl, ":")
 	return split[0] + ":" + fmt.Sprint(c.Tunnel.RemotePort)
 }
 
 func (c *ClientConfig) GetTunnelAddr() string {
-	if c.Tunnel.Type == constants.Http {
+	if c.Tunnel.Type == constants.Http || c.Tunnel.Type == constants.Stub {
 		return c.GetHttpTunnelAddr()
 	}
 	return c.GetTcpTunnelAddr()
@@ -227,6 +302,13 @@ func Load(configFile string) (Config, error) {
 	}
 
 	config.SetDefaults()
+
+	baseDir := filepath.Dir(configFile)
+	for i := range config.Tunnels {
+		if err := config.Tunnels[i].ResolveStubTemplate(baseDir); err != nil {
+			return Config{}, err
+		}
+	}
 
 	return config, nil
 }

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -3,7 +3,10 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/amalshaji/portr/internal/constants"
 )
 
 func TestSetDefaultsAppliesDashboardPort(t *testing.T) {
@@ -91,5 +94,131 @@ func TestGetDashboardAddress(t *testing.T) {
 	cfg.DisableDashboard = true
 	if got := cfg.GetDashboardAddress(); got != "" {
 		t.Fatalf("expected disabled dashboard address to be empty, got %q", got)
+	}
+}
+
+func TestLoadResolvesStubTemplateFileRelativeToConfig(t *testing.T) {
+	dir := t.TempDir()
+	templatePath := filepath.Join(dir, "response.yml")
+	if err := os.WriteFile(templatePath, []byte("message: {{message}}\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	configPath := filepath.Join(dir, "config.yaml")
+	configContent := `tunnels:
+  - name: yaml
+    type: stub
+    subdomain: yaml
+    response_format: application/yml
+    response_tmpl_file: response.yml
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	if len(cfg.Tunnels) != 1 {
+		t.Fatalf("expected 1 tunnel, got %d", len(cfg.Tunnels))
+	}
+	tunnel := cfg.Tunnels[0]
+	if tunnel.Type != constants.Stub {
+		t.Fatalf("expected stub tunnel, got %s", tunnel.Type)
+	}
+	if tunnel.ResponseTemplate != "message: {{message}}\n" {
+		t.Fatalf("unexpected response template: %q", tunnel.ResponseTemplate)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid stub config, got %v", err)
+	}
+}
+
+func TestLoadRejectsStubTunnelWithoutTemplate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	configContent := `tunnels:
+  - name: yaml
+    type: stub
+    subdomain: yaml
+    response_format: application/yml
+`
+	if err := os.WriteFile(path, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected missing template error")
+	}
+	if !strings.Contains(err.Error(), "response_tmpl or response_tmpl_file is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadRejectsStubTunnelWithBothTemplateSources(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "response.yml"), []byte("message: file\n"), 0o600); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	path := filepath.Join(dir, "config.yaml")
+	configContent := `tunnels:
+  - name: yaml
+    type: stub
+    subdomain: yaml
+    response_format: application/yml
+    response_tmpl: "message: inline"
+    response_tmpl_file: response.yml
+`
+	if err := os.WriteFile(path, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected both template sources error")
+	}
+	if !strings.Contains(err.Error(), "only one of response_tmpl or response_tmpl_file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsStubTunnelWithoutResponseFormat(t *testing.T) {
+	cfg := Config{
+		Tunnels: []Tunnel{{
+			Type:             constants.Stub,
+			Subdomain:        "yaml",
+			ResponseTemplate: "message: {{message}}",
+		}},
+	}
+	cfg.SetDefaults()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected missing response format error")
+	}
+	if !strings.Contains(err.Error(), "response_format is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsStubTunnelWithoutSubdomain(t *testing.T) {
+	cfg := Config{
+		Tunnels: []Tunnel{{
+			Type:             constants.Stub,
+			ResponseFormat:   "application/json",
+			ResponseTemplate: "{}",
+		}},
+	}
+	cfg.SetDefaults()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected missing subdomain error")
+	}
+	if !strings.Contains(err.Error(), "subdomain is required") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -261,8 +261,13 @@ func CreateNewConnectionWithContext(ctx context.Context, cfg config.ClientConfig
 		ConnectionId string `json:"connection_id"`
 	}
 
+	connectionType := cfg.Tunnel.Type
+	if connectionType == constants.Stub {
+		connectionType = constants.Http
+	}
+
 	payload := map[string]any{
-		"connection_type": string(cfg.Tunnel.Type),
+		"connection_type": string(connectionType),
 		"secret_key":      cfg.SecretKey,
 		"subdomain":       nil,
 	}
@@ -270,7 +275,7 @@ func CreateNewConnectionWithContext(ctx context.Context, cfg config.ClientConfig
 		SetError(&reqErr).
 		SetResult(&response)
 
-	if cfg.Tunnel.Type == constants.Http {
+	if cfg.Tunnel.Type == constants.Http || cfg.Tunnel.Type == constants.Stub {
 		payload["subdomain"] = cfg.Tunnel.Subdomain
 	}
 
@@ -294,6 +299,13 @@ func (s *SshClient) createNewConnection(ctx context.Context) (string, error) {
 		return s.config.ConnectionID, nil
 	}
 	return CreateNewConnectionWithContext(ctx, s.config)
+}
+
+func tunnelStatusKey(tunnel config.Tunnel) string {
+	if tunnel.Type == constants.Stub {
+		return "stub:" + tunnel.Subdomain
+	}
+	return fmt.Sprintf("%d", tunnel.Port)
 }
 
 func (s *SshClient) startListenerForClient(ctx context.Context) error {
@@ -366,6 +378,9 @@ func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready c
 	localEndpoint := s.config.Tunnel.GetLocalAddr()
 
 	tunnelType := s.config.Tunnel.Type
+	if tunnelType == constants.Stub {
+		tunnelType = constants.Http
+	}
 
 	var randomPorts []int
 	if tunnelType == constants.Http {
@@ -418,7 +433,7 @@ func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready c
 	}
 
 	if s.tui != nil {
-		s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: 1})
+		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(s.config.Tunnel), Delta: 1})
 	}
 
 	for {
@@ -440,7 +455,7 @@ func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready c
 				log.Error("Failed to accept connection", "error", err)
 			}
 			if s.tui != nil {
-				s.tui.Send(tui.UpdateConnCountMsg{Port: fmt.Sprintf("%d", s.config.Tunnel.Port), Delta: -1})
+				s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(s.config.Tunnel), Delta: -1})
 			}
 			return s.handleAcceptError(listener, err)
 		}
@@ -945,7 +960,11 @@ func (s *SshClient) logHttpRequest(
 
 	tunnelName := s.config.Tunnel.Name
 	if tunnelName == "" {
-		tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
+		if s.config.Tunnel.Type == constants.Stub && s.config.Tunnel.Subdomain != "" {
+			tunnelName = s.config.Tunnel.Subdomain
+		} else {
+			tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
+		}
 	}
 
 	if !s.config.EnableRequestLogging {
@@ -985,8 +1004,9 @@ func (s *SshClient) Shutdown(ctx context.Context) error {
 	err := s.closeTransport()
 	s.mu.RLock()
 	tuiProgram := s.tui
-	port := fmt.Sprintf("%d", s.config.Tunnel.Port)
-	address := s.config.GetTunnelAddr()
+	cfg := s.config
+	port := tunnelStatusKey(cfg.Tunnel)
+	address := cfg.GetTunnelAddr()
 	s.mu.RUnlock()
 
 	if tuiProgram != nil {
@@ -1035,7 +1055,7 @@ func (s *SshClient) StartHealthCheck(ctx context.Context) error {
 
 		if s.tui != nil {
 			s.tui.Send(tui.UpdateHealthMsg{
-				Port:    fmt.Sprintf("%d", s.config.Tunnel.Port),
+				Port:    tunnelStatusKey(s.config.Tunnel),
 				Healthy: false,
 			})
 		} else if !s.config.DisableTerminalLogs {
@@ -1061,21 +1081,23 @@ func (s *SshClient) StartHealthCheck(ctx context.Context) error {
 			s.logDebug(fmt.Sprintf("Failed to reconnect to ssh tunnel (attempt %d)", retryAttempts), reconnectErr)
 		}
 		if retryAttempts > s.config.HealthCheckMaxRetries {
-			tunnelName := s.config.Tunnel.Name
-			if tunnelName == "" {
-				tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
-			}
-			return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", tunnelName, retryAttempts, reconnectErr)
+			return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", tunnelDisplayName(s.config.Tunnel), retryAttempts, reconnectErr)
 		}
 	}
 }
 
 func (s *SshClient) startError(err error) error {
-	tunnelName := s.config.Tunnel.Name
-	if tunnelName == "" {
-		tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
+	return fmt.Errorf("failed to start tunnel '%s': %w", tunnelDisplayName(s.config.Tunnel), err)
+}
+
+func tunnelDisplayName(tunnel config.Tunnel) string {
+	if tunnel.Name != "" {
+		return tunnel.Name
 	}
-	return fmt.Errorf("failed to start tunnel '%s': %w", tunnelName, err)
+	if tunnel.Type == constants.Stub && tunnel.Subdomain != "" {
+		return tunnel.Subdomain
+	}
+	return fmt.Sprintf("%d", tunnel.Port)
 }
 
 func (s *SshClient) Start(ctx context.Context) error {
@@ -1109,7 +1131,7 @@ func (s *SshClient) Start(ctx context.Context) error {
 	case <-readyChan:
 		s.forwardListenerErrors(startupCtx, errChan)
 
-		if s.config.Tunnel.Type == constants.Http {
+		if s.config.Tunnel.Type == constants.Http || s.config.Tunnel.Type == constants.Stub {
 			defer cancelStartup()
 			return s.StartHealthCheck(startupCtx)
 		}
@@ -1197,7 +1219,7 @@ func (s *SshClient) Reconnect() error {
 		// Connection successful, update health status
 		if s.tui != nil {
 			s.tui.Send(tui.UpdateHealthMsg{
-				Port:    fmt.Sprintf("%d", s.config.Tunnel.Port),
+				Port:    tunnelStatusKey(s.config.Tunnel),
 				Healthy: true,
 			})
 		} else if !s.config.DisableTerminalLogs {
@@ -1235,7 +1257,7 @@ func (s *SshClient) HealthCheck() error {
 
 	if s.tui != nil {
 		s.tui.Send(tui.UpdateHealthMsg{
-			Port:    fmt.Sprintf("%d", s.config.Tunnel.Port),
+			Port:    tunnelStatusKey(s.config.Tunnel),
 			Healthy: true,
 		})
 	}

--- a/internal/client/ssh/ssh_create_conn_test.go
+++ b/internal/client/ssh/ssh_create_conn_test.go
@@ -79,6 +79,77 @@ func TestCreateNewConnection_Error(t *testing.T) {
 	}
 }
 
+func TestCreateNewConnection_StubUsesHTTPPayload(t *testing.T) {
+	newRestyClient = func() *resty.Client {
+		return resty.NewWithClient(&http.Client{
+			Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+
+				if payload["connection_type"] != "http" {
+					t.Fatalf("expected stub tunnel to register as http, got %v", payload["connection_type"])
+				}
+				if payload["subdomain"] != "yaml" {
+					t.Fatalf("expected yaml subdomain, got %v", payload["subdomain"])
+				}
+				if _, ok := payload["response_format"]; ok {
+					t.Fatalf("did not expect response_format in server payload")
+				}
+				if _, ok := payload["response_template"]; ok {
+					t.Fatalf("did not expect response_template in server payload")
+				}
+
+				body, _ := json.Marshal(map[string]string{"connection_id": "stub123"})
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(string(body))),
+				}, nil
+			}),
+		})
+	}
+	defer func() { newRestyClient = resty.New }()
+
+	cfg := clientcfg.ClientConfig{
+		ServerUrl:    "localhost:8001",
+		SecretKey:    "sk",
+		UseLocalHost: true,
+		Tunnel: clientcfg.Tunnel{
+			Type:             constants.Stub,
+			Subdomain:        "yaml",
+			ResponseFormat:   "application/yml",
+			ResponseTemplate: "message: {{message}}",
+		},
+	}
+
+	id, err := CreateNewConnection(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if id != "stub123" {
+		t.Fatalf("expected stub connection id, got %q", id)
+	}
+}
+
+func TestStubStartErrorUsesSubdomain(t *testing.T) {
+	client := New(clientcfg.ClientConfig{
+		Tunnel: clientcfg.Tunnel{
+			Type:      constants.Stub,
+			Subdomain: "portr-stub",
+		},
+	}, nil, nil, nil)
+
+	err := client.startError(errors.New("boom"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to start tunnel 'portr-stub'") {
+		t.Fatalf("expected stub subdomain in error, got %v", err)
+	}
+}
+
 func TestCreateNewConnectionWithContext_Canceled(t *testing.T) {
 	newRestyClient = func() *resty.Client {
 		return resty.NewWithClient(&http.Client{

--- a/internal/client/stubresponder/responder.go
+++ b/internal/client/stubresponder/responder.go
@@ -1,0 +1,357 @@
+package stubresponder
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	placeholderPattern           = regexp.MustCompile(`\{\{\s*([^{}|\s]+)\s*(?:\|\s*(int|bool|float)\s*)?\}\}`)
+	quotedCastPlaceholderPattern = regexp.MustCompile(`"\{\{\s*([^{}|\s]+)\s*\|\s*(int|bool|float)\s*\}\}"`)
+)
+
+type Route struct {
+	Subdomain        string
+	ResponseFormat   string
+	ResponseTemplate string
+}
+
+type Responder struct {
+	server   *http.Server
+	listener net.Listener
+	mu       sync.RWMutex
+	routes   map[string]Route
+}
+
+func New() *Responder {
+	responder := &Responder{
+		routes: make(map[string]Route),
+	}
+	responder.server = &http.Server{
+		Handler:           responder,
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+	return responder
+}
+
+func (r *Responder) Start() error {
+	if r.listener != nil {
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("start stub responder: %w", err)
+	}
+	r.listener = listener
+
+	go func() {
+		if err := r.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			// The tunnel worker health checks surface unreachable local endpoints;
+			// there is no caller to return this asynchronous server error to.
+		}
+	}()
+
+	return nil
+}
+
+func (r *Responder) Addr() string {
+	if r.listener == nil {
+		return ""
+	}
+	return r.listener.Addr().String()
+}
+
+func (r *Responder) Port() int {
+	if r.listener == nil {
+		return 0
+	}
+	if addr, ok := r.listener.Addr().(*net.TCPAddr); ok {
+		return addr.Port
+	}
+	return 0
+}
+
+func (r *Responder) Register(route Route) error {
+	subdomain := strings.ToLower(strings.TrimSpace(route.Subdomain))
+	if subdomain == "" {
+		return fmt.Errorf("subdomain is required")
+	}
+	if strings.TrimSpace(route.ResponseFormat) == "" {
+		return fmt.Errorf("response format is required")
+	}
+	if strings.TrimSpace(route.ResponseTemplate) == "" {
+		return fmt.Errorf("response template is required")
+	}
+
+	route.Subdomain = subdomain
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.routes[subdomain]; exists {
+		return fmt.Errorf("stub route for subdomain %q already exists", subdomain)
+	}
+	r.routes[subdomain] = route
+	return nil
+}
+
+func (r *Responder) Unregister(subdomain string) {
+	subdomain = strings.ToLower(strings.TrimSpace(subdomain))
+	if subdomain == "" {
+		return
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.routes, subdomain)
+}
+
+func (r *Responder) Shutdown(ctx context.Context) error {
+	if r.server == nil {
+		return nil
+	}
+	return r.server.Shutdown(ctx)
+}
+
+func (r *Responder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("X-Portr-Ping-Request") == "true" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	route, ok := r.routeForHost(req.Host)
+	if !ok {
+		http.NotFound(w, req)
+		return
+	}
+
+	bodyValues, err := requestBodyValues(req)
+	if err != nil {
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	rendered := renderTemplate(route.ResponseTemplate, req.URL.Query(), bodyValues, isJSONResponse(route.ResponseFormat))
+	w.Header().Set("Content-Type", route.ResponseFormat)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(rendered))
+}
+
+func (r *Responder) routeForHost(host string) (Route, bool) {
+	hostname := strings.ToLower(strings.TrimSpace(stripPort(host)))
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if route, ok := r.routes[hostname]; ok {
+		return route, true
+	}
+	for subdomain, route := range r.routes {
+		if strings.HasPrefix(hostname, subdomain+".") {
+			return route, true
+		}
+	}
+	if len(r.routes) == 1 {
+		for _, route := range r.routes {
+			return route, true
+		}
+	}
+	return Route{}, false
+}
+
+func stripPort(host string) string {
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		return hostname
+	}
+	if strings.Count(host, ":") == 1 {
+		if idx := strings.LastIndex(host, ":"); idx > -1 {
+			return host[:idx]
+		}
+	}
+	return host
+}
+
+func requestBodyValues(req *http.Request) (map[string]string, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	if req.ContentLength == 0 && len(req.TransferEncoding) == 0 {
+		return nil, nil
+	}
+
+	contentType := req.Header.Get("Content-Type")
+	if contentType == "" {
+		return nil, nil
+	}
+
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return nil, fmt.Errorf("parse content type: %w", err)
+	}
+
+	switch mediaType {
+	case "application/json":
+		return jsonBodyValues(req.Body)
+	case "application/x-www-form-urlencoded":
+		if err := req.ParseForm(); err != nil {
+			return nil, err
+		}
+		return formValues(req.PostForm), nil
+	case "multipart/form-data":
+		if err := req.ParseMultipartForm(32 << 20); err != nil {
+			return nil, err
+		}
+		return formValues(req.PostForm), nil
+	default:
+		return nil, nil
+	}
+}
+
+func formValues(form url.Values) map[string]string {
+	values := make(map[string]string)
+	for key, vals := range form {
+		if len(vals) > 0 {
+			values[key] = vals[0]
+		}
+	}
+	return values
+}
+
+func jsonBodyValues(body io.Reader) (map[string]string, error) {
+	var raw map[string]any
+	decoder := json.NewDecoder(body)
+	decoder.UseNumber()
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, err
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return nil, fmt.Errorf("json body must contain one object")
+	}
+
+	values := make(map[string]string, len(raw))
+	for key, value := range raw {
+		values[key] = stringify(value)
+	}
+	return values, nil
+}
+
+func stringify(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case json.Number:
+		return v.String()
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	default:
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprint(v)
+		}
+		return string(encoded)
+	}
+}
+
+func renderTemplate(template string, query url.Values, body map[string]string, jsonResponse bool) string {
+	rendered := quotedCastPlaceholderPattern.ReplaceAllStringFunc(template, func(match string) string {
+		parts := quotedCastPlaceholderPattern.FindStringSubmatch(match)
+		if len(parts) != 3 {
+			return `""`
+		}
+
+		value := requestValue(parts[1], query, body)
+		if casted, ok := castValue(value, parts[2]); ok {
+			return casted
+		}
+
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return strconv.Quote(value)
+		}
+		return string(encoded)
+	})
+
+	return placeholderPattern.ReplaceAllStringFunc(rendered, func(match string) string {
+		parts := placeholderPattern.FindStringSubmatch(match)
+		if len(parts) != 3 {
+			return ""
+		}
+
+		value := requestValue(parts[1], query, body)
+		if parts[2] != "" {
+			if casted, ok := castValue(value, parts[2]); ok {
+				return casted
+			}
+			if jsonResponse {
+				encoded, err := json.Marshal(value)
+				if err != nil {
+					return strconv.Quote(value)
+				}
+				return string(encoded)
+			}
+		}
+		return value
+	})
+}
+
+func isJSONResponse(responseFormat string) bool {
+	mediaType, _, err := mime.ParseMediaType(responseFormat)
+	if err != nil {
+		mediaType = responseFormat
+	}
+	mediaType = strings.ToLower(strings.TrimSpace(mediaType))
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func requestValue(key string, query url.Values, body map[string]string) string {
+	if values, ok := query[key]; ok && len(values) > 0 {
+		return values[0]
+	}
+	if body != nil {
+		if value, ok := body[key]; ok {
+			return value
+		}
+	}
+	return ""
+}
+
+func castValue(value string, format string) (string, bool) {
+	value = strings.TrimSpace(value)
+	switch strings.ToLower(format) {
+	case "int":
+		parsed, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return "", false
+		}
+		return strconv.FormatInt(parsed, 10), true
+	case "bool":
+		parsed, err := strconv.ParseBool(value)
+		if err != nil {
+			return "", false
+		}
+		return strconv.FormatBool(parsed), true
+	case "float":
+		parsed, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return "", false
+		}
+		return strconv.FormatFloat(parsed, 'g', -1, 64), true
+	default:
+		return "", false
+	}
+}

--- a/internal/client/stubresponder/responder.go
+++ b/internal/client/stubresponder/responder.go
@@ -18,6 +18,7 @@ import (
 
 var (
 	placeholderPattern           = regexp.MustCompile(`\{\{\s*([^{}|\s]+)\s*(?:\|\s*(int|bool|float)\s*)?\}\}`)
+	quotedPlaceholderPattern     = regexp.MustCompile(`"\{\{\s*([^{}|\s]+)\s*\}\}"`)
 	quotedCastPlaceholderPattern = regexp.MustCompile(`"\{\{\s*([^{}|\s]+)\s*\|\s*(int|bool|float)\s*\}\}"`)
 )
 
@@ -286,6 +287,22 @@ func renderTemplate(template string, query url.Values, body map[string]string, j
 		return string(encoded)
 	})
 
+	if jsonResponse {
+		rendered = quotedPlaceholderPattern.ReplaceAllStringFunc(rendered, func(match string) string {
+			parts := quotedPlaceholderPattern.FindStringSubmatch(match)
+			if len(parts) != 2 {
+				return `""`
+			}
+
+			value := requestValue(parts[1], query, body)
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return strconv.Quote(value)
+			}
+			return string(encoded)
+		})
+	}
+
 	return placeholderPattern.ReplaceAllStringFunc(rendered, func(match string) string {
 		parts := placeholderPattern.FindStringSubmatch(match)
 		if len(parts) != 3 {
@@ -304,6 +321,13 @@ func renderTemplate(template string, query url.Values, body map[string]string, j
 				}
 				return string(encoded)
 			}
+		}
+		if jsonResponse {
+			encoded, err := json.Marshal(value)
+			if err != nil {
+				return strconv.Quote(value)
+			}
+			return string(encoded)
 		}
 		return value
 	})

--- a/internal/client/stubresponder/responder_test.go
+++ b/internal/client/stubresponder/responder_test.go
@@ -1,6 +1,7 @@
 package stubresponder
 
 import (
+	"encoding/json"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -73,6 +74,39 @@ func TestResponderRendersTypedJSONValues(t *testing.T) {
 	}
 	if got := rec.Body.String(); got != `{"status":200,"active":true,"score":12.5,"message":"ok"}` {
 		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderEscapesNormalJSONValues(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"message":"{{message}}","raw":{{raw}}}`,
+	})
+
+	message := `hello "portr" \ ok`
+	raw := `x"y`
+	req := httptest.NewRequest(http.MethodGet, "http://json.example.test/?message="+url.QueryEscape(message)+"&raw="+url.QueryEscape(raw), nil)
+	req.Host = "json.example.test"
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if !json.Valid(rec.Body.Bytes()) {
+		t.Fatalf("expected valid JSON, got %q", rec.Body.String())
+	}
+	var got map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got["message"] != message {
+		t.Fatalf("expected escaped message %q, got %q", message, got["message"])
+	}
+	if got["raw"] != raw {
+		t.Fatalf("expected escaped raw value %q, got %q", raw, got["raw"])
 	}
 }
 

--- a/internal/client/stubresponder/responder_test.go
+++ b/internal/client/stubresponder/responder_test.go
@@ -1,0 +1,302 @@
+package stubresponder
+
+import (
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestResponderRendersQueryValues(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "yaml",
+		ResponseFormat:   "application/yml",
+		ResponseTemplate: "message: {{message}}\nmissing: {{missing}}\n",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://yaml.example.test/?message=hello", nil)
+	req.Host = "yaml.example.test"
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/yml" {
+		t.Fatalf("expected content type application/yml, got %q", got)
+	}
+	if got := rec.Body.String(); got != "message: hello\nmissing: \n" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderRendersJSONBodyValues(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"name":"{{name}}","count":"{{count}}","enabled":"{{enabled}}"}`,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://json.example.test/", strings.NewReader(`{"name":"portr","count":3,"enabled":true}`))
+	req.Host = "json.example.test"
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"name":"portr","count":"3","enabled":"true"}` {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderRendersTypedJSONValues(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"status":"{{status|int}}","active":"{{active|bool}}","score":"{{score|float}}","message":"{{message}}"}`,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://json.example.test/?status=200&active=true&score=12.5&message=ok", nil)
+	req.Host = "json.example.test"
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"status":200,"active":true,"score":12.5,"message":"ok"}` {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderKeepsFailedTypedJSONCastAsString(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"status":"{{status|int}}"}`,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://json.example.test/?status=queued", nil)
+	req.Host = "json.example.test"
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"status":"queued"}` {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderKeepsFailedUnquotedTypedJSONCastAsString(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"status":{{status|int}}}`,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://json.example.test/?status=queued", nil)
+	req.Host = "json.example.test"
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"status":"queued"}` {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderRendersTypedTextValues(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "text",
+		ResponseFormat:   "text/plain",
+		ResponseTemplate: `status={{status|int}} active={{active|bool}} score={{score|float}}`,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://text.example.test/?status=200&active=true&score=12.5", nil)
+	req.Host = "text.example.test"
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `status=200 active=true score=12.5` {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderRendersFormBodyValues(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "form",
+		ResponseFormat:   "text/plain",
+		ResponseTemplate: "name={{name}}",
+	})
+
+	form := url.Values{"name": []string{"from-form"}}
+	req := httptest.NewRequest(http.MethodPost, "http://form.example.test/", strings.NewReader(form.Encode()))
+	req.Host = "form.example.test"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != "name=from-form" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderRendersMultipartFormBodyValues(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "form",
+		ResponseFormat:   "text/plain",
+		ResponseTemplate: "name={{name}}",
+	})
+
+	body := &strings.Builder{}
+	writer := multipart.NewWriter(body)
+	if err := writer.WriteField("name", "from-multipart"); err != nil {
+		t.Fatalf("write field: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "http://form.example.test/", strings.NewReader(body.String()))
+	req.Host = "form.example.test"
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != "name=from-multipart" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderQueryTakesPrecedenceOverBody(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"name":"{{name}}"}`,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://json.example.test/?name=query", strings.NewReader(`{"name":"body"}`))
+	req.Host = "json.example.test"
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if got := rec.Body.String(); got != `{"name":"query"}` {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderRejectsInvalidJSONBody(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{"name":"{{name}}"}`,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://json.example.test/", strings.NewReader(`{"name":`))
+	req.Host = "json.example.test"
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestResponderRejectsInvalidFormBody(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "form",
+		ResponseFormat:   "text/plain",
+		ResponseTemplate: "name={{name}}",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://form.example.test/", strings.NewReader("%zz"))
+	req.Host = "form.example.test"
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", rec.Code)
+	}
+}
+
+func TestResponderRoutesMultipleSubdomainsByHost(t *testing.T) {
+	responder := New()
+	if err := responder.Register(Route{Subdomain: "json", ResponseFormat: "application/json", ResponseTemplate: `{"type":"json"}`}); err != nil {
+		t.Fatalf("register json route: %v", err)
+	}
+	if err := responder.Register(Route{Subdomain: "yaml", ResponseFormat: "application/yml", ResponseTemplate: "type: yaml\n"}); err != nil {
+		t.Fatalf("register yaml route: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://yaml.example.test/", nil)
+	req.Host = "yaml.example.test"
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if got := rec.Body.String(); got != "type: yaml\n" {
+		t.Fatalf("unexpected body: %q", got)
+	}
+}
+
+func TestResponderReturnsOKForHealthCheck(t *testing.T) {
+	responder := testResponder(t, Route{
+		Subdomain:        "json",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: `{}`,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://json.example.test/", nil)
+	req.Header.Set("X-Portr-Ping-Request", "true")
+	rec := httptest.NewRecorder()
+
+	responder.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Fatalf("expected empty health check body, got %q", rec.Body.String())
+	}
+}
+
+func testResponder(t *testing.T, route Route) *Responder {
+	t.Helper()
+
+	responder := New()
+	if err := responder.Register(route); err != nil {
+		t.Fatalf("register route: %v", err)
+	}
+	return responder
+}

--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -106,6 +107,16 @@ type model struct {
 	width                  int
 	dashboardURL           string
 	dashboardDisabledLabel string
+}
+
+func tunnelKey(tunnelConfig *config.Tunnel) string {
+	if tunnelConfig == nil {
+		return ""
+	}
+	if tunnelConfig.Type == constants.Stub {
+		return "stub:" + tunnelConfig.Subdomain
+	}
+	return fmt.Sprintf("%d", tunnelConfig.Port)
 }
 
 func New(debug bool, dashboardURL string, dashboardDisabledLabel string) *tea.Program {
@@ -212,8 +223,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 
 	case AddTunnelMsg:
-		port := fmt.Sprintf("%d", msg.Config.Port)
-		if existing, ok := m.tunnels[port]; ok {
+		key := tunnelKey(msg.Config)
+		if existing, ok := m.tunnels[key]; ok {
 			// Update pool size if provided; do not change active here
 			if msg.ClientConfig != nil {
 				existing.poolSize = max(existing.poolSize, msg.ClientConfig.Tunnel.PoolSize)
@@ -223,7 +234,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if msg.ClientConfig != nil {
 				ps = msg.ClientConfig.Tunnel.PoolSize
 			}
-			m.tunnels[port] = &tunnelStatus{
+			m.tunnels[key] = &tunnelStatus{
 				config:       msg.Config,
 				clientConfig: msg.ClientConfig,
 				healthy:      msg.Healthy,
@@ -232,7 +243,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if m.selected == "" {
-			m.selected = port
+			m.selected = key
 		}
 
 	case UpdateHealthMsg:
@@ -410,14 +421,37 @@ func (m model) View() string {
 			statusText = "🟢 Healthy (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
 		}
 
-		tunnelInfo := fmt.Sprintf("%s (%s:%d → %s) [%s] %s",
-			tunnel.config.Name,
-			tunnel.config.Host,
-			tunnel.config.Port,
-			tunnel.clientConfig.GetTunnelAddr(),
-			tunnel.config.Subdomain,
-			statusText,
-		)
+		tunnelName := tunnel.config.Name
+		if tunnelName == "" {
+			if tunnel.config.Type == constants.Stub {
+				tunnelName = tunnel.config.Subdomain
+			} else {
+				tunnelName = fmt.Sprintf("%d", tunnel.config.Port)
+			}
+		}
+		tunnelAddr := ""
+		if tunnel.clientConfig != nil {
+			tunnelAddr = tunnel.clientConfig.GetTunnelAddr()
+		}
+
+		var tunnelInfo string
+		if tunnel.config.Type == constants.Stub {
+			tunnelInfo = fmt.Sprintf("%s (stub → %s) [%s] %s",
+				tunnelName,
+				tunnelAddr,
+				tunnel.config.Subdomain,
+				statusText,
+			)
+		} else {
+			tunnelInfo = fmt.Sprintf("%s (%s:%d → %s) [%s] %s",
+				tunnelName,
+				tunnel.config.Host,
+				tunnel.config.Port,
+				tunnelAddr,
+				tunnel.config.Subdomain,
+				statusText,
+			)
+		}
 		s += tunnelStyle.MaxWidth(lineWidth).Render(tunnelInfo) + "\n"
 	}
 	s += "\n"

--- a/internal/client/tui/tui_test.go
+++ b/internal/client/tui/tui_test.go
@@ -60,6 +60,34 @@ func TestUpdateConnCountClampsToPoolSize(t *testing.T) {
 	}
 }
 
+func TestViewRendersStubTunnelWithoutLocalPort(t *testing.T) {
+	tunnel := config.Tunnel{
+		Name:      "yaml",
+		Type:      constants.Stub,
+		Subdomain: "yaml",
+		PoolSize:  1,
+	}
+	m := model{
+		tunnels: map[string]*tunnelStatus{
+			"stub:yaml": {
+				config:       &tunnel,
+				clientConfig: testClientConfig(tunnel),
+				active:       1,
+				poolSize:     1,
+			},
+		},
+		width: 200,
+	}
+
+	view := m.View()
+	if strings.Contains(view, "localhost:0") {
+		t.Fatalf("expected stub tunnel view without local port, got %q", view)
+	}
+	if !strings.Contains(view, "yaml (stub → https://yaml.go.portr.dev)") {
+		t.Fatalf("expected stub tunnel address, got %q", view)
+	}
+}
+
 func testTunnel() config.Tunnel {
 	return config.Tunnel{
 		Name:      "audio-stream",

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -17,6 +17,8 @@ func (c *ConnectionType) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		*c = Http
 	case "tcp":
 		*c = Tcp
+	case "stub":
+		*c = Stub
 	default:
 		*c = Http
 	}
@@ -27,6 +29,7 @@ func (c *ConnectionType) UnmarshalYAML(unmarshal func(interface{}) error) error 
 const (
 	Http ConnectionType = "http"
 	Tcp  ConnectionType = "tcp"
+	Stub ConnectionType = "stub"
 )
 
 const ClientUiViteDistDir = "./internal/client/dashboard/ui-v2/dist/static/.vite/manifest.json"


### PR DESCRIPTION
## Summary
- add `portr stub` and `type: stub` config/app-server support for templated response tunnels
- serve stub responses through one shared local responder and the existing HTTP tunnel path, avoiding server-side migrations or new heartbeat APIs
- support query/body placeholder substitution plus `int`, `bool`, and `float` placeholder casts with string fallback
- update TUI/display handling, docs, and JSON/YAML/XML stub examples

## Notes
- Stub tunnels register with the server as normal HTTP connections, so existing deployed servers can serve them.
- Placeholder values resolve from query parameters first, then JSON/form request bodies.
- No additional cast formats were added beyond `int`, `bool`, and `float`; string remains the default.

## Testing
- `go test ./internal/client/stubresponder ./internal/client/client ./internal/client/appserver ./internal/client/config ./internal/client/ssh ./internal/client/tui ./cmd/portr`
- `go test ./...`
- `go build ./...`
- `go build -o portr ./cmd/portr`
- `./portr stub --help`
- live smoke against `go-v1` stub tunnel: health ping returned `200`, normal request returned stub JSON
- `git diff --check`
