### PR TITLE
Preserve config when setting auth token

### DIFF
--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"os"
@@ -378,7 +379,68 @@ func SetConfig(config string) error {
 	return os.WriteFile(DefaultConfigPath, []byte(config), 0644)
 }
 
+func writeConfigNode(configNode *yaml.Node) error {
+	var buf bytes.Buffer
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(configNode); err != nil {
+		_ = encoder.Close()
+		return err
+	}
+	if err := encoder.Close(); err != nil {
+		return err
+	}
+
+	return os.WriteFile(DefaultConfigPath, buf.Bytes(), 0644)
+}
+
+func SetConfigToken(token string) error {
+	configBytes, err := os.ReadFile(DefaultConfigPath)
+	if err != nil {
+		return err
+	}
+
+	if len(bytes.TrimSpace(configBytes)) == 0 {
+		return os.WriteFile(DefaultConfigPath, []byte(fmt.Sprintf("secret_key: %s\n", token)), 0644)
+	}
+
+	var configNode yaml.Node
+	if err := yaml.Unmarshal(configBytes, &configNode); err != nil {
+		return err
+	}
+
+	if configNode.Kind == 0 || len(configNode.Content) == 0 {
+		configNode.Kind = yaml.DocumentNode
+		configNode.Content = []*yaml.Node{{Kind: yaml.MappingNode, Tag: "!!map"}}
+	}
+
+	if configNode.Kind != yaml.DocumentNode || len(configNode.Content) == 0 || configNode.Content[0].Kind != yaml.MappingNode {
+		return fmt.Errorf("config file must contain a YAML mapping")
+	}
+
+	mappingNode := configNode.Content[0]
+	for i := 0; i < len(mappingNode.Content)-1; i += 2 {
+		if mappingNode.Content[i].Value == "secret_key" {
+			mappingNode.Content[i+1] = &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: token,
+			}
+
+			return writeConfigNode(&configNode)
+		}
+	}
+
+	mappingNode.Content = append(mappingNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "secret_key"},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: token},
+	)
+
+	return writeConfigNode(&configNode)
+}
+
 func GetConfig(token string, remote string) error {
+	configFileExists := checkDefaultConfigFileExists()
 	payloadMap := map[string]string{
 		"secret_key": token,
 	}
@@ -404,6 +466,10 @@ func GetConfig(token string, remote string) error {
 
 	if resp.StatusCode() != http.StatusOK {
 		return fmt.Errorf("%s", response.Message)
+	}
+
+	if configFileExists {
+		return SetConfigToken(token)
 	}
 
 	return SetConfig(response.Message)

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -8,6 +11,16 @@ import (
 
 	"github.com/amalshaji/portr/internal/constants"
 )
+
+func useDefaultConfigPath(t *testing.T, path string) {
+	t.Helper()
+
+	previousPath := DefaultConfigPath
+	DefaultConfigPath = path
+	t.Cleanup(func() {
+		DefaultConfigPath = previousPath
+	})
+}
 
 func TestSetDefaultsAppliesDashboardPort(t *testing.T) {
 	cfg := Config{}
@@ -48,6 +61,62 @@ func TestLoadPreservesExplicitRequestLoggingFalse(t *testing.T) {
 	}
 	if *cfg.EnableRequestLogging {
 		t.Fatal("expected explicit request logging false to be preserved")
+	}
+}
+
+func TestGetConfigUpdatesOnlyTokenWhenDefaultConfigExists(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	useDefaultConfigPath(t, configPath)
+
+	existingConfig := `server_url: existing.example.com
+ssh_url: existing.example.com:2222
+secret_key: old-token
+tunnels:
+  - name: api
+    subdomain: api-dev
+    port: 3000
+    type: http
+`
+	if err := os.WriteFile(configPath, []byte(existingConfig), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	requestPath := ""
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath = r.URL.Path
+		if r.URL.Path != "/api/v1/config/download" {
+			http.Error(w, "unexpected path", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"message":"server_url: downloaded.example.com\nssh_url: downloaded.example.com:2222\nsecret_key: new-token\ntunnels:\n  - name: downloaded\n    subdomain: downloaded\n    port: 4321"}`)
+	}))
+	defer server.Close()
+
+	if err := GetConfig("new-token", server.URL); err != nil {
+		t.Fatalf("get config: %v", err)
+	}
+	if requestPath != "/api/v1/config/download" {
+		t.Fatalf("expected config download endpoint to be called, got %q", requestPath)
+	}
+
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	configContent := string(configBytes)
+
+	if !strings.Contains(configContent, "secret_key: new-token") {
+		t.Fatalf("expected token to be updated, got: %s", configContent)
+	}
+	if !strings.Contains(configContent, "server_url: existing.example.com") {
+		t.Fatalf("expected existing server_url to be preserved, got: %s", configContent)
+	}
+	if !strings.Contains(configContent, "name: api") || !strings.Contains(configContent, "subdomain: api-dev") {
+		t.Fatalf("expected existing tunnel to be preserved, got: %s", configContent)
+	}
+	if strings.Contains(configContent, "downloaded.example.com") || strings.Contains(configContent, "name: downloaded") {
+		t.Fatalf("expected downloaded template not to overwrite existing config, got: %s", configContent)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve an existing `~/.portr/config.yaml` when `portr auth set` runs
- validate the token through the server as before, then update or insert only `secret_key`
- add regression coverage that proves downloaded defaults do not replace existing tunnels/settings

## Testing

- `go test ./internal/client/config`
- `go test ./...`
- `git diff --check`
