### PR TITLE
Add Portr CLI agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ portr logs amal-test --json
 - [HTTP tunnel guide](https://portr.dev/docs/client/http-tunnel)
 - [Getting started guide](https://portr.dev/docs/getting-started)
 
+## Agent Skills
+
+This repo includes a `portr-cli` skill for Claude Code and Codex through [Vercel Labs skills](https://github.com/vercel-labs/skills).
+
+Install it into both agents from GitHub:
+
+```bash
+npx skills add amalshaji/portr --skill portr-cli -a claude-code -a codex -y
+```
+
+To install it globally instead:
+
+```bash
+npx skills add amalshaji/portr --skill portr-cli -a claude-code -a codex -g -y
+```
+
 ## Contributing
 
 Please read through [our contributing guide](.github/contributing.md) and set up your [development environment](https://portr.dev/docs/local-development).

--- a/docs-v2/content/docs/resources/agent-skills.mdx
+++ b/docs-v2/content/docs/resources/agent-skills.mdx
@@ -1,0 +1,32 @@
+---
+title: Agent Skills
+description: Install the Portr CLI skill for Claude Code and Codex
+---
+
+Portr ships a `portr-cli` agent skill for using the Portr CLI with Claude Code or Codex. The skill gives agents the command map, safety notes, config shape, request-log and replay workflows, and app-server API guidance needed to expose services from an AI harness.
+
+## Install
+
+Install the skill into both Claude Code and Codex:
+
+```bash
+npx skills add amalshaji/portr --skill portr-cli -a claude-code -a codex -y
+```
+
+To install it globally instead:
+
+```bash
+npx skills add amalshaji/portr --skill portr-cli -a claude-code -a codex -g -y
+```
+
+You do not need an npm package named `amalshaji/portr`. `npx` runs the `skills` CLI, and `amalshaji/portr` points the CLI at the GitHub repository that contains the skill.
+
+## Local Development
+
+When testing changes before they are pushed, install from the local checkout:
+
+```bash
+npx skills add . --skill portr-cli -a claude-code -a codex -y
+```
+
+The skill source lives in `skills/portr-cli/SKILL.md`, with a compact command reference in `skills/portr-cli/references/commands.md`.

--- a/docs-v2/content/docs/resources/index.mdx
+++ b/docs-v2/content/docs/resources/index.mdx
@@ -15,6 +15,14 @@ Additional resources, guides, and integrations to help you get the most out of P
   </Card>
 </Cards>
 
+## Agent Tooling
+
+<Cards>
+  <Card title="Agent Skills" href="/docs/resources/agent-skills">
+    Install the Portr CLI skill for Claude Code and Codex.
+  </Card>
+</Cards>
+
 ## Community and Support
 
 - **GitHub Repository**: [github.com/amalshaji/portr](https://github.com/amalshaji/portr)

--- a/docs-v2/content/docs/resources/meta.json
+++ b/docs-v2/content/docs/resources/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Resources",
-  "pages": ["index", "route53"]
+  "pages": ["index", "route53", "agent-skills"]
 }

--- a/skills/portr-cli/SKILL.md
+++ b/skills/portr-cli/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: portr-cli
+description: "Use when an AI agent or harness needs to operate the Portr CLI: authenticate a Portr client, create HTTP/WebSocket/TCP/stub tunnels, run config-defined tunnels, inspect request logs, replay captured requests, or control tunnels through the local app-server API. This skill is compatible with Claude Code and Codex through vercel-labs/skills."
+---
+
+# Portr CLI
+
+Use this skill to operate an installed `portr` binary from an AI agent, test harness, or automation script. Portr exposes local services through public HTTP/WebSocket or TCP tunnels, can serve stubbed templated responses, stores local HTTP request logs, can replay stored requests, and can run a local API for programmatic tunnel lifecycle control.
+
+## Agent Rules
+
+- Prefer `portr --config <temp-config.yaml> ...` for automation so user config, auth tokens, and local request logs are not accidentally changed.
+- Treat `portr http`, `portr tcp`, `portr stub`, `portr start`, and `portr app-server` as long-running processes. Keep their process/session IDs so the harness can stop them.
+- Prefer `--json` for `portr logs` and `portr replay` when a harness needs to parse output.
+- Use `portr app-server` for programmatic lifecycle management instead of scraping TUI output.
+- Do not overwrite `~/.portr/config.yaml`, `~/.portr/db.sqlite`, or auth tokens unless the user explicitly asks.
+- Do not create public tunnels for production services or sensitive local ports unless the user explicitly asks.
+- If a command's flags are uncertain, run `portr <command> --help` against the installed binary.
+
+## Command Map
+
+```bash
+portr [--config <path>] [--help] [--version] <command>
+```
+
+- `--config`, `-c`: YAML config path. Defaults to `~/.portr/config.yaml`.
+- `--help`, `-h`: show help.
+- `--version`, `-v`: print version.
+
+Commands:
+
+- `portr help [command]`: show general help or command-specific help.
+- `portr auth set`: configure client auth.
+- `portr config edit`: open the default config in the OS editor.
+- `portr http`: expose a local HTTP/WebSocket port.
+- `portr tcp`: expose a local TCP port.
+- `portr stub`: serve a templated response through a public HTTP tunnel without a local server.
+- `portr start`: start one or more tunnels from config.
+- `portr logs`: read local stored HTTP request logs.
+- `portr replay`: replay a stored HTTP request.
+- `portr app-server`: start a local HTTP API for harness-controlled tunnels.
+
+## Auth And Config
+
+```bash
+portr auth set --token <token> --remote <domain-or-url>
+portr auth set -t <token> -r <domain-or-url>
+portr config edit
+```
+
+- `--token`, `-t`: Portr client secret token from the server/admin UI. Required.
+- `--remote`, `-r`: Portr server domain or URL. Required. Bare domains become HTTPS; `localhost:*` becomes HTTP unless a scheme is already provided.
+- `config edit` only edits the default config path. For harnesses, write a temp config file and pass `--config`.
+
+Minimal automation config:
+
+```yaml
+server_url: example.com
+ssh_url: example.com:2222
+tunnel_url: example.com
+secret_key: your-secret-key
+disable_tui: true
+disable_dashboard: true
+disable_update_check: true
+enable_request_logging: true
+```
+
+Global config keys:
+
+- `server_url`: admin/server URL.
+- `ssh_url`: SSH tunnel server address.
+- `tunnel_url`: public tunnel host suffix.
+- `secret_key`: client auth secret.
+- `use_localhost`: use HTTP rather than HTTPS for server/tunnel URLs.
+- `debug`: enable debug behavior.
+- `use_vite`: use the Vite-backed local UI path when supported by the running binary.
+- `dashboard_port`: local inspector port. Default `7777`.
+- `disable_dashboard`: skip the local inspector dashboard.
+- `enable_request_logging`: store HTTP request logs locally. Default `true`.
+- `connection_log_retention_days`: auto-delete old connection logs; `0` disables cleanup.
+- `health_check_interval`: health check interval in seconds. Default `3`.
+- `health_check_max_retries`: max health check retry count. Default `10`.
+- `disable_tui`: run without the interactive terminal UI.
+- `enable_http_reverse_proxy`: enable the HTTP reverse-proxy path when supported by the running binary.
+- `disable_update_check`: suppress release update checks.
+- `insecure_skip_host_key_verification`: skip SSH host key verification. Default `true`.
+
+## One-Off Tunnels
+
+HTTP/WebSocket:
+
+```bash
+portr http <local-port>
+portr http <local-port> --subdomain <subdomain>
+portr http <local-port> -s <subdomain>
+```
+
+- Exposes `localhost:<local-port>` as a public HTTP/WebSocket tunnel.
+- If `--subdomain` is omitted, Portr generates one.
+- Starts local request capture when request logging is enabled.
+
+TCP:
+
+```bash
+portr tcp <local-port>
+```
+
+- Exposes `localhost:<local-port>` as a public TCP tunnel.
+- Use for databases and raw TCP protocols.
+- TCP traffic is not available through `portr logs`.
+
+Stub:
+
+```bash
+portr stub --subdomain <subdomain> \
+  --response-format application/json \
+  --response-tmpl '{"ok": true}'
+
+portr stub --subdomain <subdomain> \
+  --response-format application/json \
+  --response-tmpl-file ./response.json
+```
+
+- `--subdomain`, `-s`: public stub subdomain. Required.
+- `--response-format`: response `Content-Type`, such as `application/json`, `application/yml`, or `text/plain`. Required.
+- `--response-tmpl`: inline response template.
+- `--response-tmpl-file`: path to response template file.
+- Use exactly one of `--response-tmpl` or `--response-tmpl-file`.
+- Stub templates can read request values using Portr's template placeholders.
+
+## Config-Defined Tunnels
+
+Config tunnel fields:
+
+```yaml
+tunnels:
+  - name: app
+    type: http
+    host: localhost
+    port: 3000
+    subdomain: app-dev
+    pool_size: 2
+  - name: pg
+    type: tcp
+    host: localhost
+    port: 5432
+    subdomain: pg-dev
+  - name: mock
+    type: stub
+    subdomain: mock-dev
+    response_format: application/json
+    response_tmpl_file: ./response.json
+```
+
+- `name`: identifier used by `portr start`.
+- `type`: `http`, `tcp`, or `stub`. Defaults to `http`.
+- `host`: local host. Defaults to `localhost` except stubs.
+- `port`: local port for `http` and `tcp`.
+- `subdomain`: public subdomain. Required for `stub`; generated for one-off HTTP when omitted.
+- `pool_size`: worker count for non-stub tunnels. Defaults to `2`; stubs use `1`.
+- `response_format`, `response_tmpl`, `response_tmpl_file`: stub response settings.
+
+Start configured tunnels:
+
+```bash
+portr start
+portr start app
+portr start app pg mock
+```
+
+- No names starts all configured tunnels.
+- Passing names starts only those tunnel entries.
+
+## Request Logs
+
+```bash
+portr logs <subdomain>
+portr logs <subdomain> <url-substring-filter>
+portr logs <subdomain> --count 100
+portr logs <subdomain> -n 100
+portr logs <subdomain> --since 2026-04-04
+portr logs <subdomain> --since 2026-04-04T10:30:00Z
+portr logs <subdomain> --json
+```
+
+- Reads local HTTP request logs from `~/.portr/db.sqlite`.
+- Logs are only available for traffic captured on the current machine with request logging enabled.
+- Results are newest first.
+- Positional filter is a case-insensitive URL substring.
+- `--count`, `-n`: max records to return. Default `20`.
+- `--since`: RFC3339 timestamp or `YYYY-MM-DD`.
+- `--json`: emit full records. Binary body fields stay base64-encoded; UTF-8 payloads also include text fields.
+- Use log IDs from this output with `portr replay`.
+
+## Request Replay
+
+```bash
+portr replay <request-id>
+portr replay --latest --subdomain <subdomain>
+portr replay --latest --subdomain <subdomain> --filter /api/orders --since 2026-04-04
+portr replay <request-id> --method POST --header 'Content-Type: application/json' --body '{"message":"hello"}'
+cat payload.json | portr replay <request-id> --method POST --header 'Content-Type: application/json' --stdin
+portr replay <request-id> --json
+```
+
+- Replays a stored HTTP request through the original tunnel host.
+- `--latest`: choose the newest matching stored request instead of passing an ID.
+- `--subdomain`: required with `--latest`.
+- `--filter`: case-insensitive URL substring filter for `--latest`.
+- `--since`: RFC3339 timestamp or `YYYY-MM-DD` filter for `--latest`.
+- `--method`: override HTTP method.
+- `--path`: override path and query. Must start with `/`.
+- `--header 'Key: Value'`: add or override a header. Repeatable.
+- `--drop-header <name>`: remove inherited header. Repeatable.
+- `--body <value>`: inline body override.
+- `--body-file <path>`: read body override from file.
+- `--stdin`: read body override from stdin.
+- `--body-encoding`: `utf8` or `base64`.
+- `--json`: emit replay details, effective request, response, and structured errors.
+- Body sources are mutually exclusive: use only one of `--body`, `--body-file`, or `--stdin`.
+- Changing the body does not change the method; set `--method POST`, `PUT`, or `PATCH` when the body must matter.
+
+## App Server For Harnesses
+
+```bash
+PORTR_APP_SERVER_TOKEN=change-me portr app-server
+portr app-server --host 127.0.0.1 --port 7778 --token change-me
+```
+
+- Starts a local HTTP API around Portr tunnel lifecycle management.
+- Default bind address is `127.0.0.1:7778`.
+- `--host`: bind host.
+- `--port`: bind port.
+- `--token`: bearer token required by the API.
+- `PORTR_APP_SERVER_TOKEN`: env var alternative for `--token`.
+- If no token is configured, the local API is unauthenticated. Prefer a token in harnesses.
+
+API endpoints:
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/api/v1/health` | Health check. |
+| `POST` | `/api/v1/tunnels` | Start a managed tunnel. |
+| `GET` | `/api/v1/tunnels` | List managed tunnels. |
+| `GET` | `/api/v1/tunnels/{id}` | Get one tunnel status. |
+| `DELETE` | `/api/v1/tunnels/{id}` | Stop one tunnel. |
+| `POST` | `/api/v1/tunnels/{id}/shutdown` | Stop one tunnel. |
+| `GET` | `/api/v1/events` | List lifecycle events. |
+| `GET` | `/api/v1/events?tunnel_id={id}` | List lifecycle events for one tunnel. |
+
+Create tunnel JSON:
+
+```json
+{
+  "name": "app",
+  "type": "http",
+  "host": "localhost",
+  "port": 3000,
+  "subdomain": "app-dev",
+  "pool_size": 2,
+  "callback_url": "http://127.0.0.1:9000/portr-events",
+  "callback_urls": ["https://automation.example.com/webhooks/portr"]
+}
+```
+
+Stub tunnel JSON:
+
+```json
+{
+  "name": "mock",
+  "type": "stub",
+  "subdomain": "mock-dev",
+  "response_format": "application/json",
+  "response_tmpl": "{\"ok\": true}"
+}
+```
+
+Useful response fields:
+
+- `id`: app-server tunnel ID for status and shutdown.
+- `status`: lifecycle state such as `starting`, `running`, `stopped`, or `error`.
+- `type`, `host`, `port`, `subdomain`, `remote_port`, `tunnel_url`: tunnel addressing.
+- `callback_urls`: configured lifecycle callbacks.
+- `last_error`: error text when startup or shutdown fails.
+
+Harness pattern:
+
+```bash
+APP_SERVER=http://127.0.0.1:7778
+TOKEN=change-me
+
+curl -sS -H "Authorization: Bearer $TOKEN" "$APP_SERVER/api/v1/health"
+
+TUNNEL_ID="$(curl -sS -X POST "$APP_SERVER/api/v1/tunnels" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"app","type":"http","host":"localhost","port":3000,"subdomain":"app-dev"}' \
+  | jq -r '.id')"
+
+curl -sS -H "Authorization: Bearer $TOKEN" "$APP_SERVER/api/v1/tunnels/$TUNNEL_ID"
+curl -sS -X DELETE -H "Authorization: Bearer $TOKEN" "$APP_SERVER/api/v1/tunnels/$TUNNEL_ID"
+```
+
+## Choosing The Right Interface
+
+- Use `portr http`, `portr tcp`, or `portr stub` for quick one-off terminal workflows.
+- Use `portr start` when a harness already has a prepared config file and wants multiple named tunnels.
+- Use `portr app-server` when a harness must create, inspect, and stop tunnels programmatically.
+- Use `portr logs --json` to inspect captured traffic.
+- Use `portr replay --json` to replay captured traffic and parse the result.

--- a/skills/portr-cli/agents/openai.yaml
+++ b/skills/portr-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Portr CLI"
+  short_description: "Use Portr tunnels from an agent harness"
+  default_prompt: "Use $portr-cli to expose a local service, inspect captured traffic, or control Portr tunnels from an agent harness."

--- a/skills/portr-cli/references/commands.md
+++ b/skills/portr-cli/references/commands.md
@@ -1,0 +1,44 @@
+# Portr CLI Command Reference
+
+This file mirrors the CLI surface for quick lookup. The skill body contains the operating workflow and harness guidance.
+
+## Global
+
+- `portr --config <path> <command>`: use a specific YAML config file.
+- `portr --help`: list commands.
+- `portr --version`: print version.
+
+## Commands And Flags
+
+| Command | Purpose | Key flags and args |
+| --- | --- | --- |
+| `portr help [command]` | Show general or command-specific help. | command name as optional positional arg |
+| `portr auth set` | Configure client auth from a Portr server/admin UI token. | `--token`, `-t`; `--remote`, `-r` |
+| `portr config edit` | Open the default config file in the OS editor. | none |
+| `portr http <port>` | Expose a local HTTP/WebSocket port. | `--subdomain`, `-s` |
+| `portr tcp <port>` | Expose a local TCP port. | none |
+| `portr stub` | Serve a templated response through an HTTP tunnel. | `--subdomain`, `-s`; `--response-format`; `--response-tmpl`; `--response-tmpl-file` |
+| `portr start [names...]` | Start config-defined tunnels. | tunnel names as positional args |
+| `portr logs <subdomain> [filter]` | Read stored local HTTP request logs. | `--count`, `-n`; `--since`; `--json` |
+| `portr replay <request-id>` | Replay a stored HTTP request. | `--latest`; `--subdomain`; `--filter`; `--since`; `--method`; `--path`; `--header`; `--drop-header`; `--body`; `--body-file`; `--stdin`; `--body-encoding`; `--json` |
+| `portr app-server` | Run a local HTTP API for tunnel lifecycle control. | `--host`; `--port`; `--token`; `PORTR_APP_SERVER_TOKEN` |
+
+## Config Keys
+
+- Global: `server_url`, `ssh_url`, `tunnel_url`, `secret_key`, `use_localhost`, `debug`, `use_vite`, `dashboard_port`, `disable_dashboard`, `enable_request_logging`, `connection_log_retention_days`, `health_check_interval`, `health_check_max_retries`, `disable_tui`, `enable_http_reverse_proxy`, `disable_update_check`, `insecure_skip_host_key_verification`.
+- Tunnel: `name`, `type`, `host`, `port`, `subdomain`, `pool_size`, `response_format`, `response_tmpl`, `response_tmpl_file`.
+
+## App Server API
+
+| Method | Path |
+| --- | --- |
+| `GET` | `/api/v1/health` |
+| `POST` | `/api/v1/tunnels` |
+| `GET` | `/api/v1/tunnels` |
+| `GET` | `/api/v1/tunnels/{id}` |
+| `DELETE` | `/api/v1/tunnels/{id}` |
+| `POST` | `/api/v1/tunnels/{id}/shutdown` |
+| `GET` | `/api/v1/events` |
+| `GET` | `/api/v1/events?tunnel_id={id}` |
+
+`POST /api/v1/tunnels` accepts `name`, `type`, `host`, `port`, `subdomain`, `pool_size`, `response_format`, `response_tmpl`, `response_tmpl_file`, `callback_url`, and `callback_urls`.


### PR DESCRIPTION
## Summary

- add a repo-local `portr-cli` skill for Claude Code and Codex
- make the skill an operational guide for AI agents/harnesses using the installed Portr CLI
- document the full CLI surface in the skill: auth/config, one-off tunnels, config-defined tunnels, logs, replay, app-server endpoints, config keys, and safe harness patterns
- add docs for installing the skill with `npx skills add amalshaji/portr`

## Testing

- `/Users/amalshaji/.rye/py/cpython@3.12.1/install/bin/python3 /Users/amalshaji/.codex/skills/.system/skill-creator/scripts/quick_validate.py /private/tmp/portr-skills-pr/skills/portr-cli`
- `npx --yes skills add . --list`
- `bun run build` in `docs-v2/`
