### PR TITLE
fix: don't evict tunnel backend on websocket EOF

### DIFF
--- a/internal/server/proxy/proxy.go
+++ b/internal/server/proxy/proxy.go
@@ -9,11 +9,9 @@ import (
 	"slices"
 
 	"io"
-	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 
@@ -171,14 +169,20 @@ func connectionLostError(w http.ResponseWriter) {
 
 func (p *Proxy) reverseProxy(target *url.URL, subdomain, backend string) *httputil.ReverseProxy {
 	rp := httputil.NewSingleHostReverseProxy(target)
-	// Capture backend so we can remove only the failing one
+	// This handler is used for upgraded (WebSocket) connections, where the
+	// ErrorHandler also fires on normal stream termination (EOF) once the
+	// connection has been established. The only signal that the backend is
+	// actually bad is that it never produced a response at all (unreachable);
+	// anything after a response is a normal/abrupt stream end, not a failure.
+	// Evicting on a normal close would wipe the route while the tunnel is still
+	// healthy and break every subsequent connection on this subdomain.
+	responded := false
+	rp.ModifyResponse = func(*http.Response) error {
+		responded = true
+		return nil
+	}
 	rp.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
-		// This handler is used for upgraded (WebSocket) connections. An EOF or
-		// closed-connection error is normal stream termination, not a backend
-		// failure. Evicting the backend here would wipe the route while the tunnel
-		// is still healthy, breaking every subsequent connection on this subdomain.
-		// Only evict on a real dial/transport failure.
-		if isNormalClose(err) {
+		if responded {
 			return
 		}
 		log.Error("Error from proxy", "error", err, "subdomain", subdomain, "backend", backend)
@@ -186,20 +190,6 @@ func (p *Proxy) reverseProxy(target *url.URL, subdomain, backend string) *httput
 		connectionLostError(res)
 	}
 	return rp
-}
-
-// isNormalClose reports whether err represents an expected end of a streamed
-// (WebSocket) connection rather than a backend that should be evicted.
-func isNormalClose(err error) bool {
-	if err == nil {
-		return true
-	}
-	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
-		return true
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "use of closed network connection") ||
-		strings.Contains(msg, "broken pipe")
 }
 
 func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/proxy/proxy.go
+++ b/internal/server/proxy/proxy.go
@@ -9,9 +9,11 @@ import (
 	"slices"
 
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -171,11 +173,33 @@ func (p *Proxy) reverseProxy(target *url.URL, subdomain, backend string) *httput
 	rp := httputil.NewSingleHostReverseProxy(target)
 	// Capture backend so we can remove only the failing one
 	rp.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
+		// This handler is used for upgraded (WebSocket) connections. An EOF or
+		// closed-connection error is normal stream termination, not a backend
+		// failure. Evicting the backend here would wipe the route while the tunnel
+		// is still healthy, breaking every subsequent connection on this subdomain.
+		// Only evict on a real dial/transport failure.
+		if isNormalClose(err) {
+			return
+		}
 		log.Error("Error from proxy", "error", err, "subdomain", subdomain, "backend", backend)
 		_ = p.RemoveBackend(subdomain, backend)
 		connectionLostError(res)
 	}
 	return rp
+}
+
+// isNormalClose reports whether err represents an expected end of a streamed
+// (WebSocket) connection rather than a backend that should be evicted.
+func isNormalClose(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "broken pipe")
 }
 
 func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/proxy/proxy.go
+++ b/internal/server/proxy/proxy.go
@@ -169,24 +169,14 @@ func connectionLostError(w http.ResponseWriter) {
 
 func (p *Proxy) reverseProxy(target *url.URL, subdomain, backend string) *httputil.ReverseProxy {
 	rp := httputil.NewSingleHostReverseProxy(target)
-	// This handler is used for upgraded (WebSocket) connections, where the
-	// ErrorHandler also fires on normal stream termination (EOF) once the
-	// connection has been established. The only signal that the backend is
-	// actually bad is that it never produced a response at all (unreachable);
-	// anything after a response is a normal/abrupt stream end, not a failure.
-	// Evicting on a normal close would wipe the route while the tunnel is still
-	// healthy and break every subsequent connection on this subdomain.
-	responded := false
-	rp.ModifyResponse = func(*http.Response) error {
-		responded = true
-		return nil
-	}
+	// Used for upgraded (WebSocket) connections. Backend lifecycle is owned
+	// solely by the SSH layer (added on tunnel connect, removed on tunnel
+	// disconnect), so the proxy never mutates the route pool here. An EOF after
+	// a successful upgrade is a normal stream close, not a failure.
 	rp.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
-		if responded {
-			return
+		if !errors.Is(err, io.EOF) {
+			log.Error("Error from proxy", "error", err, "subdomain", subdomain, "backend", backend)
 		}
-		log.Error("Error from proxy", "error", err, "subdomain", subdomain, "backend", backend)
-		_ = p.RemoveBackend(subdomain, backend)
 		connectionLostError(res)
 	}
 	return rp
@@ -240,8 +230,10 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 		failed := false
 		rp := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: "http", Host: target})
 		rp.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
+			// Don't evict — the backend may just be transiently failing while the
+			// tunnel is healthy. Round-robin to the next backend for this request;
+			// the SSH layer removes backends when the tunnel actually drops.
 			log.Error("Error from proxy (will retry)", "error", err, "subdomain", subdomain, "backend", target)
-			_ = p.RemoveBackend(subdomain, target)
 			failed = true
 			// Do not write to client here; allow retry loop to proceed
 		}

--- a/internal/server/proxy/proxy_pool_test.go
+++ b/internal/server/proxy/proxy_pool_test.go
@@ -1,6 +1,11 @@
 package proxy
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
 	"testing"
 
 	serverConfig "github.com/amalshaji/portr/internal/server/config"
@@ -58,5 +63,32 @@ func TestProxy_RemoveBackend(t *testing.T) {
 	}
 	if _, err := p.GetNextBackend(sub); err == nil {
 		t.Fatalf("expected error after removing all backends")
+	}
+}
+
+func TestIsNormalClose(t *testing.T) {
+	normal := []error{
+		nil,
+		io.EOF,
+		fmt.Errorf("read: %w", io.EOF),
+		net.ErrClosed,
+		context.Canceled,
+		errors.New("write tcp 1.2.3.4:80: use of closed network connection"),
+		errors.New("write tcp 1.2.3.4:80: broken pipe"),
+	}
+	for _, err := range normal {
+		if !isNormalClose(err) {
+			t.Fatalf("expected normal close for %v", err)
+		}
+	}
+
+	evict := []error{
+		errors.New("dial tcp 0.0.0.0:21002: connect: connection refused"),
+		errors.New("connection reset by peer"),
+	}
+	for _, err := range evict {
+		if isNormalClose(err) {
+			t.Fatalf("expected eviction for %v", err)
+		}
 	}
 }

--- a/internal/server/proxy/proxy_pool_test.go
+++ b/internal/server/proxy/proxy_pool_test.go
@@ -119,8 +119,10 @@ func TestReverseProxy_KeepsBackendOnNormalClose(t *testing.T) {
 	}
 }
 
-// An unreachable backend never responds — it should be evicted from the pool.
-func TestReverseProxy_EvictsUnreachableBackend(t *testing.T) {
+// The proxy never mutates the route pool — backend lifecycle is owned by the
+// SSH layer. Even an unreachable backend stays put so it can auto-recover once
+// its local app comes back (the tunnel itself is still up).
+func TestReverseProxy_DoesNotEvictUnreachableBackend(t *testing.T) {
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
@@ -134,7 +136,7 @@ func TestReverseProxy_EvictsUnreachableBackend(t *testing.T) {
 
 	sendUpgrade(t, strings.TrimPrefix(srv.URL, "http://"), "sub.example.com")
 
-	if _, err := p.GetNextBackend("sub"); err == nil {
-		t.Fatalf("expected unreachable backend to be evicted")
+	if _, err := p.GetNextBackend("sub"); err != nil {
+		t.Fatalf("proxy evicted backend it does not own: %v", err)
 	}
 }

--- a/internal/server/proxy/proxy_pool_test.go
+++ b/internal/server/proxy/proxy_pool_test.go
@@ -1,11 +1,11 @@
 package proxy
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"io"
+	"bufio"
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	serverConfig "github.com/amalshaji/portr/internal/server/config"
@@ -66,29 +66,75 @@ func TestProxy_RemoveBackend(t *testing.T) {
 	}
 }
 
-func TestIsNormalClose(t *testing.T) {
-	normal := []error{
-		nil,
-		io.EOF,
-		fmt.Errorf("read: %w", io.EOF),
-		net.ErrClosed,
-		context.Canceled,
-		errors.New("write tcp 1.2.3.4:80: use of closed network connection"),
-		errors.New("write tcp 1.2.3.4:80: broken pipe"),
+// sendUpgrade sends a minimal WebSocket-style upgrade request to addr for the
+// given host and returns once the response status line has been read.
+func sendUpgrade(t *testing.T, addr, host string) {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
 	}
-	for _, err := range normal {
-		if !isNormalClose(err) {
-			t.Fatalf("expected normal close for %v", err)
-		}
+	defer conn.Close()
+	req := "GET / HTTP/1.1\r\nHost: " + host + "\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write upgrade: %v", err)
 	}
+	// Read whatever the proxy sends back (101, error page, or EOF) and discard.
+	_, _ = bufio.NewReader(conn).ReadString('\n')
+}
 
-	evict := []error{
-		errors.New("dial tcp 0.0.0.0:21002: connect: connection refused"),
-		errors.New("connection reset by peer"),
+func newTestProxy(sub, backend string) *Proxy {
+	cfg := &serverConfig.Config{Domain: "example.com"}
+	p := New(cfg)
+	_ = p.AddBackend(sub, backend)
+	return p
+}
+
+// A WebSocket that upgrades and then closes (EOF) is a normal termination, not a
+// backend failure — the backend must stay in the pool.
+func TestReverseProxy_KeepsBackendOnNormalClose(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen backend: %v", err)
 	}
-	for _, err := range evict {
-		if isNormalClose(err) {
-			t.Fatalf("expected eviction for %v", err)
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
 		}
+		// Upgrade, then immediately close so the proxied stream ends in EOF.
+		_, _ = conn.Write([]byte("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n"))
+		conn.Close()
+	}()
+
+	p := newTestProxy("sub", ln.Addr().String())
+	srv := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer srv.Close()
+
+	sendUpgrade(t, strings.TrimPrefix(srv.URL, "http://"), "sub.example.com")
+
+	if _, err := p.GetNextBackend("sub"); err != nil {
+		t.Fatalf("backend evicted on normal close: %v", err)
+	}
+}
+
+// An unreachable backend never responds — it should be evicted from the pool.
+func TestReverseProxy_EvictsUnreachableBackend(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	dead := ln.Addr().String()
+	ln.Close() // free the port so dials are refused
+
+	p := newTestProxy("sub", dead)
+	srv := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer srv.Close()
+
+	sendUpgrade(t, strings.TrimPrefix(srv.URL, "http://"), "sub.example.com")
+
+	if _, err := p.GetNextBackend("sub"); err == nil {
+		t.Fatalf("expected unreachable backend to be evicted")
 	}
 }


### PR DESCRIPTION
## Problem

Portr v1 server repeatedly fails on WebSocket endpoints (e.g. `audio-stream.go-v1.portr.dev`). Server logs:

```
ERRO Error from proxy error=EOF subdomain=audio-stream backend=0.0.0.0:21002
ERRO Failed to remove backend ... subdomain=audio-stream backend=0.0.0.0:21002 error="route not found"
```

## Root cause

`internal/server/proxy/proxy.go` evicted a backend from the route pool on **any** proxy error. For an upgraded (WebSocket) connection, an `EOF` is normal stream termination — not a backend failure:

1. Tunnel connects → SSH layer `AddBackend(audio-stream, 0.0.0.0:21002)`.
2. Client opens WebSocket → streams direct.
3. WebSocket closes → `ErrorHandler` fires with `EOF` → proxy calls `RemoveBackend(...)` → last backend → subdomain entry deleted.
4. SSH `ctx.Done` cleanup (`sshd.go:155`) removes the same backend → already gone → `route not found`.
5. Next WebSocket → no backend → 404 unregistered-subdomain.

A healthy tunnel was killed on the first WebSocket disconnect.

Deeper issue: the route pool had **two owners** — the SSH layer (add on tunnel up, remove on tunnel down) and the proxy (evict on transport error). The proxy also evicted *permanently* on a single transient failure, so a route stayed broken even after the backend's local app recovered.

## Fix

Make the **SSH layer the sole owner** of backend lifecycle; the proxy is now a read-only consumer of the route pool:

- **Upgrade (WebSocket) path** — no eviction. An `EOF` after upgrade is a normal close.
- **HTTP retry path** — on a transport failure, round-robin to the next backend for this request instead of permanently removing the failing one.

Backends are added/removed exclusively by the SSH layer based on the tunnel lifecycle.

## Tests

`internal/server/proxy/proxy_pool_test.go` — two integration tests through a real proxy + backend:
- WebSocket that upgrades then closes (EOF) keeps the backend.
- An unreachable backend is **not** evicted by the proxy (SSH owns removal; the route can auto-recover).

`go test ./internal/server/...` passes.

Closes #258.