### PR TITLE
fix: make GenerateRandomNumbers return unique values

### DIFF
--- a/internal/utils/random.go
+++ b/internal/utils/random.go
@@ -5,13 +5,25 @@ import (
 	"time"
 )
 
+// GenerateRandomNumbers returns up to limit distinct numbers in [start, end).
+// Values are unique so callers (e.g. port allocation) never get a duplicate.
 func GenerateRandomNumbers(start, end, limit int) []int {
-	rand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	randomNumbers := make([]int, limit)
-	for i := range limit {
-		randomNumbers[i] = rand.Intn(end-start) + start
+	span := end - start
+	if limit > span {
+		limit = span
+	}
+
+	seen := make(map[int]bool, limit)
+	randomNumbers := make([]int, 0, limit)
+	for len(randomNumbers) < limit {
+		n := r.Intn(span) + start
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		randomNumbers = append(randomNumbers, n)
 	}
 	return randomNumbers
-
 }


### PR DESCRIPTION
## Problem

`TestGenerateRandomHttpPorts` failed on `main` CI: `Duplicate port found: 25133`.

`GenerateRandomNumbers(start, end, limit)` picked `limit` independent random numbers with **no dedup**, so it could return duplicates. Over a 10k range with 10 picks that's ~0.45% collision per run (birthday paradox) — a flaky test, and a latent bug: port allocation expects distinct ports.

## Fix

Collect distinct values until `limit` is reached. Cap `limit` to the range size so the loop is always satisfiable.

## Test

`go test ./internal/utils/ -run TestGenerateRandom -count=2000` passes (previously flaked ~1 in 220).