### PR TITLE
Improve tunnel reliability and performance

### DIFF
--- a/.github/workflows/portr-server.yml
+++ b/.github/workflows/portr-server.yml
@@ -57,5 +57,8 @@ jobs:
       - name: Build server
         run: go build -v ./...
 
+      - name: Test real tunnel data flow
+        run: go test -race -v ./tests -run '^TestTunnelDataFlow' -count=1 -timeout=2m
+
       - name: Test server
         run: go test -v ./...

--- a/cmd/portrd/main.go
+++ b/cmd/portrd/main.go
@@ -194,11 +194,12 @@ func startTunnel(configFilePath string) {
 	_db := db.New(&config.Database)
 	_db.Connect()
 
-	service := service.New(_db)
+	tunnelService := service.New(_db)
+	reconcileTunnelConnections(tunnelService)
 
 	proxyServer := proxy.New(config)
-	sshServer := sshd.New(&config.Ssh, proxyServer, service)
-	cron := cron.New(_db, config, service)
+	sshServer := sshd.New(&config.Ssh, proxyServer, tunnelService)
+	cron := cron.New(config, tunnelService)
 
 	go proxyServer.Start()
 	go sshServer.Start()
@@ -214,9 +215,9 @@ func startTunnel(configFilePath string) {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	cron.Shutdown()
 	proxyServer.Shutdown(shutdownCtx)
 	sshServer.Shutdown(shutdownCtx)
-	cron.Shutdown()
 }
 
 func startAdmin() error {
@@ -265,10 +266,11 @@ func startAll(configFilePath string) error {
 	_db := db.New(&tunnelConfig.Database)
 	_db.Connect()
 
-	service := service.New(_db)
+	tunnelService := service.New(_db)
+	reconcileTunnelConnections(tunnelService)
 	proxyServer := proxy.New(tunnelConfig)
-	sshServer := sshd.New(&tunnelConfig.Ssh, proxyServer, service)
-	cronJob := cron.New(_db, tunnelConfig, service)
+	sshServer := sshd.New(&tunnelConfig.Ssh, proxyServer, tunnelService)
+	cronJob := cron.New(tunnelConfig, tunnelService)
 	adminServer := admin.NewServer(adminCfg, _db.Conn)
 
 	// Use WaitGroup to track all servers
@@ -327,9 +329,9 @@ func startAll(configFilePath string) error {
 	}
 
 	// Shutdown tunnel components
+	cronJob.Shutdown()
 	proxyServer.Shutdown(shutdownCtx)
 	sshServer.Shutdown(shutdownCtx)
-	cronJob.Shutdown()
 
 	// Wait for all goroutines to finish
 	cancel()
@@ -341,4 +343,12 @@ func startAll(configFilePath string) error {
 
 	log.Info("All services shut down successfully")
 	return nil
+}
+
+func reconcileTunnelConnections(tunnelService *service.Service) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := tunnelService.CloseAllActiveConnections(ctx); err != nil {
+		log.Fatal("Failed to reconcile stale tunnel connections", "error", err)
+	}
 }

--- a/docs-v2/app/(home)/page.tsx
+++ b/docs-v2/app/(home)/page.tsx
@@ -6,7 +6,6 @@ import {
   AnimatedSpan,
 } from "@/components/magicui/terminal";
 import { SparklesText } from "@/components/magicui/sparkles-text";
-import { GithubInfo } from "fumadocs-ui/components/github-info";
 import Logo from "@/components/ui/logo";
 
 const title = "Portr - Self-Hosted Tunnel Solution for Teams";
@@ -133,12 +132,26 @@ export default function HomePage() {
                 Read Documentation
               </SparklesText>
             </Link>
-            <GithubInfo
-              owner="amalshaji"
-              repo="portr"
-              token={process.env.GITHUB_TOKEN}
+            <Link
+              href="https://github.com/amalshaji/portr"
+              target="_blank"
+              rel="noopener noreferrer"
               className="w-full md:w-auto px-6 sm:px-8 py-3 sm:py-4 border border-fd-border text-fd-foreground font-semibold rounded-lg hover:bg-fd-accent transition-colors text-base sm:text-lg text-center flex flex-row items-center justify-center gap-2 min-h-[3.5rem]"
-            />
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="18"
+                height="18"
+                aria-hidden="true"
+                className="shrink-0"
+              >
+                <path
+                  fill="currentColor"
+                  d="M12 .7a11.5 11.5 0 0 0-3.64 22.4c.58.1.79-.25.79-.56v-2.24c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.04 1.77 2.72 1.26 3.38.96.1-.75.4-1.26.74-1.55-2.57-.29-5.27-1.28-5.27-5.68 0-1.26.45-2.28 1.19-3.08-.12-.29-.52-1.46.11-3.04 0 0 .97-.31 3.16 1.18a10.9 10.9 0 0 1 5.76 0c2.2-1.49 3.16-1.18 3.16-1.18.63 1.58.23 2.75.11 3.04.74.8 1.19 1.82 1.19 3.08 0 4.41-2.71 5.38-5.29 5.67.42.36.79 1.06.79 2.14v3.18c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z"
+                />
+              </svg>
+              GitHub
+            </Link>
             <Link
               href="https://news.ycombinator.com/item?id=39913197"
               className="w-full md:w-auto px-6 sm:px-8 py-3 sm:py-4 border border-fd-border text-fd-foreground font-semibold rounded-lg hover:bg-fd-accent transition-colors text-base sm:text-lg flex items-center justify-center gap-2"

--- a/docs-v2/app/(home)/page.tsx
+++ b/docs-v2/app/(home)/page.tsx
@@ -6,6 +6,7 @@ import {
   AnimatedSpan,
 } from "@/components/magicui/terminal";
 import { SparklesText } from "@/components/magicui/sparkles-text";
+import { GitHubStarsLink } from "@/components/github-stars-link";
 import Logo from "@/components/ui/logo";
 
 const title = "Portr - Self-Hosted Tunnel Solution for Teams";
@@ -132,26 +133,9 @@ export default function HomePage() {
                 Read Documentation
               </SparklesText>
             </Link>
-            <Link
-              href="https://github.com/amalshaji/portr"
-              target="_blank"
-              rel="noopener noreferrer"
+            <GitHubStarsLink
               className="w-full md:w-auto px-6 sm:px-8 py-3 sm:py-4 border border-fd-border text-fd-foreground font-semibold rounded-lg hover:bg-fd-accent transition-colors text-base sm:text-lg text-center flex flex-row items-center justify-center gap-2 min-h-[3.5rem]"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                width="18"
-                height="18"
-                aria-hidden="true"
-                className="shrink-0"
-              >
-                <path
-                  fill="currentColor"
-                  d="M12 .7a11.5 11.5 0 0 0-3.64 22.4c.58.1.79-.25.79-.56v-2.24c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.04 1.77 2.72 1.26 3.38.96.1-.75.4-1.26.74-1.55-2.57-.29-5.27-1.28-5.27-5.68 0-1.26.45-2.28 1.19-3.08-.12-.29-.52-1.46.11-3.04 0 0 .97-.31 3.16 1.18a10.9 10.9 0 0 1 5.76 0c2.2-1.49 3.16-1.18 3.16-1.18.63 1.58.23 2.75.11 3.04.74.8 1.19 1.82 1.19 3.08 0 4.41-2.71 5.38-5.29 5.67.42.36.79 1.06.79 2.14v3.18c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z"
-                />
-              </svg>
-              GitHub
-            </Link>
+            />
             <Link
               href="https://news.ycombinator.com/item?id=39913197"
               className="w-full md:w-auto px-6 sm:px-8 py-3 sm:py-4 border border-fd-border text-fd-foreground font-semibold rounded-lg hover:bg-fd-accent transition-colors text-base sm:text-lg flex items-center justify-center gap-2"

--- a/docs-v2/app/docs/layout.tsx
+++ b/docs-v2/app/docs/layout.tsx
@@ -1,6 +1,7 @@
 import { DocsLayout, type DocsLayoutProps } from "fumadocs-ui/layouts/notebook";
 import type { ReactNode } from "react";
 import { baseOptions } from "@/app/layout.config";
+import { GitHubStarsLink } from "@/components/github-stars-link";
 import { source } from "@/lib/source";
 
 const docsOptions: DocsLayoutProps = {
@@ -10,6 +11,14 @@ const docsOptions: DocsLayoutProps = {
     defaultOpenLevel: 10,
     collapsible: true,
   },
+  links: [
+    {
+      type: "custom",
+      children: (
+        <GitHubStarsLink className="rounded-md px-2 py-1.5 text-sm text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-foreground lg:-mx-2" />
+      ),
+    },
+  ],
   nav: {
     ...baseOptions.nav,
     transparentMode: "top",

--- a/docs-v2/app/docs/layout.tsx
+++ b/docs-v2/app/docs/layout.tsx
@@ -2,7 +2,6 @@ import { DocsLayout, type DocsLayoutProps } from "fumadocs-ui/layouts/notebook";
 import type { ReactNode } from "react";
 import { baseOptions } from "@/app/layout.config";
 import { source } from "@/lib/source";
-import { GithubInfo } from "fumadocs-ui/components/github-info";
 
 const docsOptions: DocsLayoutProps = {
   ...baseOptions,
@@ -11,19 +10,6 @@ const docsOptions: DocsLayoutProps = {
     defaultOpenLevel: 10,
     collapsible: true,
   },
-  links: [
-    {
-      type: "custom",
-      children: (
-        <GithubInfo
-          owner="amalshaji"
-          repo="portr"
-          token={process.env.GITHUB_TOKEN}
-          className="lg:-mx-2"
-        />
-      ),
-    },
-  ],
   nav: {
     ...baseOptions.nav,
     transparentMode: "top",

--- a/docs-v2/bun.lock
+++ b/docs-v2/bun.lock
@@ -17,12 +17,14 @@
         "tw-animate-css": "^1.3.6",
       },
       "devDependencies": {
+        "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/postcss": "^4.1.11",
         "@types/mdx": "^2.0.13",
         "@types/node": "24.1.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "postcss": "^8.5.6",
+        "satori": "^0.26.0",
         "tailwindcss": "^4.1.11",
         "typescript": "^5.8.3",
       },
@@ -241,6 +243,32 @@
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
+    "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
+
+    "@resvg/resvg-js-android-arm-eabi": ["@resvg/resvg-js-android-arm-eabi@2.6.2", "", { "os": "android", "cpu": "arm" }, "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA=="],
+
+    "@resvg/resvg-js-android-arm64": ["@resvg/resvg-js-android-arm64@2.6.2", "", { "os": "android", "cpu": "arm64" }, "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ=="],
+
+    "@resvg/resvg-js-darwin-arm64": ["@resvg/resvg-js-darwin-arm64@2.6.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A=="],
+
+    "@resvg/resvg-js-darwin-x64": ["@resvg/resvg-js-darwin-x64@2.6.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw=="],
+
+    "@resvg/resvg-js-linux-arm-gnueabihf": ["@resvg/resvg-js-linux-arm-gnueabihf@2.6.2", "", { "os": "linux", "cpu": "arm" }, "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw=="],
+
+    "@resvg/resvg-js-linux-arm64-gnu": ["@resvg/resvg-js-linux-arm64-gnu@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg=="],
+
+    "@resvg/resvg-js-linux-arm64-musl": ["@resvg/resvg-js-linux-arm64-musl@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg=="],
+
+    "@resvg/resvg-js-linux-x64-gnu": ["@resvg/resvg-js-linux-x64-gnu@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw=="],
+
+    "@resvg/resvg-js-linux-x64-musl": ["@resvg/resvg-js-linux-x64-musl@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ=="],
+
+    "@resvg/resvg-js-win32-arm64-msvc": ["@resvg/resvg-js-win32-arm64-msvc@2.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ=="],
+
+    "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
+
+    "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
+
     "@shikijs/core": ["@shikijs/core@3.8.1", "", { "dependencies": { "@shikijs/types": "3.8.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-uTSXzUBQ/IgFcUa6gmGShCHr4tMdR3pxUiiWKDm8pd42UKJdYhkAYsAmHX5mTwybQ5VyGDgTjW4qKSsRvGSang=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.8.1", "", { "dependencies": { "@shikijs/types": "3.8.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.3" } }, "sha512-rZRp3BM1llrHkuBPAdYAzjlF7OqlM0rm/7EWASeCcY7cRYZIrOnGIHE9qsLz5TCjGefxBFnwgIECzBs2vmOyKA=="],
@@ -258,6 +286,8 @@
     "@shikijs/types": ["@shikijs/types@3.8.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-5C39Q8/8r1I26suLh+5TPk1DTrbY/kn3IdWA5HdizR0FhlhD05zx5nKCqhzSfDHH3p4S0ZefxWd77DLV+8FhGg=="],
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
@@ -329,6 +359,10 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
+    "base64-js": ["base64-js@0.0.8", "", {}, "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="],
+
+    "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001727", "", {}, "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
@@ -365,6 +399,16 @@
 
     "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
 
+    "css-background-parser": ["css-background-parser@0.1.0", "", {}, "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA=="],
+
+    "css-box-shadow": ["css-box-shadow@1.0.0-3", "", {}, "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg=="],
+
+    "css-color-keywords": ["css-color-keywords@1.0.0", "", {}, "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg=="],
+
+    "css-gradient-parser": ["css-gradient-parser@0.0.17", "", {}, "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg=="],
+
+    "css-to-react-native": ["css-to-react-native@3.2.0", "", { "dependencies": { "camelize": "^1.0.0", "css-color-keywords": "^1.0.0", "postcss-value-parser": "^4.0.2" } }, "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ=="],
+
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
@@ -381,6 +425,8 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "emoji-regex-xs": ["emoji-regex-xs@2.0.1", "", {}, "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.18.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
@@ -388,6 +434,8 @@
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
 
     "esbuild": ["esbuild@0.25.8", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.8", "@esbuild/android-arm": "0.25.8", "@esbuild/android-arm64": "0.25.8", "@esbuild/android-x64": "0.25.8", "@esbuild/darwin-arm64": "0.25.8", "@esbuild/darwin-x64": "0.25.8", "@esbuild/freebsd-arm64": "0.25.8", "@esbuild/freebsd-x64": "0.25.8", "@esbuild/linux-arm": "0.25.8", "@esbuild/linux-arm64": "0.25.8", "@esbuild/linux-ia32": "0.25.8", "@esbuild/linux-loong64": "0.25.8", "@esbuild/linux-mips64el": "0.25.8", "@esbuild/linux-ppc64": "0.25.8", "@esbuild/linux-riscv64": "0.25.8", "@esbuild/linux-s390x": "0.25.8", "@esbuild/linux-x64": "0.25.8", "@esbuild/netbsd-arm64": "0.25.8", "@esbuild/netbsd-x64": "0.25.8", "@esbuild/openbsd-arm64": "0.25.8", "@esbuild/openbsd-x64": "0.25.8", "@esbuild/openharmony-arm64": "0.25.8", "@esbuild/sunos-x64": "0.25.8", "@esbuild/win32-arm64": "0.25.8", "@esbuild/win32-ia32": "0.25.8", "@esbuild/win32-x64": "0.25.8" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
@@ -410,6 +458,8 @@
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fdir": ["fdir@6.4.6", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w=="],
+
+    "fflate": ["fflate@0.7.4", "", {}, "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw=="],
 
     "framer-motion": ["framer-motion@12.23.9", "", { "dependencies": { "motion-dom": "^12.23.9", "motion-utils": "^12.23.6", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-TqEHXj8LWfQSKqfdr5Y4mYltYLw96deu6/K9kGDd+ysqRJPNwF9nb5mZcrLmybHbU7gcJ+HQar41U3UTGanbbQ=="],
 
@@ -436,6 +486,8 @@
     "hast-util-to-string": ["hast-util-to-string@3.0.1", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A=="],
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hex-rgb": ["hex-rgb@4.3.0", "", {}, "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
@@ -480,6 +532,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.30.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg=="],
+
+    "linebreak": ["linebreak@1.1.0", "", { "dependencies": { "base64-js": "0.0.8", "unicode-trie": "^2.0.0" } }, "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -623,6 +677,10 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.3", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg=="],
 
+    "pako": ["pako@0.2.9", "", {}, "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="],
+
+    "parse-css-color": ["parse-css-color@0.2.1", "", { "dependencies": { "color-name": "^1.1.4", "hex-rgb": "^4.1.0" } }, "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -632,6 +690,8 @@
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "postcss-selector-parser": ["postcss-selector-parser@7.1.0", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -677,6 +737,8 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "satori": ["satori@0.26.0", "", { "dependencies": { "@shuding/opentype.js": "1.4.0-beta.0", "css-background-parser": "^0.1.0", "css-box-shadow": "1.0.0-3", "css-gradient-parser": "^0.0.17", "css-to-react-native": "^3.0.0", "emoji-regex-xs": "^2.0.1", "escape-html": "^1.0.3", "linebreak": "^1.1.0", "parse-css-color": "^0.2.1", "postcss-value-parser": "^4.2.0", "yoga-layout": "^3.2.1" } }, "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA=="],
+
     "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
@@ -695,6 +757,8 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "string.prototype.codepointat": ["string.prototype.codepointat@0.2.1", "", {}, "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="],
+
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "style-to-js": ["style-to-js@1.1.17", "", { "dependencies": { "style-to-object": "1.0.9" } }, "sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA=="],
@@ -711,6 +775,8 @@
 
     "tar": ["tar@7.4.3", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.0.1", "mkdirp": "^3.0.1", "yallist": "^5.0.0" } }, "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw=="],
 
+    "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
+
     "tinyexec": ["tinyexec@1.0.1", "", {}, "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw=="],
 
     "tinyglobby": ["tinyglobby@0.2.14", "", { "dependencies": { "fdir": "^6.4.4", "picomatch": "^4.0.2" } }, "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ=="],
@@ -726,6 +792,8 @@
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
     "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
+
+    "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 
@@ -752,6 +820,8 @@
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
 
     "zod": ["zod@4.0.10", "", {}, "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA=="],
 

--- a/docs-v2/components/github-stars-link.tsx
+++ b/docs-v2/components/github-stars-link.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+
+const starsEndpoint = "https://github-stars.amalshaji.workers.dev/";
+const repository = "amalshaji/portr";
+
+type GitHubStarsResponse = Record<string, { stars?: unknown }>;
+
+export function GitHubStarsLink({ className }: { className?: string }) {
+  const [stars, setStars] = useState<number | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function loadStars() {
+      try {
+        const response = await fetch(starsEndpoint, {
+          cache: "force-cache",
+          credentials: "omit",
+          signal: controller.signal,
+        });
+        if (!response.ok) return;
+
+        const data = (await response.json()) as GitHubStarsResponse;
+        const value = data[repository]?.stars;
+        if (
+          typeof value === "number" &&
+          Number.isSafeInteger(value) &&
+          value >= 0
+        ) {
+          setStars(value);
+        }
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+      }
+    }
+
+    void loadStars();
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <a
+      href="https://github.com/amalshaji/portr"
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn("inline-flex items-center justify-center gap-2", className)}
+    >
+      <svg
+        viewBox="0 0 24 24"
+        width="18"
+        height="18"
+        aria-hidden="true"
+        className="shrink-0"
+      >
+        <path
+          fill="currentColor"
+          d="M12 .7a11.5 11.5 0 0 0-3.64 22.4c.58.1.79-.25.79-.56v-2.24c-3.22.7-3.9-1.37-3.9-1.37-.53-1.34-1.29-1.7-1.29-1.7-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.04 1.77 2.72 1.26 3.38.96.1-.75.4-1.26.74-1.55-2.57-.29-5.27-1.28-5.27-5.68 0-1.26.45-2.28 1.19-3.08-.12-.29-.52-1.46.11-3.04 0 0 .97-.31 3.16 1.18a10.9 10.9 0 0 1 5.76 0c2.2-1.49 3.16-1.18 3.16-1.18.63 1.58.23 2.75.11 3.04.74.8 1.19 1.82 1.19 3.08 0 4.41-2.71 5.38-5.29 5.67.42.36.79 1.06.79 2.14v3.18c0 .31.21.67.8.56A11.5 11.5 0 0 0 12 .7Z"
+        />
+      </svg>
+      <span>GitHub</span>
+      {stars !== null && (
+        <span
+          aria-label={`${stars.toLocaleString()} GitHub stars`}
+          aria-live="polite"
+          className="tabular-nums text-fd-muted-foreground"
+        >
+          ★ {stars.toLocaleString()}
+        </span>
+      )}
+    </a>
+  );
+}

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -253,6 +253,9 @@ Each tunnel template supports the following options:
 - **host**: The local host to bind to (default: localhost)
 - **pool_size**: HTTP only. Number of SSH workers to run per HTTP tunnel (default: 2). Increases resilience and throughput.
 
+HTTP tunnels use streaming reverse proxying by default. Request and response bodies are forwarded as they arrive, while inspector captures are stored asynchronously and capped at 1 MiB per body.
+The former `enable_http_reverse_proxy` option is no longer required; existing configurations containing it still load, but the option is ignored.
+
 ## Example Configurations
 
 ### Development Environment

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.1
 	github.com/valyala/fasttemplate v1.2.2
 	golang.org/x/crypto v0.45.0
+	golang.org/x/net v0.47.0
 	golang.org/x/oauth2 v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.0
@@ -89,7 +90,6 @@ require (
 	github.com/xrash/smetrics v0.0.0-20240312152122-5f08fbb34913 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
-	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -213,9 +213,15 @@ func (m *Manager) StopTunnel(ctx context.Context, id string) (TunnelStatus, erro
 	m.mu.Unlock()
 
 	tunnel.cancel()
+	var shutdowns sync.WaitGroup
 	for _, client := range tunnel.clients {
-		_ = client.Shutdown(ctx)
+		shutdowns.Add(1)
+		go func() {
+			defer shutdowns.Done()
+			_ = client.Shutdown(ctx)
+		}()
 	}
+	shutdowns.Wait()
 	m.unregisterStubTunnel(clientcfg.Tunnel{
 		Type:      tunnel.status.Type,
 		Subdomain: tunnel.status.Subdomain,
@@ -322,7 +328,6 @@ func (m *Manager) clientConfigForTunnel(tunnel clientcfg.Tunnel) clientcfg.Clien
 		HealthCheckMaxRetries:           m.baseConfig.HealthCheckMaxRetries,
 		DisableTUI:                      true,
 		DisableTerminalLogs:             true,
-		EnableHttpReverseProxy:          m.baseConfig.EnableHttpReverseProxy,
 		InsecureSkipHostKeyVerification: *m.baseConfig.InsecureSkipHostKeyVerification,
 	}
 }

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -140,7 +140,6 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 			HealthCheckInterval:             c.config.HealthCheckInterval,
 			HealthCheckMaxRetries:           c.config.HealthCheckMaxRetries,
 			DisableTUI:                      c.config.DisableTUI,
-			EnableHttpReverseProxy:          c.config.EnableHttpReverseProxy,
 			InsecureSkipHostKeyVerification: *c.config.InsecureSkipHostKeyVerification,
 		})
 	}
@@ -266,9 +265,15 @@ func (c *Client) Shutdown(ctx context.Context) {
 		fmt.Printf("🛑 Shutting down tunnels...\n")
 	}
 
+	var shutdowns sync.WaitGroup
 	for _, sshc := range c.sshcs {
-		sshc.Shutdown(ctx)
+		shutdowns.Add(1)
+		go func() {
+			defer shutdowns.Done()
+			_ = sshc.Shutdown(ctx)
+		}()
 	}
+	shutdowns.Wait()
 
 	if c.stubResponder != nil {
 		_ = c.stubResponder.Shutdown(ctx)

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -147,7 +147,6 @@ type Config struct {
 	HealthCheckInterval             int      `yaml:"health_check_interval"`
 	HealthCheckMaxRetries           int      `yaml:"health_check_max_retries"`
 	DisableTUI                      bool     `yaml:"disable_tui"`
-	EnableHttpReverseProxy          bool     `yaml:"enable_http_reverse_proxy"`
 	DisableUpdateCheck              bool     `yaml:"disable_update_check"`
 	InsecureSkipHostKeyVerification *bool    `yaml:"insecure_skip_host_key_verification"`
 }
@@ -249,7 +248,6 @@ type ClientConfig struct {
 	HealthCheckMaxRetries           int
 	DisableTUI                      bool
 	DisableTerminalLogs             bool
-	EnableHttpReverseProxy          bool
 	InsecureSkipHostKeyVerification bool
 }
 

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -64,6 +64,22 @@ func TestLoadPreservesExplicitRequestLoggingFalse(t *testing.T) {
 	}
 }
 
+func TestLoadAcceptsDeprecatedHTTPReverseProxyOption(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	contents := "enable_http_reverse_proxy: false\nserver_url: example.test\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config with deprecated option: %v", err)
+	}
+	if cfg.ServerUrl != "example.test" {
+		t.Fatalf("expected remaining config to load, got server_url=%q", cfg.ServerUrl)
+	}
+}
+
 func TestGetConfigUpdatesOnlyTokenWhenDefaultConfigExists(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	useDefaultConfigPath(t, configPath)

--- a/internal/client/ssh/capture.go
+++ b/internal/client/ssh/capture.go
@@ -1,0 +1,255 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+const (
+	maxCapturedBodyBytes = 1 << 20
+	captureQueueSize     = 32
+)
+
+type requestLogContextKey struct{}
+
+type requestLogData struct {
+	id        string
+	request   *http.Request
+	body      *bodyCapture
+	startTime time.Time
+}
+
+type bodyCapture struct {
+	mu        sync.Mutex
+	data      bytes.Buffer
+	total     int64
+	truncated bool
+}
+
+func (c *bodyCapture) Write(payload []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.total += int64(len(payload))
+	remaining := maxCapturedBodyBytes - c.data.Len()
+	if remaining <= 0 {
+		c.truncated = true
+		return
+	}
+	if len(payload) > remaining {
+		payload = payload[:remaining]
+		c.truncated = true
+	}
+	_, _ = c.data.Write(payload)
+}
+
+func (c *bodyCapture) Size() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.total
+}
+
+func (c *bodyCapture) Bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return bytes.Clone(c.data.Bytes())
+}
+
+type capturingReadCloser struct {
+	io.ReadCloser
+	capture *bodyCapture
+	onDone  func()
+	once    sync.Once
+}
+
+func (r *capturingReadCloser) Read(payload []byte) (int, error) {
+	n, err := r.ReadCloser.Read(payload)
+	if n > 0 {
+		r.capture.Write(payload[:n])
+	}
+	if err != nil {
+		r.once.Do(r.onDone)
+	}
+	return n, err
+}
+
+func (r *capturingReadCloser) Close() error {
+	err := r.ReadCloser.Close()
+	r.once.Do(r.onDone)
+	return err
+}
+
+type captureTask interface {
+	persist(*SshClient)
+}
+
+type httpCaptureTask struct {
+	id           string
+	request      *http.Request
+	requestBody  []byte
+	response     *http.Response
+	responseBody []byte
+	durationMs   int64
+	bytesIn      int64
+	bytesOut     int64
+}
+
+func (t httpCaptureTask) persist(client *SshClient) {
+	client.logHttpRequestSized(
+		t.id,
+		t.request,
+		t.requestBody,
+		t.response,
+		t.responseBody,
+		t.durationMs,
+		t.bytesIn,
+		t.bytesOut,
+	)
+}
+
+type websocketEventCaptureTask struct {
+	sessionID string
+	direction string
+	frame     *webSocketFrame
+}
+
+type websocketOpenCaptureTask struct {
+	handshake httpCaptureTask
+	sessionID string
+	request   *http.Request
+	response  *http.Response
+}
+
+func (t websocketOpenCaptureTask) persist(client *SshClient) {
+	t.handshake.persist(client)
+	client.logWebSocketSessionWithID(t.sessionID, t.handshake.id, t.request, t.response)
+}
+
+func (t websocketEventCaptureTask) persist(client *SshClient) {
+	client.recordWebSocketEvent(t.sessionID, t.direction, t.frame)
+}
+
+type websocketCloseCaptureTask struct {
+	sessionID string
+	err       error
+}
+
+func (t websocketCloseCaptureTask) persist(client *SshClient) {
+	client.closeWebSocketSession(t.sessionID, t.err)
+}
+
+type captureRecorder struct {
+	queue  chan queuedCaptureTask
+	done   chan struct{}
+	mu     sync.Mutex
+	closed bool
+}
+
+func newCaptureRecorder() *captureRecorder {
+	recorder := &captureRecorder{
+		queue: make(chan queuedCaptureTask, captureQueueSize),
+		done:  make(chan struct{}),
+	}
+	go func() {
+		defer close(recorder.done)
+		for queued := range recorder.queue {
+			func() {
+				defer func() {
+					if recovered := recover(); recovered != nil && queued.client.config.Debug {
+						queued.client.logDebug("Traffic log persistence panic", nil)
+					}
+				}()
+				queued.task.persist(queued.client)
+			}()
+		}
+	}()
+	return recorder
+}
+
+func (r *captureRecorder) submit(client *SshClient, task captureTask) bool {
+	if r == nil || task == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
+	select {
+	case r.queue <- queuedCaptureTask{client: client, task: task}:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *captureRecorder) submitContext(ctx context.Context, client *SshClient, task captureTask) bool {
+	if r == nil || task == nil {
+		return false
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return false
+	}
+	select {
+	case r.queue <- queuedCaptureTask{client: client, task: task}:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (r *captureRecorder) close(ctx context.Context) error {
+	if r == nil {
+		return nil
+	}
+	r.mu.Lock()
+	if !r.closed {
+		r.closed = true
+		close(r.queue)
+	}
+	r.mu.Unlock()
+	select {
+	case <-r.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type queuedCaptureTask struct {
+	client *SshClient
+	task   captureTask
+}
+
+func (s *SshClient) submitCapture(task captureTask) bool {
+	s.mu.Lock()
+	if s.recorder == nil {
+		s.recorder = newCaptureRecorder()
+	}
+	recorder := s.recorder
+	s.mu.Unlock()
+	accepted := recorder.submit(s, task)
+	if !accepted && s.config.Debug {
+		s.logDebug("Traffic log queue full or closed; dropping capture", nil)
+	}
+	return accepted
+}
+
+func (s *SshClient) submitCaptureContext(ctx context.Context, task captureTask) bool {
+	s.mu.Lock()
+	if s.recorder == nil {
+		s.recorder = newCaptureRecorder()
+	}
+	recorder := s.recorder
+	s.mu.Unlock()
+	accepted := recorder.submitContext(ctx, s, task)
+	if !accepted && s.config.Debug {
+		s.logDebug("Traffic log queue full or closed; dropping capture", nil)
+	}
+	return accepted
+}

--- a/internal/client/ssh/deadline_conn.go
+++ b/internal/client/ssh/deadline_conn.go
@@ -1,0 +1,193 @@
+package ssh
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+const deadlineConnReadBufferSize = 32 * 1024
+
+type deadlineReadResult struct {
+	buffer []byte
+	read   int
+	err    error
+}
+
+var deadlineConnReadBufferPool = sync.Pool{
+	New: func() any {
+		return make([]byte, deadlineConnReadBufferSize)
+	},
+}
+
+type deadlineConn struct {
+	net.Conn
+
+	results chan deadlineReadResult
+	done    chan struct{}
+
+	readMu     sync.Mutex
+	pending    []byte
+	pendingBuf []byte
+	pendingErr error
+
+	deadlineMu      sync.Mutex
+	readDeadline    time.Time
+	deadlineChanged chan struct{}
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func newDeadlineConn(conn net.Conn) *deadlineConn {
+	wrapped := &deadlineConn{
+		Conn:            conn,
+		results:         make(chan deadlineReadResult),
+		done:            make(chan struct{}),
+		deadlineChanged: make(chan struct{}),
+	}
+	go wrapped.readPump()
+	return wrapped
+}
+
+func (c *deadlineConn) readPump() {
+	for {
+		buffer := deadlineConnReadBufferPool.Get().([]byte)
+		read, err := c.Conn.Read(buffer)
+		if read == 0 {
+			deadlineConnReadBufferPool.Put(buffer)
+		}
+		if read == 0 && err == nil {
+			continue
+		}
+		result := deadlineReadResult{buffer: buffer, read: read, err: err}
+		select {
+		case c.results <- result:
+		case <-c.done:
+			if read > 0 {
+				deadlineConnReadBufferPool.Put(buffer)
+			}
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func (c *deadlineConn) Read(payload []byte) (int, error) {
+	if len(payload) == 0 {
+		return 0, nil
+	}
+
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+	for {
+		if len(c.pending) > 0 {
+			read := copy(payload, c.pending)
+			c.pending = c.pending[read:]
+			if len(c.pending) == 0 {
+				deadlineConnReadBufferPool.Put(c.pendingBuf)
+				c.pendingBuf = nil
+			}
+			return read, nil
+		}
+		if c.pendingErr != nil {
+			err := c.pendingErr
+			c.pendingErr = nil
+			return 0, err
+		}
+
+		result, err := c.nextReadResult()
+		if err != nil {
+			return 0, err
+		}
+		if result.read > 0 {
+			c.pendingBuf = result.buffer
+			c.pending = result.buffer[:result.read]
+		}
+		c.pendingErr = result.err
+	}
+}
+
+func (c *deadlineConn) nextReadResult() (deadlineReadResult, error) {
+	for {
+		c.deadlineMu.Lock()
+		deadline := c.readDeadline
+		changed := c.deadlineChanged
+		c.deadlineMu.Unlock()
+
+		if deadline.IsZero() {
+			select {
+			case result := <-c.results:
+				return result, nil
+			case <-changed:
+				continue
+			case <-c.done:
+				return deadlineReadResult{}, net.ErrClosed
+			}
+		}
+
+		delay := time.Until(deadline)
+		if delay <= 0 {
+			return deadlineReadResult{}, os.ErrDeadlineExceeded
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case result := <-c.results:
+			stopTimer(timer)
+			return result, nil
+		case <-changed:
+			stopTimer(timer)
+			continue
+		case <-c.done:
+			stopTimer(timer)
+			return deadlineReadResult{}, net.ErrClosed
+		case <-timer.C:
+			return deadlineReadResult{}, os.ErrDeadlineExceeded
+		}
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+func (c *deadlineConn) SetDeadline(deadline time.Time) error {
+	if err := c.SetReadDeadline(deadline); err != nil {
+		return err
+	}
+	return c.SetWriteDeadline(deadline)
+}
+
+func (c *deadlineConn) SetReadDeadline(deadline time.Time) error {
+	c.deadlineMu.Lock()
+	c.readDeadline = deadline
+	close(c.deadlineChanged)
+	c.deadlineChanged = make(chan struct{})
+	c.deadlineMu.Unlock()
+	return nil
+}
+
+func (c *deadlineConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func (c *deadlineConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.done)
+		c.closeErr = c.Conn.Close()
+		if errors.Is(c.closeErr, net.ErrClosed) {
+			c.closeErr = nil
+		}
+	})
+	return c.closeErr
+}

--- a/internal/client/ssh/lifecycle.go
+++ b/internal/client/ssh/lifecycle.go
@@ -1,0 +1,297 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/client/tui"
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/charmbracelet/log"
+)
+
+func (s *SshClient) Shutdown(ctx context.Context) error {
+	atomic.StoreInt32(&s.shutdown, 1)
+	s.mu.Lock()
+	if s.lifecycleCancel != nil {
+		s.lifecycleCancel()
+	}
+	lifecycleDone := s.lifecycleDone
+	s.mu.Unlock()
+
+	err := s.closeTransport()
+	if lifecycleDone != nil {
+		select {
+		case <-lifecycleDone:
+		case <-ctx.Done():
+			if err == nil {
+				err = ctx.Err()
+			}
+		}
+	} else {
+		s.mu.RLock()
+		recorder := s.recorder
+		s.mu.RUnlock()
+		if recorderErr := recorder.close(ctx); recorderErr != nil && err == nil {
+			err = recorderErr
+		}
+	}
+	cfg := s.ConfigSnapshot()
+	if s.tui != nil {
+		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(cfg.Tunnel), Delta: -1})
+	}
+	s.emitEvent(EventStopped, nil)
+	log.Info("Stopped tunnel connection", "address", cfg.GetTunnelAddr())
+	return err
+}
+
+func reconnectBackoff(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	if attempt > 5 {
+		attempt = 5
+	}
+	base := time.Second * time.Duration(1<<(attempt-1))
+	return base + time.Duration(rand.IntN(500))*time.Millisecond
+}
+
+func (s *SshClient) startError(err error) error {
+	return fmt.Errorf("failed to start tunnel '%s': %w", tunnelDisplayName(s.config.Tunnel), err)
+}
+
+func tunnelDisplayName(tunnel config.Tunnel) string {
+	if tunnel.Name != "" {
+		return tunnel.Name
+	}
+	if tunnel.Type == constants.Stub && tunnel.Subdomain != "" {
+		return tunnel.Subdomain
+	}
+	return fmt.Sprintf("%d", tunnel.Port)
+}
+
+func (s *SshClient) Start(ctx context.Context) error {
+	if atomic.LoadInt32(&s.shutdown) == 1 {
+		return errClientShuttingDown
+	}
+	lifecycleCtx, lifecycleCancel := context.WithCancel(ctx)
+	lifecycleDone := make(chan struct{})
+	s.mu.Lock()
+	s.lifecycleCancel = lifecycleCancel
+	s.lifecycleDone = lifecycleDone
+	s.mu.Unlock()
+	defer func() {
+		lifecycleCancel()
+		_ = s.closeTransport()
+		s.connections.Wait()
+		s.mu.RLock()
+		recorder := s.recorder
+		s.mu.RUnlock()
+		recorderCtx, cancelRecorder := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = recorder.close(recorderCtx)
+		cancelRecorder()
+		s.mu.Lock()
+		s.lifecycleCancel = nil
+		s.lifecycleDone = nil
+		s.mu.Unlock()
+		close(lifecycleDone)
+	}()
+
+	transport, err := s.establishWithTimeout(lifecycleCtx)
+	if err != nil {
+		if lifecycleCtx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+			return nil
+		}
+		startErr := s.startError(err)
+		s.emitEvent(EventFailed, startErr)
+		return startErr
+	}
+	if !s.installTransport(lifecycleCtx, transport) {
+		return nil
+	}
+	s.announceTransportReady(true)
+
+	maxRetries := s.config.HealthCheckMaxRetries
+	if maxRetries < 1 {
+		maxRetries = 1
+	}
+	for {
+		err = s.monitorTransport(lifecycleCtx, transport)
+		s.clearTransport(transport)
+		_ = transport.Close()
+		if lifecycleCtx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 || errors.Is(err, errClientShuttingDown) {
+			return nil
+		}
+		s.announceTransportLost(err)
+
+		for attempt := 1; ; attempt++ {
+			transport, err = s.establishWithTimeout(lifecycleCtx)
+			if err == nil && s.installTransport(lifecycleCtx, transport) {
+				s.announceTransportReady(false)
+				break
+			}
+			if lifecycleCtx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+				return nil
+			}
+			if s.config.Debug {
+				s.logDebug(fmt.Sprintf("Failed to reconnect to ssh tunnel (attempt %d)", attempt), err)
+			}
+			if attempt >= maxRetries {
+				return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", tunnelDisplayName(s.config.Tunnel), attempt, err)
+			}
+			if !waitForReconnect(lifecycleCtx, reconnectBackoff(attempt)) {
+				return nil
+			}
+		}
+	}
+}
+
+func (s *SshClient) establishWithTimeout(ctx context.Context) (*tunnelTransport, error) {
+	setupCtx, cancel := context.WithTimeout(ctx, tunnelStartTimeout)
+	defer cancel()
+	return s.establishTransport(setupCtx)
+}
+
+func waitForReconnect(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func (s *SshClient) monitorTransport(ctx context.Context, transport *tunnelTransport) error {
+	serveErr := make(chan error, 1)
+	go func() {
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				serveErr <- fmt.Errorf("tunnel listener panic: %v", recovered)
+			}
+		}()
+		serveErr <- s.serveTransport(ctx, transport)
+	}()
+
+	interval := time.Duration(s.config.HealthCheckInterval) * time.Second
+	if interval <= 0 {
+		interval = 3 * time.Second
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			_ = transport.Close()
+			<-serveErr
+			return errClientShuttingDown
+		case err := <-serveErr:
+			return err
+		case <-ticker.C:
+			if err := checkSSHKeepAlive(transport.client, 5*time.Second); err != nil {
+				_ = transport.Close()
+				<-serveErr
+				return err
+			}
+			if s.tui != nil {
+				s.tui.Send(tui.UpdateHealthMsg{Port: tunnelStatusKey(s.config.Tunnel), Healthy: true})
+			}
+		}
+	}
+}
+
+func (s *SshClient) announceTransportReady(initial bool) {
+	cfg := s.ConfigSnapshot()
+	if initial {
+		if s.tui != nil {
+			s.tui.Send(tui.AddTunnelMsg{Config: &cfg.Tunnel, ClientConfig: &cfg, Healthy: true})
+		} else if !cfg.DisableTerminalLogs {
+			fmt.Printf("✅ Tunnel started: %s → %s\n", cfg.Tunnel.GetLocalAddr(), cfg.GetTunnelAddr())
+		}
+		s.emitEvent(EventStarted, nil)
+	} else {
+		if s.tui != nil {
+			s.tui.Send(tui.UpdateHealthMsg{Port: tunnelStatusKey(cfg.Tunnel), Healthy: true})
+		} else if !cfg.DisableTerminalLogs {
+			fmt.Printf("🔄 Tunnel reconnected: %s\n", cfg.GetTunnelAddr())
+		}
+		s.emitEvent(EventReconnected, nil)
+	}
+	if s.tui != nil {
+		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(cfg.Tunnel), Delta: 1})
+	}
+}
+
+func (s *SshClient) announceTransportLost(err error) {
+	cfg := s.ConfigSnapshot()
+	if s.config.Debug {
+		s.logDebug("Tunnel transport failed", err)
+	}
+	if s.tui != nil {
+		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(cfg.Tunnel), Delta: -1})
+		s.tui.Send(tui.UpdateHealthMsg{Port: tunnelStatusKey(cfg.Tunnel), Healthy: false})
+	} else if !cfg.DisableTerminalLogs {
+		fmt.Printf("❌ Tunnel unhealthy: %s (attempting reconnect)\n", cfg.GetTunnelAddr())
+	}
+	s.emitEvent(EventUnhealthy, err)
+}
+
+func (s *SshClient) HealthCheck() error {
+	s.mu.RLock()
+	transport := s.transport
+	s.mu.RUnlock()
+	if transport == nil || transport.client == nil || transport.listener == nil {
+		return fmt.Errorf("ssh tunnel transport is not connected")
+	}
+	return checkSSHKeepAlive(transport.client, 5*time.Second)
+}
+
+type sshRequestSender interface {
+	SendRequest(string, bool, []byte) (bool, []byte, error)
+}
+
+func checkSSHKeepAlive(client sshRequestSender, timeout time.Duration) error {
+	type keepAliveResult struct {
+		accepted bool
+		err      error
+	}
+	result := make(chan keepAliveResult, 1)
+	go func() {
+		accepted, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
+		result <- keepAliveResult{accepted: accepted, err: err}
+	}()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case response := <-result:
+		if response.err != nil {
+			return response.err
+		}
+		if !response.accepted {
+			return fmt.Errorf("ssh keepalive rejected")
+		}
+	case <-timer.C:
+		return fmt.Errorf("ssh keepalive timed out")
+	}
+	return nil
+}
+
+func (s *SshClient) logDebug(message string, err error) {
+	if !s.config.Debug {
+		return
+	}
+	errString := ""
+	if err != nil {
+		errString = err.Error()
+	}
+	if s.tui != nil {
+		s.tui.Send(tui.AddDebugLogMsg{
+			Time: time.Now().Format("15:04:05"), Level: "DEBUG", Message: message, Error: errString,
+		})
+	}
+}

--- a/internal/client/ssh/local_server_error_test.go
+++ b/internal/client/ssh/local_server_error_test.go
@@ -1,0 +1,159 @@
+package ssh
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientdb "github.com/amalshaji/portr/internal/client/db"
+)
+
+func startClosingTCPServer(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	return listener.Addr().String()
+}
+
+func runTunnelRequest(t *testing.T, localEndpoint, rawRequest string) string {
+	t.Helper()
+	remoteConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+	client := &SshClient{config: clientcfg.ClientConfig{Tunnel: clientcfg.Tunnel{
+		Name: "test", Subdomain: "test", Port: 3000,
+	}}}
+
+	done := make(chan struct{})
+	go func() {
+		client.httpTunnel(remoteConn, localEndpoint)
+		close(done)
+	}()
+	if _, err := clientConn.Write([]byte(rawRequest)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	response, err := io.ReadAll(clientConn)
+	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "closed") {
+		t.Fatalf("read response: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tunnel handler did not finish")
+	}
+	return string(response)
+}
+
+func assertLocalServerUnavailable(t *testing.T, response string) {
+	t.Helper()
+	if !strings.HasPrefix(response, "HTTP/1.1 503 Service Unavailable") ||
+		!strings.Contains(response, "X-Portr-Error: true") ||
+		!strings.Contains(response, "X-Portr-Error-Reason: local-server-not-online") {
+		t.Fatalf("unexpected response %q", response)
+	}
+}
+
+func TestHTTPTunnelReturns503WhenLocalClosesWithoutResponse(t *testing.T) {
+	response := runTunnelRequest(t, startClosingTCPServer(t), "GET / HTTP/1.1\r\nHost: test.example\r\nConnection: close\r\n\r\n")
+	assertLocalServerUnavailable(t, response)
+}
+
+func TestWebSocketTunnelReturns503WhenLocalClosesWithoutHandshake(t *testing.T) {
+	request := strings.Join([]string{
+		"GET /ws HTTP/1.1",
+		"Host: test.example",
+		"Connection: Upgrade",
+		"Upgrade: websocket",
+		"Sec-WebSocket-Version: 13",
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+		"",
+		"",
+	}, "\r\n")
+	response := runTunnelRequest(t, startClosingTCPServer(t), request)
+	assertLocalServerUnavailable(t, response)
+}
+
+func TestHTTPTunnelReusesForwardedConnection(t *testing.T) {
+	var requests atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer backend.Close()
+
+	remoteConn, clientConn := net.Pipe()
+	client := &SshClient{
+		config: clientcfg.ClientConfig{Tunnel: clientcfg.Tunnel{Name: "test", Subdomain: "test", Port: 3000}},
+		db:     newTestRequestStore(t),
+	}
+	done := make(chan struct{})
+	go func() {
+		client.httpTunnel(remoteConn, strings.TrimPrefix(backend.URL, "http://"))
+		close(done)
+	}()
+
+	reader := bufio.NewReader(clientConn)
+	for index := 0; index < 2; index++ {
+		connection := "keep-alive"
+		if index == 1 {
+			connection = "close"
+		}
+		request, _ := http.NewRequest(http.MethodGet, "http://test.example/", nil)
+		request.Header.Set("Connection", connection)
+		if err := request.Write(clientConn); err != nil {
+			t.Fatalf("write request %d: %v", index, err)
+		}
+		response, err := http.ReadResponse(reader, request)
+		if err != nil {
+			t.Fatalf("read response %d: %v", index, err)
+		}
+		body, err := io.ReadAll(response.Body)
+		_ = response.Body.Close()
+		if err != nil || string(body) != "ok" {
+			t.Fatalf("response %d body=%q err=%v", index, body, err)
+		}
+	}
+	_ = clientConn.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("HTTP tunnel did not close")
+	}
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown tunnel client: %v", err)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf("expected two requests over one forward, got %d", requests.Load())
+	}
+	var persisted int64
+	if err := client.db.Conn.Model(&clientdb.Request{}).Count(&persisted).Error; err != nil {
+		t.Fatalf("count persisted requests: %v", err)
+	}
+	if persisted != 2 {
+		t.Fatalf("expected two persisted requests, got %d", persisted)
+	}
+}

--- a/internal/client/ssh/reliability_test.go
+++ b/internal/client/ssh/reliability_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -153,6 +154,52 @@ func TestWriteAllRejectsZeroLengthWrite(t *testing.T) {
 	err := writeAll(writerFunc(func([]byte) (int, error) { return 0, nil }), []byte("x"))
 	if !errors.Is(err, io.ErrShortWrite) {
 		t.Fatalf("expected short write, got %v", err)
+	}
+}
+
+func TestDeadlineConnInterruptsReadWithoutLosingData(t *testing.T) {
+	server, client := net.Pipe()
+	wrapped := newDeadlineConn(server)
+	t.Cleanup(func() {
+		_ = wrapped.Close()
+		_ = client.Close()
+	})
+
+	readDone := make(chan error, 1)
+	go func() {
+		buffer := make([]byte, 1)
+		_, err := wrapped.Read(buffer)
+		readDone <- err
+	}()
+	if err := wrapped.SetReadDeadline(time.Now().Add(20 * time.Millisecond)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	select {
+	case err := <-readDone:
+		if !errors.Is(err, os.ErrDeadlineExceeded) {
+			t.Fatalf("expected deadline error, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("deadline did not interrupt read")
+	}
+
+	if err := wrapped.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear read deadline: %v", err)
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		_, err := client.Write([]byte("websocket-frame"))
+		writeDone <- err
+	}()
+	buffer := make([]byte, len("websocket-frame"))
+	if _, err := io.ReadFull(wrapped, buffer); err != nil {
+		t.Fatalf("read data after deadline: %v", err)
+	}
+	if err := <-writeDone; err != nil {
+		t.Fatalf("write data after deadline: %v", err)
+	}
+	if string(buffer) != "websocket-frame" {
+		t.Fatalf("data was lost after interrupted read: %q", buffer)
 	}
 }
 

--- a/internal/client/ssh/reliability_test.go
+++ b/internal/client/ssh/reliability_test.go
@@ -1,0 +1,260 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+type captureTaskFunc func()
+
+func (f captureTaskFunc) persist(*SshClient) { f() }
+
+type requestSenderFunc func(string, bool, []byte) (bool, []byte, error)
+
+func (f requestSenderFunc) SendRequest(name string, wantReply bool, payload []byte) (bool, []byte, error) {
+	return f(name, wantReply, payload)
+}
+
+func TestCheckSSHKeepAliveRequiresAcknowledgement(t *testing.T) {
+	called := false
+	err := checkSSHKeepAlive(requestSenderFunc(func(name string, wantReply bool, _ []byte) (bool, []byte, error) {
+		called = true
+		if name != "keepalive@openssh.com" {
+			t.Fatalf("unexpected request %q", name)
+		}
+		if !wantReply {
+			t.Fatal("keepalive must require a reply")
+		}
+		return true, nil, nil
+	}), time.Second)
+	if err != nil {
+		t.Fatalf("keepalive failed: %v", err)
+	}
+	if !called {
+		t.Fatal("keepalive request was not sent")
+	}
+}
+
+func TestCheckSSHKeepAliveRejectsMissingAcknowledgement(t *testing.T) {
+	err := checkSSHKeepAlive(requestSenderFunc(func(string, bool, []byte) (bool, []byte, error) {
+		return false, nil, nil
+	}), time.Second)
+	if err == nil {
+		t.Fatal("expected rejected keepalive to fail")
+	}
+}
+
+func TestCheckSSHKeepAliveTimesOut(t *testing.T) {
+	blocked := make(chan struct{})
+	err := checkSSHKeepAlive(requestSenderFunc(func(string, bool, []byte) (bool, []byte, error) {
+		<-blocked
+		return false, nil, errors.New("closed")
+	}), 10*time.Millisecond)
+	close(blocked)
+	if err == nil || err.Error() != "ssh keepalive timed out" {
+		t.Fatalf("expected timeout, got %v", err)
+	}
+}
+
+func TestBodyCaptureIsBounded(t *testing.T) {
+	capture := &bodyCapture{}
+	capture.Write(bytes.Repeat([]byte("x"), maxCapturedBodyBytes+1024))
+	if got := len(capture.Bytes()); got != maxCapturedBodyBytes {
+		t.Fatalf("expected %d captured bytes, got %d", maxCapturedBodyBytes, got)
+	}
+	if !capture.truncated {
+		t.Fatal("expected capture to be marked truncated")
+	}
+	if capture.Size() != maxCapturedBodyBytes+1024 {
+		t.Fatalf("expected full byte count, got %d", capture.Size())
+	}
+}
+
+func TestCaptureRecorderDrainsBeforeClose(t *testing.T) {
+	recorder := newCaptureRecorder()
+	client := &SshClient{}
+	persisted := make(chan struct{}, 1)
+	if !recorder.submit(client, captureTaskFunc(func() { persisted <- struct{}{} })) {
+		t.Fatal("expected capture task to be accepted")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := recorder.close(ctx); err != nil {
+		t.Fatalf("close recorder: %v", err)
+	}
+	select {
+	case <-persisted:
+	default:
+		t.Fatal("recorder closed before draining task")
+	}
+	if recorder.submit(client, captureTaskFunc(func() {})) {
+		t.Fatal("closed recorder accepted another task")
+	}
+}
+
+type repeatedByteReader byte
+
+func (r repeatedByteReader) Read(payload []byte) (int, error) {
+	for index := range payload {
+		payload[index] = byte(r)
+	}
+	return len(payload), nil
+}
+
+func TestForwardWebSocketFrameStreamsLargePayloadWithBoundedCapture(t *testing.T) {
+	payloadLength := int64(16<<20 + 1)
+	header := []byte{0x82, 0x7f}
+	length := make([]byte, 8)
+	binary.BigEndian.PutUint64(length, uint64(payloadLength))
+	reader := io.MultiReader(
+		bytes.NewReader(append(header, length...)),
+		io.LimitReader(repeatedByteReader('x'), payloadLength),
+	)
+	frame, err := forwardWebSocketFrame(reader, io.Discard)
+	if err != nil {
+		t.Fatalf("forward frame: %v", err)
+	}
+	if frame.PayloadLength != int(payloadLength) || len(frame.Payload) != maxCapturedBodyBytes {
+		t.Fatalf("payload length=%d capture=%d", frame.PayloadLength, len(frame.Payload))
+	}
+}
+
+type shortWriter struct {
+	buffer bytes.Buffer
+}
+
+func (w *shortWriter) Write(payload []byte) (int, error) {
+	if len(payload) > 2 {
+		payload = payload[:2]
+	}
+	return w.buffer.Write(payload)
+}
+
+func TestWriteAllHandlesShortWrites(t *testing.T) {
+	writer := &shortWriter{}
+	payload := []byte("websocket-frame")
+	if err := writeAll(writer, payload); err != nil {
+		t.Fatalf("writeAll failed: %v", err)
+	}
+	if !bytes.Equal(writer.buffer.Bytes(), payload) {
+		t.Fatalf("unexpected payload %q", writer.buffer.Bytes())
+	}
+}
+
+func TestWriteAllRejectsZeroLengthWrite(t *testing.T) {
+	err := writeAll(writerFunc(func([]byte) (int, error) { return 0, nil }), []byte("x"))
+	if !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("expected short write, got %v", err)
+	}
+}
+
+type writerFunc func([]byte) (int, error)
+
+func (f writerFunc) Write(payload []byte) (int, error) { return f(payload) }
+
+func TestReconnectBackoffIsBounded(t *testing.T) {
+	for attempt := 1; attempt <= 20; attempt++ {
+		delay := reconnectBackoff(attempt)
+		if delay < time.Second || delay >= 33*time.Second {
+			t.Fatalf("attempt %d produced out-of-range delay %s", attempt, delay)
+		}
+	}
+}
+
+func TestHTTPRemotePortsRemainLegacyServerCompatible(t *testing.T) {
+	for _, port := range remotePortCandidates(constants.Http) {
+		if port == 0 || port < 20000 || port > 30000 {
+			t.Fatalf("HTTP candidate port %d is not legacy-server compatible", port)
+		}
+	}
+}
+
+func tcpPair(t *testing.T) (*net.TCPConn, *net.TCPConn) {
+	t.Helper()
+	listener, err := net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP("127.0.0.1")})
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer listener.Close()
+
+	accepted := make(chan *net.TCPConn, 1)
+	go func() {
+		conn, acceptErr := listener.AcceptTCP()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+	client, err := net.DialTCP("tcp", nil, listener.Addr().(*net.TCPAddr))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	server := <-accepted
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = server.Close()
+	})
+	return server, client
+}
+
+func TestTCPTunnelPropagatesHalfClose(t *testing.T) {
+	remoteTunnel, remoteClient := tcpPair(t)
+	localTunnel, localServer := tcpPair(t)
+	deadline := time.Now().Add(2 * time.Second)
+	_ = remoteClient.SetDeadline(deadline)
+	_ = localServer.SetDeadline(deadline)
+
+	client := &SshClient{}
+	tunnelDone := make(chan struct{})
+	go func() {
+		client.tcpTunnel(remoteTunnel, localTunnel)
+		close(tunnelDone)
+	}()
+
+	backendDone := make(chan error, 1)
+	go func() {
+		request, err := io.ReadAll(localServer)
+		if err != nil {
+			backendDone <- err
+			return
+		}
+		if string(request) != "request" {
+			backendDone <- errors.New("unexpected request")
+			return
+		}
+		_, err = localServer.Write([]byte("response"))
+		if closeErr := localServer.CloseWrite(); err == nil {
+			err = closeErr
+		}
+		backendDone <- err
+	}()
+
+	if _, err := remoteClient.Write([]byte("request")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := remoteClient.CloseWrite(); err != nil {
+		t.Fatalf("half-close request: %v", err)
+	}
+	response, err := io.ReadAll(remoteClient)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if string(response) != "response" {
+		t.Fatalf("unexpected response %q", response)
+	}
+	if err := <-backendDone; err != nil {
+		t.Fatalf("backend failed: %v", err)
+	}
+	select {
+	case <-tunnelDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tunnel did not close after both half-closes")
+	}
+}

--- a/internal/client/ssh/single_conn_listener.go
+++ b/internal/client/ssh/single_conn_listener.go
@@ -1,0 +1,60 @@
+package ssh
+
+import (
+	"net"
+	"sync"
+)
+
+type singleConnListener struct {
+	conn      net.Conn
+	accepted  bool
+	closed    bool
+	done      chan struct{}
+	closeOnce sync.Once
+	mu        sync.Mutex
+}
+
+func (l *singleConnListener) Accept() (net.Conn, error) {
+	l.mu.Lock()
+	if l.closed || l.accepted {
+		done := l.doneChannelLocked()
+		l.mu.Unlock()
+		<-done
+		return nil, net.ErrClosed
+	}
+	l.accepted = true
+	l.doneChannelLocked()
+	conn := &listenerConn{Conn: l.conn, onClose: l.Close}
+	l.mu.Unlock()
+	return conn, nil
+}
+
+func (l *singleConnListener) Close() error {
+	l.mu.Lock()
+	l.closed = true
+	done := l.doneChannelLocked()
+	l.mu.Unlock()
+	l.closeOnce.Do(func() { close(done) })
+	return nil
+}
+
+func (l *singleConnListener) Addr() net.Addr { return l.conn.LocalAddr() }
+
+func (l *singleConnListener) doneChannelLocked() chan struct{} {
+	if l.done == nil {
+		l.done = make(chan struct{})
+	}
+	return l.done
+}
+
+type listenerConn struct {
+	net.Conn
+	onClose func() error
+	once    sync.Once
+}
+
+func (c *listenerConn) Close() error {
+	err := c.Conn.Close()
+	c.once.Do(func() { _ = c.onClose() })
+	return err
+}

--- a/internal/client/ssh/single_conn_listener.go
+++ b/internal/client/ssh/single_conn_listener.go
@@ -24,7 +24,7 @@ func (l *singleConnListener) Accept() (net.Conn, error) {
 	}
 	l.accepted = true
 	l.doneChannelLocked()
-	conn := &listenerConn{Conn: l.conn, onClose: l.Close}
+	conn := &listenerConn{Conn: newDeadlineConn(l.conn), onClose: l.Close}
 	l.mu.Unlock()
 	return conn, nil
 }

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -1,7 +1,6 @@
 package ssh
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -12,9 +11,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/amalshaji/portr/internal/client/config"
@@ -28,7 +25,6 @@ import (
 	"github.com/amalshaji/portr/internal/client/tui"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/oklog/ulid/v2"
-	"golang.org/x/crypto/ssh"
 )
 
 var (
@@ -38,57 +34,19 @@ var (
 	tunnelStartTimeout      = 20 * time.Second
 )
 
-type requestLogContextKey struct{}
-
-type requestLogData struct {
-	id        string
-	request   *http.Request
-	body      []byte
-	startTime time.Time
-}
-
-type singleConnListener struct {
-	conn     net.Conn
-	accepted bool
-	closed   bool
-	mu       sync.Mutex
-}
-
-func (l *singleConnListener) Accept() (net.Conn, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	if l.closed || l.accepted {
-		return nil, net.ErrClosed
-	}
-
-	l.accepted = true
-	return l.conn, nil
-}
-
-func (l *singleConnListener) Close() error {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	l.closed = true
-	return nil
-}
-
-func (l *singleConnListener) Addr() net.Addr {
-	return l.conn.LocalAddr()
-}
-
 type SshClient struct {
-	config       config.ClientConfig
-	listener     net.Listener
-	db           *db.Db
-	client       *ssh.Client
-	tui          *tea.Program
-	fatal        func(error)
-	eventHandler func(Event)
-	mu           sync.RWMutex
-	reconnecting int32 // atomic flag to prevent concurrent reconnects
-	shutdown     int32 // atomic flag for shutdown state
+	config          config.ClientConfig
+	db              *db.Db
+	transport       *tunnelTransport
+	tui             *tea.Program
+	fatal           func(error)
+	eventHandler    func(Event)
+	recorder        *captureRecorder
+	mu              sync.RWMutex
+	connections     sync.WaitGroup
+	shutdown        int32
+	lifecycleCancel context.CancelFunc
+	lifecycleDone   chan struct{}
 }
 
 type EventType string
@@ -111,12 +69,10 @@ type Event struct {
 
 func New(config config.ClientConfig, db *db.Db, tui *tea.Program, fatal func(error)) *SshClient {
 	return &SshClient{
-		config:   config,
-		listener: nil,
-		db:       db,
-		client:   nil,
-		tui:      tui,
-		fatal:    fatal,
+		config: config,
+		db:     db,
+		tui:    tui,
+		fatal:  fatal,
 	}
 }
 
@@ -182,70 +138,23 @@ func (s *SshClient) goSafe(scope string, fn func()) {
 	}()
 }
 
-func (s *SshClient) shouldIgnoreListenerError(ctx context.Context, err error) bool {
-	return err == nil ||
-		ctx.Err() != nil ||
-		atomic.LoadInt32(&s.shutdown) == 1 ||
-		errors.Is(err, errClientShuttingDown)
-}
-
-func (s *SshClient) forwardListenerErrors(ctx context.Context, errChan <-chan error) {
-	go func() {
-		select {
-		case err := <-errChan:
-			if s.shouldIgnoreListenerError(ctx, err) {
-				return
-			}
-			s.reportFatal(s.startError(err))
-		case <-ctx.Done():
-		}
-	}()
+func (s *SshClient) runConnection(scope string, fn func()) {
+	s.connections.Add(1)
+	s.goSafe(scope, func() {
+		defer s.connections.Done()
+		fn()
+	})
 }
 
 func (s *SshClient) closeTransport() error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	var err error
-	if s.listener != nil {
-		err = s.listener.Close()
-		s.listener = nil
-	}
-
-	if s.client != nil {
-		if clientErr := s.client.Close(); clientErr != nil && err == nil {
-			err = clientErr
-		}
-		s.client = nil
-	}
-
-	return err
-}
-
-func (s *SshClient) closeListenerIfCurrent(listener net.Listener) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.listener == listener {
-		_ = s.listener.Close()
-		s.listener = nil
-	}
-}
-
-func (s *SshClient) handleAcceptError(listener net.Listener, err error) error {
-	if err == nil {
+	transport := s.transport
+	s.transport = nil
+	s.mu.Unlock()
+	if transport == nil {
 		return nil
 	}
-
-	s.mu.RLock()
-	currentListener := s.listener
-	s.mu.RUnlock()
-
-	if atomic.LoadInt32(&s.shutdown) == 1 || currentListener != listener {
-		return errClientShuttingDown
-	}
-
-	return fmt.Errorf("failed to accept connection: %w", err)
+	return transport.Close()
 }
 
 func CreateNewConnection(cfg config.ClientConfig) (string, error) {
@@ -308,229 +217,26 @@ func tunnelStatusKey(tunnel config.Tunnel) string {
 	return fmt.Sprintf("%d", tunnel.Port)
 }
 
-func (s *SshClient) startListenerForClient(ctx context.Context) error {
-	return s.startListenerForClientWithReady(ctx, nil)
-}
-
-func (s *SshClient) startListenerForClientWithReady(ctx context.Context, ready chan<- struct{}) error {
-	if atomic.LoadInt32(&s.shutdown) == 1 {
-		return errClientShuttingDown
-	}
-
-	var err error
-	var connectionId string
-
-	if connectionId, err = s.createNewConnection(ctx); err != nil {
-		return err
-	}
-
-	sshConfig := &ssh.ClientConfig{
-		User: fmt.Sprintf("%s:%s", connectionId, s.config.SecretKey),
-		Auth: []ssh.AuthMethod{
-			ssh.Password(""),
-		},
-		HostKeyCallback: getHostKeyCallback(s.config.InsecureSkipHostKeyVerification),
-	}
-
-	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 15 * time.Second}
-	rawConn, err := dialer.DialContext(ctx, "tcp", s.config.SshUrl)
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Failed to dial ssh tcp", err)
-		}
-		return err
-	}
-	if tcp, ok := rawConn.(*net.TCPConn); ok {
-		_ = tcp.SetKeepAlive(true)
-		_ = tcp.SetKeepAlivePeriod(15 * time.Second)
-		_ = tcp.SetNoDelay(true)
-	}
-
-	handshakeDone := make(chan struct{})
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = rawConn.Close()
-		case <-handshakeDone:
-		}
-	}()
-	_ = rawConn.SetDeadline(time.Now().Add(10 * time.Second))
-	cc, chans, reqs, err := ssh.NewClientConn(rawConn, s.config.SshUrl, sshConfig)
-	close(handshakeDone)
-	_ = rawConn.SetDeadline(time.Time{})
-	if err != nil {
-		_ = rawConn.Close()
-		if s.config.Debug {
-			s.logDebug("Failed to establish ssh client conn", err)
-		}
-		return err
-	}
-
-	s.mu.Lock()
-	s.client = ssh.NewClient(cc, chans, reqs)
-	clientRef := s.client
-	s.mu.Unlock()
-
-	s.goSafe("ssh keepalive", func() {
-		s.startSSHKeepAlive(clientRef)
-	})
-
-	localEndpoint := s.config.Tunnel.GetLocalAddr()
-
-	tunnelType := s.config.Tunnel.Type
-	if tunnelType == constants.Stub {
-		tunnelType = constants.Http
-	}
-
-	var randomPorts []int
-	if tunnelType == constants.Http {
-		randomPorts = utils.GenerateRandomHttpPorts()
-	} else {
-		randomPorts = utils.GenerateRandomTcpPorts()
-	}
-
-	var remotePort int
-	var ln net.Listener
-
-	for _, port := range randomPorts {
-		l, lerr := s.client.Listen("tcp", "0.0.0.0:"+fmt.Sprint(port))
-		if lerr == nil {
-			ln = l
-			remotePort = port
-			break
-		} else {
-			err = lerr
-		}
-	}
-
-	if ln == nil {
-		return fmt.Errorf("failed to listen on remote endpoint: %v", err)
-	}
-
-	s.mu.Lock()
-	s.listener = ln
-	s.config.Tunnel.RemotePort = remotePort
-	s.mu.Unlock()
-
-	defer func() {
-		s.closeListenerIfCurrent(ln)
-	}()
-
-	if s.tui != nil {
-		s.tui.Send(tui.AddTunnelMsg{
-			Config:       &s.config.Tunnel,
-			ClientConfig: &s.config,
-			Healthy:      true,
-		})
-	} else if !s.config.DisableTerminalLogs {
-		tunnelAddr := s.config.GetTunnelAddr()
-		fmt.Printf("✅ Tunnel started: %s → %s\n", s.config.Tunnel.GetLocalAddr(), tunnelAddr)
-	}
-
-	s.emitEvent(EventStarted, nil)
-	if ready != nil {
-		close(ready)
-	}
-
-	if s.tui != nil {
-		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(s.config.Tunnel), Delta: 1})
-	}
-
-	for {
-		if atomic.LoadInt32(&s.shutdown) == 1 {
-			return errClientShuttingDown
-		}
-
-		s.mu.RLock()
-		listener := s.listener
-		s.mu.RUnlock()
-
-		if listener == nil {
-			return fmt.Errorf("listener is nil, cannot accept connections")
-		}
-
-		remoteConn, err := listener.Accept()
-		if err != nil {
-			if s.config.Debug {
-				log.Error("Failed to accept connection", "error", err)
-			}
-			if s.tui != nil {
-				s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(s.config.Tunnel), Delta: -1})
-			}
-			return s.handleAcceptError(listener, err)
-		}
-
-		if tunnelType == constants.Http {
-			s.goSafe("http tunnel", func() {
-				s.httpTunnel(remoteConn, localEndpoint)
-			})
-		} else {
-			// Connect to the local endpoint for TCP passthrough.
-			localConn, err := net.Dial("tcp", localEndpoint)
-			if err != nil {
-				remoteConn.Close()
-				continue
-			}
-			s.goSafe("tcp tunnel", func() {
-				s.tcpTunnel(remoteConn, localConn)
-			})
-		}
-	}
-}
-
-func (s *SshClient) startSSHKeepAlive(clientRef *ssh.Client) {
-	ticker := time.NewTicker(15 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		if atomic.LoadInt32(&s.shutdown) == 1 {
-			return
-		}
-
-		s.mu.RLock()
-		sameClient := s.client == clientRef
-		s.mu.RUnlock()
-		if !sameClient {
-			return
-		}
-
-		select {
-		case <-ticker.C:
-			errCh := make(chan error, 1)
-			s.goSafe("ssh keepalive request", func() {
-				_, _, err := clientRef.SendRequest("keepalive@openssh.com", false, nil)
-				errCh <- err
-			})
-
-			select {
-			case err := <-errCh:
-				if err != nil {
-					if s.config.Debug {
-						s.logDebug("SSH keepalive failed, reconnecting", err)
-					}
-					_ = s.Reconnect()
-					return
-				}
-			case <-time.After(5 * time.Second):
-				if s.config.Debug {
-					s.logDebug("SSH keepalive timed out, reconnecting", nil)
-				}
-				_ = s.Reconnect()
-				return
-			}
-		default:
-			time.Sleep(100 * time.Millisecond)
-		}
-	}
-}
-
 func (s *SshClient) httpTunnel(src net.Conn, localEndpoint string) {
-	if s.config.EnableHttpReverseProxy {
-		s.httpTunnelReverseProxy(src, localEndpoint)
-		return
-	}
+	s.httpTunnelReverseProxy(src, localEndpoint)
+}
 
-	s.httpTunnelLegacy(src, localEndpoint)
+func writeLocalServerUnavailable(writer io.Writer, localEndpoint string) error {
+	htmlContent := []byte(utils.LocalServerNotOnline(localEndpoint))
+	response := &http.Response{
+		Status:        "503 Service Unavailable",
+		StatusCode:    http.StatusServiceUnavailable,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        make(http.Header),
+		ContentLength: int64(len(htmlContent)),
+		Body:          io.NopCloser(bytes.NewReader(htmlContent)),
+	}
+	response.Header.Set("Content-Type", "text/html")
+	response.Header.Set("X-Portr-Error", "true")
+	response.Header.Set("X-Portr-Error-Reason", "local-server-not-online")
+	return response.Write(writer)
 }
 
 func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
@@ -545,9 +251,12 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 		Proxy:             http.ProxyFromEnvironment,
 		ForceAttemptHTTP2: false,
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			var d net.Dialer
+			d := net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}
 			return d.DialContext(ctx, network, localEndpoint)
 		},
+		MaxIdleConns:        8,
+		MaxIdleConnsPerHost: 8,
+		IdleConnTimeout:     90 * time.Second,
 	}
 	defer transport.CloseIdleConnections()
 
@@ -562,31 +271,33 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 	}
 
 	proxy.ModifyResponse = func(response *http.Response) error {
-		if response.StatusCode == http.StatusSwitchingProtocols {
-			return nil
-		}
-
-		if strings.Contains(response.Header.Get("Content-Type"), "text/event-stream") {
-			return nil
-		}
-
 		logData, ok := response.Request.Context().Value(requestLogContextKey{}).(*requestLogData)
 		if !ok || logData == nil || logData.request == nil {
 			return nil
 		}
 
-		responseBody, err := io.ReadAll(response.Body)
-		if err != nil {
-			if s.config.Debug {
-				s.logDebug("Failed to read response body from reverse proxy", err)
-			}
-			return err
+		responseSnapshot := *response
+		responseSnapshot.Header = response.Header.Clone()
+		responseSnapshot.Body = nil
+		responseSnapshot.Request = nil
+		responseCapture := &bodyCapture{}
+		response.Body = &capturingReadCloser{
+			ReadCloser: response.Body,
+			capture:    responseCapture,
+			onDone: func() {
+				durationMs := time.Since(logData.startTime).Milliseconds()
+				s.submitCapture(httpCaptureTask{
+					id:           logData.id,
+					request:      logData.request,
+					requestBody:  logData.body.Bytes(),
+					response:     &responseSnapshot,
+					responseBody: responseCapture.Bytes(),
+					durationMs:   durationMs,
+					bytesIn:      logData.body.Size(),
+					bytesOut:     responseCapture.Size(),
+				})
+			},
 		}
-		response.Body.Close()
-		response.Body = io.NopCloser(bytes.NewBuffer(responseBody))
-
-		durationMs := time.Since(logData.startTime).Milliseconds()
-		s.logHttpRequest(logData.id, logData.request, logData.body, response, responseBody, durationMs)
 		return nil
 	}
 
@@ -631,17 +342,6 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 			return
 		}
 
-		requestBody, err := io.ReadAll(request.Body)
-		if err != nil {
-			if s.config.Debug {
-				s.logDebug("Failed to read request body for reverse proxy logging", err)
-			}
-			http.Error(writer, "Bad Request", http.StatusBadRequest)
-			return
-		}
-		request.Body.Close()
-		request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
-
 		requestForLog := request.Clone(context.Background())
 		requestForLog.Header = request.Header.Clone()
 		requestForLog.Host = request.Host
@@ -650,10 +350,19 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 			requestForLog.URL = &clonedURL
 		}
 
+		requestCapture := &bodyCapture{}
+		if request.Body != nil {
+			request.Body = &capturingReadCloser{
+				ReadCloser: request.Body,
+				capture:    requestCapture,
+				onDone:     func() {},
+			}
+		}
+
 		logCtx := context.WithValue(request.Context(), requestLogContextKey{}, &requestLogData{
 			id:        ulid.Make().String(),
 			request:   requestForLog,
-			body:      requestBody,
+			body:      requestCapture,
 			startTime: time.Now(),
 		})
 
@@ -674,214 +383,6 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 	}
 }
 
-func (s *SshClient) httpTunnelLegacy(src net.Conn, localEndpoint string) {
-	var dst net.Conn
-
-	defer src.Close()
-
-	srcReader := bufio.NewReader(src)
-	srcWriter := bufio.NewWriter(src)
-
-	request, err := http.ReadRequest(srcReader)
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Failed to read request", err)
-		}
-		return
-	}
-
-	if request.Header.Get("X-Portr-Ping-Request") == "true" {
-		response := &http.Response{
-			Status:     "200 OK",
-			StatusCode: 200,
-			Proto:      "HTTP/1.1",
-			ProtoMajor: 1,
-			ProtoMinor: 1,
-			Header:     http.Header{},
-			Body:       io.NopCloser(bytes.NewBufferString("")),
-		}
-
-		err = response.Write(srcWriter)
-		if err != nil {
-			if s.config.Debug {
-				log.Error("Failed to write health check response", "error", err)
-			}
-			return
-		}
-		srcWriter.Flush()
-		return
-	}
-
-	if isWebSocketUpgrade(request) {
-		if err := s.handleWebSocketRequest(src, srcReader, srcWriter, request, localEndpoint); err != nil && s.config.Debug {
-			s.logDebug("Failed to proxy websocket request", err)
-		}
-		return
-	}
-
-	// Connect to the local endpoint only after filtering internal health checks.
-	dst, err = net.Dial("tcp", localEndpoint)
-	if err != nil {
-		// serve local html if the local server is not available
-		// change this to a beautiful template
-		htmlContent := utils.LocalServerNotOnline(localEndpoint)
-		fmt.Fprintf(src, "HTTP/1.1 503 Service Unavailable\r\n")
-		fmt.Fprintf(src, "Content-Length: %d\r\n", len(htmlContent))
-		fmt.Fprintf(src, "Content-Type: text/html\r\n")
-		fmt.Fprintf(src, "X-Portr-Error: true\r\n")
-		fmt.Fprintf(src, "X-Portr-Error-Reason: local-server-not-online\r\n\r\n")
-		fmt.Fprint(src, htmlContent)
-		return
-	}
-	defer dst.Close()
-
-	dstReader := bufio.NewReader(dst)
-	dstWriter := bufio.NewWriter(dst)
-
-	// read and replace request body
-	requestBody, err := io.ReadAll(request.Body)
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Failed to read request body", err)
-		}
-		return
-	}
-	defer request.Body.Close()
-	request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
-
-	err = request.Write(dstWriter)
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Failed to tunnel request to local", err)
-		}
-		return
-	}
-	dstWriter.Flush()
-
-	response, err := http.ReadResponse(dstReader, request)
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Failed to read response", err)
-		}
-		return
-	}
-
-	// Handle WebSocket upgrades and SSE streams with TCP tunneling
-	if response.StatusCode == http.StatusSwitchingProtocols {
-		// WebSocket upgrade - write response headers and switch to TCP tunneling
-		err = response.Write(srcWriter)
-		if err != nil {
-			if s.config.Debug {
-				s.logDebug("Failed to write WebSocket upgrade response", err)
-			}
-			return
-		}
-		srcWriter.Flush()
-
-		// Drain any bytes already buffered post-handshake to avoid loss when switching to raw TCP
-		if n := dstReader.Buffered(); n > 0 {
-			buf := make([]byte, n)
-			if _, err := io.ReadFull(dstReader, buf); err == nil {
-				if _, err := srcWriter.Write(buf); err != nil {
-					if s.config.Debug {
-						s.logDebug("Failed to flush buffered server bytes on WS upgrade", err)
-					}
-					return
-				}
-				srcWriter.Flush()
-			}
-		}
-
-		if n := srcReader.Buffered(); n > 0 {
-			buf := make([]byte, n)
-			if _, err := io.ReadFull(srcReader, buf); err == nil {
-				if _, err := dstWriter.Write(buf); err != nil {
-					if s.config.Debug {
-						s.logDebug("Failed to flush buffered client bytes on WS upgrade", err)
-					}
-					return
-				}
-				dstWriter.Flush()
-			}
-		}
-
-		s.tcpTunnel(src, dst)
-		return
-	}
-
-	// Check for SSE (Server-Sent Events) streams
-	contentType := response.Header.Get("Content-Type")
-	if strings.Contains(contentType, "text/event-stream") {
-		// Ensure SSE response body is closed when streaming finishes or on error
-		defer response.Body.Close()
-
-		// SSE stream - copy the response body in real-time without buffering
-		// Write status line and headers first
-		fmt.Fprintf(srcWriter, "%s %s\r\n", response.Proto, response.Status)
-
-		// Write headers, excluding Content-Length and Transfer-Encoding
-		// as we'll be streaming the body directly
-		for key, values := range response.Header {
-			if key == "Content-Length" || key == "Transfer-Encoding" {
-				continue
-			}
-			for _, value := range values {
-				fmt.Fprintf(srcWriter, "%s: %s\r\n", key, value)
-			}
-		}
-
-		// Empty line to end headers
-		fmt.Fprintf(srcWriter, "\r\n")
-		srcWriter.Flush()
-
-		// Stream the body with immediate flushing for real-time delivery
-		buf := make([]byte, 32*1024) // 32KB buffer
-		for {
-			n, err := response.Body.Read(buf)
-			if n > 0 {
-				_, writeErr := srcWriter.Write(buf[:n])
-				if writeErr != nil {
-					if s.config.Debug {
-						s.logDebug("Failed to write SSE data", writeErr)
-					}
-					return
-				}
-				// Flush immediately to ensure real-time streaming
-				srcWriter.Flush()
-			}
-			if err != nil {
-				if err != io.EOF && s.config.Debug {
-					s.logDebug("SSE stream ended", err)
-				}
-				break
-			}
-		}
-		return
-	}
-
-	// read and replace response body for regular HTTP responses
-	responseBody, err := io.ReadAll(response.Body)
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Failed to read response body", err)
-		}
-		return
-	}
-	defer response.Body.Close()
-	response.Body = io.NopCloser(bytes.NewBuffer(responseBody))
-
-	err = response.Write(srcWriter)
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Failed to write response to remote", err)
-		}
-		return
-	}
-	srcWriter.Flush()
-
-	s.logHttpRequest(ulid.Make().String(), request, requestBody, response, responseBody, 0)
-}
-
 func (s *SshClient) logHttpRequest(
 	id string,
 	request *http.Request,
@@ -889,6 +390,28 @@ func (s *SshClient) logHttpRequest(
 	response *http.Response,
 	responseBody []byte,
 	durationMs int64,
+) {
+	s.logHttpRequestSized(
+		id,
+		request,
+		requestBody,
+		response,
+		responseBody,
+		durationMs,
+		int64(len(requestBody)),
+		int64(len(responseBody)),
+	)
+}
+
+func (s *SshClient) logHttpRequestSized(
+	id string,
+	request *http.Request,
+	requestBody []byte,
+	response *http.Response,
+	responseBody []byte,
+	durationMs int64,
+	bytesIn int64,
+	bytesOut int64,
 ) {
 	requestHeaders := make(map[string][]string)
 	for key, values := range request.Header {
@@ -946,8 +469,8 @@ func (s *SshClient) logHttpRequest(
 		IsReplayed:         isReplayedRequest,
 		ParentID:           replayedRequestId,
 		DurationMs:         durationMs,
-		BytesIn:            int64(len(requestBody)),
-		BytesOut:           int64(len(responseBody)),
+		BytesIn:            bytesIn,
+		BytesOut:           bytesOut,
 		Protocol:           request.Proto,
 	}
 	result := s.db.Conn.Create(&req)
@@ -989,298 +512,27 @@ func (s *SshClient) logHttpRequest(
 }
 
 func (s *SshClient) tcpTunnel(src, dst net.Conn) {
-	defer src.Close()
-	defer dst.Close()
-
-	s.goSafe("tcp tunnel copy", func() {
-		_, _ = io.Copy(dst, src)
-	})
-	_, _ = io.Copy(src, dst)
-}
-
-func (s *SshClient) Shutdown(ctx context.Context) error {
-	atomic.StoreInt32(&s.shutdown, 1)
-
-	err := s.closeTransport()
-	s.mu.RLock()
-	tuiProgram := s.tui
-	cfg := s.config
-	port := tunnelStatusKey(cfg.Tunnel)
-	address := cfg.GetTunnelAddr()
-	s.mu.RUnlock()
-
-	if tuiProgram != nil {
-		tuiProgram.Send(tui.UpdateConnCountMsg{Port: port, Delta: -1})
-	}
-	s.emitEvent(EventStopped, nil)
-	log.Info("Stopped tunnel connection", "address", address)
-	return err
-}
-
-func (s *SshClient) StartHealthCheck(ctx context.Context) error {
-	ticker := time.NewTicker(time.Duration(s.config.HealthCheckInterval) * time.Second)
-	defer ticker.Stop()
-	retryAttempts := 0
-
-	for {
-		select {
-		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
-		}
-
-		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
-			return nil
-		}
-
-		err := s.HealthCheck()
-		if err == nil {
-			retryAttempts = 0
-			continue
-		}
-
-		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
-			return nil
-		}
-
-		retryAttempts++
-
-		if s.config.Debug {
-			s.logDebug("Health check failed", err)
-		}
-
-		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
-			return nil
-		}
-
-		if s.tui != nil {
-			s.tui.Send(tui.UpdateHealthMsg{
-				Port:    tunnelStatusKey(s.config.Tunnel),
-				Healthy: false,
-			})
-		} else if !s.config.DisableTerminalLogs {
-			// Log unhealthy status when TUI is disabled
-			fmt.Printf("❌ Tunnel unhealthy: %s (attempting reconnect)\n", s.config.GetTunnelAddr())
-		}
-
-		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
-			return nil
-		}
-
-		s.emitEvent(EventUnhealthy, err)
-
-		reconnectErr := s.Reconnect()
-		if reconnectErr == nil {
-			retryAttempts = 0
-			continue
-		}
-		if errors.Is(reconnectErr, errClientShuttingDown) || ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
-			return nil
-		}
-		if s.config.Debug {
-			s.logDebug(fmt.Sprintf("Failed to reconnect to ssh tunnel (attempt %d)", retryAttempts), reconnectErr)
-		}
-		if retryAttempts > s.config.HealthCheckMaxRetries {
-			return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", tunnelDisplayName(s.config.Tunnel), retryAttempts, reconnectErr)
-		}
-	}
-}
-
-func (s *SshClient) startError(err error) error {
-	return fmt.Errorf("failed to start tunnel '%s': %w", tunnelDisplayName(s.config.Tunnel), err)
-}
-
-func tunnelDisplayName(tunnel config.Tunnel) string {
-	if tunnel.Name != "" {
-		return tunnel.Name
-	}
-	if tunnel.Type == constants.Stub && tunnel.Subdomain != "" {
-		return tunnel.Subdomain
-	}
-	return fmt.Sprintf("%d", tunnel.Port)
-}
-
-func (s *SshClient) Start(ctx context.Context) error {
-	errChan := make(chan error, 1)
-	readyChan := make(chan struct{})
-	startupCtx, cancelStartup := context.WithCancel(ctx)
-	timer := time.NewTimer(tunnelStartTimeout)
-	defer timer.Stop()
-
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				errChan <- fmt.Errorf("tunnel listener panic: %v", r)
-			}
-		}()
-		if err := s.startListenerForClientWithReady(startupCtx, readyChan); err != nil {
-			errChan <- err
-		}
+	defer func() {
+		_ = src.Close()
+		_ = dst.Close()
 	}()
 
-	select {
-	case err := <-errChan:
-		if s.shouldIgnoreListenerError(ctx, err) {
-			return nil
+	results := make(chan error, 2)
+	copyDirection := func(target, source net.Conn) {
+		_, err := io.Copy(target, source)
+		if closeWriter, ok := target.(interface{ CloseWrite() error }); ok {
+			_ = closeWriter.CloseWrite()
 		}
-
-		startErr := s.startError(err)
-		s.emitEvent(EventFailed, startErr)
-		return startErr
-
-	case <-readyChan:
-		s.forwardListenerErrors(startupCtx, errChan)
-
-		if s.config.Tunnel.Type == constants.Http || s.config.Tunnel.Type == constants.Stub {
-			defer cancelStartup()
-			return s.StartHealthCheck(startupCtx)
-		}
-		return nil
-
-	case <-timer.C:
-		cancelStartup()
-		_ = s.closeTransport()
-		startErr := s.startError(fmt.Errorf("timed out waiting for tunnel listener after %s", tunnelStartTimeout))
-		s.emitEvent(EventFailed, startErr)
-		return startErr
-
-	case <-ctx.Done():
-		cancelStartup()
-		_ = s.closeTransport()
-		return nil
-	}
-}
-
-func (s *SshClient) Reconnect() error {
-	// Prevent concurrent reconnects using atomic CAS
-	if !atomic.CompareAndSwapInt32(&s.reconnecting, 0, 1) {
-		return fmt.Errorf("reconnect already in progress")
-	}
-	defer atomic.StoreInt32(&s.reconnecting, 0)
-
-	// Check if we're shutting down
-	if atomic.LoadInt32(&s.shutdown) == 1 {
-		return errClientShuttingDown
+		results <- err
 	}
 
-	// Close existing connections with mutex protection
-	s.mu.Lock()
-	if s.client != nil {
-		if err := s.client.Close(); err != nil {
-			if s.config.Debug {
-				s.logDebug("Failed to close client", err)
-			}
-		}
-		s.client = nil
+	go copyDirection(dst, src)
+	go copyDirection(src, dst)
+
+	firstErr := <-results
+	if firstErr != nil && !errors.Is(firstErr, net.ErrClosed) {
+		_ = src.Close()
+		_ = dst.Close()
 	}
-
-	if s.listener != nil {
-		if err := s.listener.Close(); err != nil {
-			if s.config.Debug {
-				s.logDebug("Failed to close listener", err)
-			}
-		}
-		s.listener = nil
-	}
-	s.mu.Unlock()
-
-	// Create context with timeout for the reconnection attempt
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	// Channel to receive errors from the goroutine
-	errChan := make(chan error, 1)
-	readyChan := make(chan struct{})
-
-	// Start the listener in a goroutine with context
-	go func() {
-		defer func() {
-			if r := recover(); r != nil {
-				select {
-				case errChan <- fmt.Errorf("reconnect panic: %v", r):
-				default:
-					s.reportFatal(fmt.Errorf("reconnect panic: %v", r))
-				}
-			}
-		}()
-		if err := s.startListenerForClientWithReady(ctx, readyChan); err != nil {
-			select {
-			case errChan <- err:
-			case <-ctx.Done():
-			}
-		}
-	}()
-
-	// Wait for either an error, successful connection, or timeout
-	select {
-	case err := <-errChan:
-		return err
-	case <-readyChan:
-		// Connection successful, update health status
-		if s.tui != nil {
-			s.tui.Send(tui.UpdateHealthMsg{
-				Port:    tunnelStatusKey(s.config.Tunnel),
-				Healthy: true,
-			})
-		} else if !s.config.DisableTerminalLogs {
-			// Log successful reconnection when TUI is disabled
-			fmt.Printf("🔄 Tunnel reconnected: %s\n", s.config.GetTunnelAddr())
-		}
-		s.emitEvent(EventReconnected, nil)
-		return nil
-	case <-ctx.Done():
-		return fmt.Errorf("reconnect timeout")
-	}
-}
-
-func (s *SshClient) HealthCheck() error {
-	client := resty.New().
-		SetTimeout(5 * time.Second)
-
-	resp, err := client.R().
-		SetHeader("X-Portr-Ping-Request", "true").
-		Get(s.config.GetTunnelAddr())
-
-	if err != nil {
-		if s.config.Debug {
-			s.logDebug("Health check failed, attempting to reconnect", err)
-		}
-		return err
-	}
-
-	portrError := resp.Header().Get("X-Portr-Error")
-	portrErrorReason := resp.Header().Get("X-Portr-Error-Reason")
-
-	if portrError == "true" && (portrErrorReason == "connection-lost" || portrErrorReason == "unregistered-subdomain") {
-		return fmt.Errorf("unhealthy tunnel")
-	}
-
-	if s.tui != nil {
-		s.tui.Send(tui.UpdateHealthMsg{
-			Port:    tunnelStatusKey(s.config.Tunnel),
-			Healthy: true,
-		})
-	}
-
-	return nil
-}
-
-func (s *SshClient) logDebug(message string, err error) {
-	if !s.config.Debug {
-		return
-	}
-
-	errStr := ""
-	if err != nil {
-		errStr = err.Error()
-	}
-
-	if s.tui != nil {
-		s.tui.Send(tui.AddDebugLogMsg{
-			Time:    time.Now().Format("15:04:05"),
-			Level:   "DEBUG",
-			Message: message,
-			Error:   errStr,
-		})
-	}
+	<-results
 }

--- a/internal/client/ssh/ssh_panic_test.go
+++ b/internal/client/ssh/ssh_panic_test.go
@@ -2,9 +2,9 @@ package ssh
 
 import (
 	"context"
-	"errors"
 	"net"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -50,106 +50,38 @@ func TestGoSafeReportsPanic(t *testing.T) {
 	}
 }
 
-func TestHandleAcceptErrorReportsUnexpectedFailure(t *testing.T) {
+func TestInstallTransportPublishesCompleteTransport(t *testing.T) {
 	listener := &testListener{}
-	client := &SshClient{
-		listener: listener,
-	}
+	transport := &tunnelTransport{listener: listener, remotePort: 23456}
+	client := &SshClient{}
 
-	err := client.handleAcceptError(listener, errors.New("boom"))
-	if err == nil {
-		t.Fatal("expected accept error, got nil")
+	if !client.installTransport(context.Background(), transport) {
+		t.Fatal("expected transport to be installed")
 	}
-	if !strings.Contains(err.Error(), "failed to accept connection: boom") {
-		t.Fatalf("unexpected accept error: %v", err)
+	if client.transport != transport {
+		t.Fatal("expected installed transport to be current")
 	}
-}
-
-func TestHandleAcceptErrorIgnoresReplacedListener(t *testing.T) {
-	oldListener := &testListener{}
-	client := &SshClient{
-		listener: &testListener{},
+	if client.ConfigSnapshot().Tunnel.RemotePort != 23456 {
+		t.Fatal("expected remote port to publish with transport")
 	}
-
-	err := client.handleAcceptError(oldListener, net.ErrClosed)
-	if !errors.Is(err, errClientShuttingDown) {
-		t.Fatalf("expected shutdown sentinel, got %v", err)
+	if err := client.closeTransport(); err != nil {
+		t.Fatalf("close transport: %v", err)
+	}
+	if listener.closeCount != 1 || client.transport != nil {
+		t.Fatalf("expected one close and no current transport, closes=%d", listener.closeCount)
 	}
 }
 
-func TestCloseListenerIfCurrentDoesNotCloseReplacement(t *testing.T) {
-	oldListener := &testListener{}
-	newListener := &testListener{}
-	client := &SshClient{
-		listener: newListener,
+func TestInstallTransportRejectsShutdownRace(t *testing.T) {
+	listener := &testListener{}
+	transport := &tunnelTransport{listener: listener}
+	client := &SshClient{}
+	atomic.StoreInt32(&client.shutdown, 1)
+
+	if client.installTransport(context.Background(), transport) {
+		t.Fatal("transport must not publish after shutdown")
 	}
-
-	client.closeListenerIfCurrent(oldListener)
-
-	if oldListener.closeCount != 0 {
-		t.Fatalf("expected old listener not to be closed, got %d closes", oldListener.closeCount)
-	}
-	if newListener.closeCount != 0 {
-		t.Fatalf("expected replacement listener not to be closed, got %d closes", newListener.closeCount)
-	}
-	if client.listener != newListener {
-		t.Fatal("expected replacement listener to remain active")
-	}
-
-	client.closeListenerIfCurrent(newListener)
-
-	if newListener.closeCount != 1 {
-		t.Fatalf("expected current listener to be closed once, got %d closes", newListener.closeCount)
-	}
-	if client.listener != nil {
-		t.Fatal("expected current listener to be cleared")
-	}
-}
-
-func TestForwardListenerErrorsReportsFatal(t *testing.T) {
-	errCh := make(chan error, 1)
-	fatalCh := make(chan error, 1)
-	client := &SshClient{
-		fatal: func(err error) {
-			fatalCh <- err
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	expected := errors.New("listener failed")
-	client.forwardListenerErrors(ctx, errCh)
-	errCh <- expected
-
-	select {
-	case err := <-fatalCh:
-		if !errors.Is(err, expected) {
-			t.Fatalf("expected %v, got %v", expected, err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for fatal listener error")
-	}
-}
-
-func TestForwardListenerErrorsIgnoresShutdownError(t *testing.T) {
-	errCh := make(chan error, 1)
-	fatalCh := make(chan error, 1)
-	client := &SshClient{
-		fatal: func(err error) {
-			fatalCh <- err
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	client.forwardListenerErrors(ctx, errCh)
-	errCh <- errClientShuttingDown
-
-	select {
-	case err := <-fatalCh:
-		t.Fatalf("unexpected fatal error: %v", err)
-	case <-time.After(100 * time.Millisecond):
+	if client.transport != nil || listener.closeCount != 1 {
+		t.Fatalf("expected rejected transport to close, current=%v closes=%d", client.transport, listener.closeCount)
 	}
 }

--- a/internal/client/ssh/transport.go
+++ b/internal/client/ssh/transport.go
@@ -1,0 +1,193 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/amalshaji/portr/internal/utils"
+	"golang.org/x/crypto/ssh"
+)
+
+type tunnelTransport struct {
+	client     *ssh.Client
+	listener   net.Listener
+	remotePort int
+	closeOnce  sync.Once
+	closeErr   error
+}
+
+func (t *tunnelTransport) Close() error {
+	if t == nil {
+		return nil
+	}
+	t.closeOnce.Do(func() {
+		if t.client != nil {
+			t.closeErr = t.client.Close()
+		}
+		if t.listener != nil {
+			if err := t.listener.Close(); err != nil && t.closeErr == nil {
+				t.closeErr = err
+			}
+		}
+	})
+	return t.closeErr
+}
+
+func (s *SshClient) establishTransport(ctx context.Context) (*tunnelTransport, error) {
+	if atomic.LoadInt32(&s.shutdown) == 1 {
+		return nil, errClientShuttingDown
+	}
+
+	connectionID, err := s.createNewConnection(ctx)
+	if err != nil {
+		return nil, err
+	}
+	sshConfig := &ssh.ClientConfig{
+		User: fmt.Sprintf("%s:%s", connectionID, s.config.SecretKey),
+		Auth: []ssh.AuthMethod{
+			ssh.Password(""),
+		},
+		HostKeyCallback: getHostKeyCallback(s.config.InsecureSkipHostKeyVerification),
+	}
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second, KeepAlive: 15 * time.Second}
+	rawConn, err := dialer.DialContext(ctx, "tcp", s.config.SshUrl)
+	if err != nil {
+		return nil, err
+	}
+	if tcp, ok := rawConn.(*net.TCPConn); ok {
+		_ = tcp.SetKeepAlive(true)
+		_ = tcp.SetKeepAlivePeriod(15 * time.Second)
+		_ = tcp.SetNoDelay(true)
+	}
+
+	handshakeDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = rawConn.Close()
+		case <-handshakeDone:
+		}
+	}()
+	_ = rawConn.SetDeadline(time.Now().Add(10 * time.Second))
+	cc, channels, requests, err := ssh.NewClientConn(rawConn, s.config.SshUrl, sshConfig)
+	close(handshakeDone)
+	_ = rawConn.SetDeadline(time.Time{})
+	if err != nil {
+		_ = rawConn.Close()
+		return nil, err
+	}
+
+	client := ssh.NewClient(cc, channels, requests)
+	setupDone := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = client.Close()
+		case <-setupDone:
+		}
+	}()
+	defer close(setupDone)
+
+	ports := remotePortCandidates(s.tunnelType())
+
+	var listenErr error
+	for _, port := range ports {
+		if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+			_ = client.Close()
+			return nil, errClientShuttingDown
+		}
+		listener, err := client.Listen("tcp", net.JoinHostPort("0.0.0.0", fmt.Sprint(port)))
+		if err != nil {
+			listenErr = err
+			continue
+		}
+		return &tunnelTransport{client: client, listener: listener, remotePort: port}, nil
+	}
+
+	_ = client.Close()
+	if listenErr == nil {
+		listenErr = errors.New("no remote ports available")
+	}
+	return nil, fmt.Errorf("failed to listen on remote endpoint: %w", listenErr)
+}
+
+func remotePortCandidates(tunnelType constants.ConnectionType) []int {
+	if tunnelType == constants.Http {
+		// Keep non-zero ports for compatibility with legacy servers, whose
+		// registration callback observes the requested port before binding.
+		return utils.GenerateRandomHttpPorts()
+	}
+	return utils.GenerateRandomTcpPorts()
+}
+
+func (s *SshClient) installTransport(ctx context.Context, transport *tunnelTransport) bool {
+	s.mu.Lock()
+	if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+		s.mu.Unlock()
+		_ = transport.Close()
+		return false
+	}
+	previous := s.transport
+	s.transport = transport
+	s.config.Tunnel.RemotePort = transport.remotePort
+	s.mu.Unlock()
+	if previous != nil {
+		_ = previous.Close()
+	}
+	return true
+}
+
+func (s *SshClient) clearTransport(transport *tunnelTransport) {
+	s.mu.Lock()
+	if s.transport == transport {
+		s.transport = nil
+	}
+	s.mu.Unlock()
+}
+
+func (s *SshClient) tunnelType() constants.ConnectionType {
+	tunnelType := s.config.Tunnel.Type
+	if tunnelType == constants.Stub {
+		return constants.Http
+	}
+	return tunnelType
+}
+
+func (s *SshClient) serveTransport(ctx context.Context, transport *tunnelTransport) error {
+	localEndpoint := s.config.Tunnel.GetLocalAddr()
+	tunnelType := s.tunnelType()
+	for {
+		remoteConn, err := transport.listener.Accept()
+		if err != nil {
+			if ctx.Err() != nil || atomic.LoadInt32(&s.shutdown) == 1 {
+				return errClientShuttingDown
+			}
+			return fmt.Errorf("failed to accept connection: %w", err)
+		}
+
+		if tunnelType == constants.Http {
+			s.runConnection("http tunnel", func() {
+				s.httpTunnel(remoteConn, localEndpoint)
+			})
+			continue
+		}
+
+		s.runConnection("tcp tunnel", func() {
+			dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			localConn, err := (&net.Dialer{KeepAlive: 30 * time.Second}).DialContext(dialCtx, "tcp", localEndpoint)
+			if err != nil {
+				_ = remoteConn.Close()
+				return
+			}
+			s.tcpTunnel(remoteConn, localConn)
+		})
+	}
+}

--- a/internal/client/ssh/websocket.go
+++ b/internal/client/ssh/websocket.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -14,18 +15,25 @@ import (
 	"time"
 
 	"github.com/amalshaji/portr/internal/client/db"
-	"github.com/amalshaji/portr/internal/utils"
 	"github.com/oklog/ulid/v2"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
 type webSocketFrame struct {
-	Raw           []byte
 	Opcode        byte
 	IsFinal       bool
 	Payload       []byte
 	PayloadLength int
+}
+
+type webSocketFrameHeader struct {
+	raw           []byte
+	opcode        byte
+	isFinal       bool
+	masked        bool
+	maskingKey    [4]byte
+	payloadLength uint64
 }
 
 func isWebSocketUpgrade(request *http.Request) bool {
@@ -72,7 +80,7 @@ func websocketOpcodeName(opcode byte) string {
 	}
 }
 
-func readWebSocketFrame(reader io.Reader) (*webSocketFrame, error) {
+func readWebSocketFrameHeader(reader io.Reader) (*webSocketFrameHeader, error) {
 	header := make([]byte, 2)
 	if _, err := io.ReadFull(reader, header); err != nil {
 		return nil, err
@@ -82,7 +90,7 @@ func readWebSocketFrame(reader io.Reader) (*webSocketFrame, error) {
 	isFinal := header[0]&0x80 != 0
 	opcode := header[0] & 0x0F
 
-	payloadLength := int64(header[1] & 0x7F)
+	payloadLength := uint64(header[1] & 0x7F)
 	switch payloadLength {
 	case 126:
 		extended := make([]byte, 2)
@@ -90,47 +98,35 @@ func readWebSocketFrame(reader io.Reader) (*webSocketFrame, error) {
 			return nil, err
 		}
 		raw = append(raw, extended...)
-		payloadLength = int64(binary.BigEndian.Uint16(extended))
+		payloadLength = uint64(binary.BigEndian.Uint16(extended))
 	case 127:
 		extended := make([]byte, 8)
 		if _, err := io.ReadFull(reader, extended); err != nil {
 			return nil, err
 		}
 		raw = append(raw, extended...)
-		payloadLength = int64(binary.BigEndian.Uint64(extended))
+		payloadLength = binary.BigEndian.Uint64(extended)
+		if payloadLength&(uint64(1)<<63) != 0 {
+			return nil, errors.New("invalid websocket payload length")
+		}
 	}
 
 	masked := header[1]&0x80 != 0
-	var maskingKey []byte
+	var maskingKey [4]byte
 	if masked {
-		maskingKey = make([]byte, 4)
-		if _, err := io.ReadFull(reader, maskingKey); err != nil {
+		if _, err := io.ReadFull(reader, maskingKey[:]); err != nil {
 			return nil, err
 		}
-		raw = append(raw, maskingKey...)
+		raw = append(raw, maskingKey[:]...)
 	}
 
-	payload := make([]byte, payloadLength)
-	if payloadLength > 0 {
-		if _, err := io.ReadFull(reader, payload); err != nil {
-			return nil, err
-		}
-		raw = append(raw, payload...)
-	}
-
-	decodedPayload := append([]byte{}, payload...)
-	if masked {
-		for idx := range decodedPayload {
-			decodedPayload[idx] ^= maskingKey[idx%4]
-		}
-	}
-
-	return &webSocketFrame{
-		Raw:           raw,
-		Opcode:        opcode,
-		IsFinal:       isFinal,
-		Payload:       decodedPayload,
-		PayloadLength: len(decodedPayload),
+	return &webSocketFrameHeader{
+		raw:           raw,
+		opcode:        opcode,
+		isFinal:       isFinal,
+		masked:        masked,
+		maskingKey:    maskingKey,
+		payloadLength: payloadLength,
 	}, nil
 }
 
@@ -143,6 +139,10 @@ func isIgnorableWebSocketError(err error) bool {
 }
 
 func (s *SshClient) logWebSocketSession(handshakeRequestID string, request *http.Request, response *http.Response) string {
+	return s.logWebSocketSessionWithID(ulid.Make().String(), handshakeRequestID, request, response)
+}
+
+func (s *SshClient) logWebSocketSessionWithID(sessionID, handshakeRequestID string, request *http.Request, response *http.Response) string {
 	requestHeadersBytes, err := json.Marshal(request.Header)
 	if err != nil {
 		if s.config.Debug {
@@ -161,7 +161,7 @@ func (s *SshClient) logWebSocketSession(handshakeRequestID string, request *http
 
 	now := time.Now().UTC()
 	session := db.WebSocketSession{
-		ID:                 ulid.Make().String(),
+		ID:                 sessionID,
 		HandshakeRequestID: handshakeRequestID,
 		Subdomain:          s.config.Tunnel.Subdomain,
 		Localport:          s.config.Tunnel.Port,
@@ -259,17 +259,79 @@ func (s *SshClient) closeWebSocketSession(sessionID string, err error) {
 
 func (s *SshClient) proxyWebSocketFrames(sessionID string, direction string, reader io.Reader, writer net.Conn) error {
 	for {
-		frame, err := readWebSocketFrame(reader)
+		frame, err := forwardWebSocketFrame(reader, writer)
 		if err != nil {
 			return err
 		}
+		if sessionID != "" {
+			s.submitCapture(websocketEventCaptureTask{sessionID: sessionID, direction: direction, frame: frame})
+		}
+	}
+}
 
-		if _, err := writer.Write(frame.Raw); err != nil {
+func forwardWebSocketFrame(reader io.Reader, writer io.Writer) (*webSocketFrame, error) {
+	header, err := readWebSocketFrameHeader(reader)
+	if err != nil {
+		return nil, err
+	}
+	if header.payloadLength > uint64(^uint(0)>>1) {
+		return nil, errors.New("websocket payload length exceeds platform capacity")
+	}
+	if err := writeAll(writer, header.raw); err != nil {
+		return nil, err
+	}
+
+	captureLength := int(header.payloadLength)
+	if captureLength > maxCapturedBodyBytes {
+		captureLength = maxCapturedBodyBytes
+	}
+	captured := make([]byte, 0, captureLength)
+	buffer := make([]byte, 32*1024)
+	remaining := header.payloadLength
+	var payloadOffset uint64
+	for remaining > 0 {
+		chunkLength := uint64(len(buffer))
+		if remaining < chunkLength {
+			chunkLength = remaining
+		}
+		chunk := buffer[:int(chunkLength)]
+		if _, err := io.ReadFull(reader, chunk); err != nil {
+			return nil, err
+		}
+		if err := writeAll(writer, chunk); err != nil {
+			return nil, err
+		}
+		for index := 0; index < len(chunk) && len(captured) < captureLength; index++ {
+			value := chunk[index]
+			if header.masked {
+				value ^= header.maskingKey[(payloadOffset+uint64(index))%4]
+			}
+			captured = append(captured, value)
+		}
+		payloadOffset += chunkLength
+		remaining -= chunkLength
+	}
+
+	return &webSocketFrame{
+		Opcode:        header.opcode,
+		IsFinal:       header.isFinal,
+		Payload:       captured,
+		PayloadLength: int(header.payloadLength),
+	}, nil
+}
+
+func writeAll(writer io.Writer, payload []byte) error {
+	for len(payload) > 0 {
+		written, err := writer.Write(payload)
+		if err != nil {
 			return err
 		}
-
-		s.recordWebSocketEvent(sessionID, direction, frame)
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		payload = payload[written:]
 	}
+	return nil
 }
 
 func (s *SshClient) websocketTunnel(sessionID string, clientReader io.Reader, serverConn net.Conn, serverReader io.Reader, clientConn net.Conn) {
@@ -312,7 +374,11 @@ func (s *SshClient) websocketTunnel(sessionID string, clientReader io.Reader, se
 
 	completed.Wait()
 	closeAll()
-	s.closeWebSocketSession(sessionID, firstErr)
+	if sessionID != "" {
+		captureCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		s.submitCaptureContext(captureCtx, websocketCloseCaptureTask{sessionID: sessionID, err: firstErr})
+	}
 }
 
 func (s *SshClient) handleWebSocketRequest(
@@ -322,23 +388,11 @@ func (s *SshClient) handleWebSocketRequest(
 	request *http.Request,
 	localEndpoint string,
 ) error {
-	dst, err := net.Dial("tcp", localEndpoint)
+	dialCtx, cancelDial := context.WithTimeout(request.Context(), 5*time.Second)
+	defer cancelDial()
+	dst, err := (&net.Dialer{KeepAlive: 30 * time.Second}).DialContext(dialCtx, "tcp", localEndpoint)
 	if err != nil {
-		htmlContent := []byte(utils.LocalServerNotOnline(localEndpoint))
-		response := &http.Response{
-			Status:        "503 Service Unavailable",
-			StatusCode:    http.StatusServiceUnavailable,
-			Proto:         "HTTP/1.1",
-			ProtoMajor:    1,
-			ProtoMinor:    1,
-			Header:        http.Header{},
-			ContentLength: int64(len(htmlContent)),
-			Body:          io.NopCloser(bytes.NewReader(htmlContent)),
-		}
-		response.Header.Set("Content-Type", "text/html")
-		response.Header.Set("X-Portr-Error", "true")
-		response.Header.Set("X-Portr-Error-Reason", "local-server-not-online")
-		if writeErr := response.Write(srcWriter); writeErr != nil {
+		if writeErr := writeLocalServerUnavailable(srcWriter, localEndpoint); writeErr != nil {
 			return writeErr
 		}
 		return srcWriter.Flush()
@@ -354,33 +408,35 @@ func (s *SshClient) handleWebSocketRequest(
 	dstReader := bufio.NewReader(dst)
 	dstWriter := bufio.NewWriter(dst)
 
-	requestBody, err := io.ReadAll(request.Body)
-	if err != nil {
-		return err
+	requestCapture := &bodyCapture{}
+	if request.Body != nil {
+		request.Body = &capturingReadCloser{ReadCloser: request.Body, capture: requestCapture, onDone: func() {}}
+		defer request.Body.Close()
 	}
-	_ = request.Body.Close()
-	request.Body = io.NopCloser(bytes.NewBuffer(requestBody))
 
 	if err := request.Write(dstWriter); err != nil {
+		_ = writeLocalServerUnavailable(srcWriter, localEndpoint)
+		_ = srcWriter.Flush()
 		return err
 	}
+	requestBody := requestCapture.Bytes()
 	if err := dstWriter.Flush(); err != nil {
+		_ = writeLocalServerUnavailable(srcWriter, localEndpoint)
+		_ = srcWriter.Flush()
 		return err
 	}
 
 	response, err := http.ReadResponse(dstReader, request)
 	if err != nil {
+		_ = writeLocalServerUnavailable(srcWriter, localEndpoint)
+		_ = srcWriter.Flush()
 		return err
 	}
 
 	if response.StatusCode != http.StatusSwitchingProtocols {
-		responseBody, err := io.ReadAll(response.Body)
-		if err != nil {
-			return err
-		}
-		_ = response.Body.Close()
-		response.Body = io.NopCloser(bytes.NewBuffer(responseBody))
-
+		responseCapture := &bodyCapture{}
+		response.Body = &capturingReadCloser{ReadCloser: response.Body, capture: responseCapture, onDone: func() {}}
+		defer response.Body.Close()
 		if err := response.Write(srcWriter); err != nil {
 			return err
 		}
@@ -388,7 +444,17 @@ func (s *SshClient) handleWebSocketRequest(
 			return err
 		}
 
-		s.logHttpRequest(ulid.Make().String(), request, requestBody, response, responseBody, 0)
+		responseBody := responseCapture.Bytes()
+		requestID := ulid.Make().String()
+		s.submitCapture(httpCaptureTask{
+			id:           requestID,
+			request:      request,
+			requestBody:  requestBody,
+			response:     response,
+			responseBody: responseBody,
+			bytesIn:      requestCapture.Size(),
+			bytesOut:     responseCapture.Size(),
+		})
 		return nil
 	}
 
@@ -400,8 +466,21 @@ func (s *SshClient) handleWebSocketRequest(
 	}
 
 	handshakeRequestID := ulid.Make().String()
-	s.logHttpRequest(handshakeRequestID, request, requestBody, response, nil, 0)
-	sessionID := s.logWebSocketSession(handshakeRequestID, request, response)
+	sessionID := ulid.Make().String()
+	if !s.submitCapture(websocketOpenCaptureTask{
+		handshake: httpCaptureTask{
+			id:          handshakeRequestID,
+			request:     request,
+			requestBody: requestBody,
+			response:    response,
+			bytesIn:     requestCapture.Size(),
+		},
+		sessionID: sessionID,
+		request:   request,
+		response:  response,
+	}) {
+		sessionID = ""
+	}
 
 	clientBuffered := drainBufferedBytes(srcReader)
 	serverBuffered := drainBufferedBytes(dstReader)

--- a/internal/server/cron/cron.go
+++ b/internal/server/cron/cron.go
@@ -5,20 +5,24 @@ import (
 	"time"
 
 	"github.com/amalshaji/portr/internal/server/config"
-	"github.com/amalshaji/portr/internal/server/db"
 	"github.com/amalshaji/portr/internal/server/service"
 	"github.com/charmbracelet/log"
+	"github.com/go-resty/resty/v2"
 )
 
 type Cron struct {
-	db         *db.Db
 	config     *config.Config
 	service    *service.Service
 	cancelFunc context.CancelFunc
+	httpClient *resty.Client
 }
 
-func New(db *db.Db, config *config.Config, service *service.Service) *Cron {
-	return &Cron{db: db, config: config, service: service}
+func New(config *config.Config, service *service.Service) *Cron {
+	return &Cron{
+		config:     config,
+		service:    service,
+		httpClient: resty.New().SetTimeout(5 * time.Second),
+	}
 }
 
 func (c *Cron) Start() {
@@ -33,7 +37,7 @@ func (c *Cron) Start() {
 				select {
 				case <-ticker.C:
 					log.Debug("Running cron job", "name", job.Name)
-					job.Function(c)
+					job.Function(ctx, c)
 				case <-ctx.Done():
 					ticker.Stop()
 					return
@@ -44,5 +48,7 @@ func (c *Cron) Start() {
 }
 
 func (c *Cron) Shutdown() {
-	c.cancelFunc()
+	if c.cancelFunc != nil {
+		c.cancelFunc()
+	}
 }

--- a/internal/server/cron/ping.go
+++ b/internal/server/cron/ping.go
@@ -2,8 +2,10 @@ package cron
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/amalshaji/portr/internal/server/db"
@@ -11,35 +13,56 @@ import (
 	"github.com/go-resty/resty/v2"
 )
 
-var ErrInactiveTunnel = fmt.Errorf("inactive tunnel")
+var ErrInactiveTunnel = errors.New("inactive tunnel")
 
-func (c *Cron) pingHttpConnection(connection db.Connection) error {
-	client := resty.New().R()
-	resp, err := client.SetHeader("X-Portr-Ping-Request", "true").Get(c.config.HttpTunnelUrl(*connection.Subdomain))
-	// don't care about the error, just care about the response
-	if err != nil {
-		return nil
+const maxConcurrentPings = 16
+
+func (c *Cron) pingHttpConnection(ctx context.Context, connection db.Connection) error {
+	if connection.Subdomain == nil {
+		return ErrInactiveTunnel
 	}
-	if resp.StatusCode() == 404 && resp.Header().Get("X-Portr-Error") == "true" {
+	client := c.httpClient
+	if client == nil {
+		client = resty.New().SetTimeout(5 * time.Second)
+	}
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeader("X-Portr-Ping-Request", "true").
+		Get(c.config.HttpTunnelUrl(*connection.Subdomain))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() == 404 &&
+		resp.Header().Get("X-Portr-Error") == "true" &&
+		resp.Header().Get("X-Portr-Error-Reason") == "unregistered-subdomain" {
 		return ErrInactiveTunnel
 	}
 	return nil
 }
 
-func (c *Cron) pingTcpConnection(connection db.Connection) error {
-	timeout := time.Second * 5
-
-	conn, err := net.DialTimeout("tcp", c.config.TcpTunnelUrl(*connection.Port), timeout)
-	if err != nil {
+func (c *Cron) pingTcpConnection(ctx context.Context, connection db.Connection) error {
+	if connection.Port == nil {
 		return ErrInactiveTunnel
 	}
-	defer conn.Close()
+	dialCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	conn, err := (&net.Dialer{}).DialContext(dialCtx, "tcp", c.config.TcpTunnelUrl(*connection.Port))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
 	return nil
 }
 
 func (c *Cron) pingActiveConnections(ctx context.Context) {
-	var err error
-	connections := c.service.GetAllActiveConnections(ctx)
+	c.pingActiveConnectionsWithProbe(ctx, c.probeConnection)
+}
+
+func (c *Cron) pingActiveConnectionsWithProbe(
+	ctx context.Context,
+	probe func(context.Context, db.Connection) error,
+) {
+	connections, err := c.service.GetAllActiveConnections(ctx)
 	if err != nil {
 		log.Error("Error getting active connections", "error", err)
 		return
@@ -47,17 +70,46 @@ func (c *Cron) pingActiveConnections(ctx context.Context) {
 
 	log.Info("Pinging active connections", "count", len(connections))
 
+	semaphore := make(chan struct{}, maxConcurrentPings)
+	var wg sync.WaitGroup
+connectionLoop:
 	for _, connection := range connections {
+		if ctx.Err() != nil {
+			break
+		}
+		select {
+		case semaphore <- struct{}{}:
+		case <-ctx.Done():
+			break connectionLoop
+		}
+		wg.Add(1)
 		go func(connection db.Connection) {
-			if connection.Type == "http" {
-				err = c.pingHttpConnection(connection)
-			} else {
-				err = c.pingTcpConnection(connection)
-			}
+			defer wg.Done()
+			defer func() { <-semaphore }()
 
-			if err != nil {
-				c.service.MarkConnectionAsClosed(ctx, connection.ID)
+			pingErr := probe(ctx, connection)
+
+			switch {
+			case pingErr == nil:
+			case errors.Is(pingErr, ErrInactiveTunnel):
+				if err := c.service.MarkConnectionAsClosed(ctx, connection.ID); err != nil {
+					log.Error("Failed to close inactive connection", "connection_id", connection.ID, "error", err)
+				}
+			default:
+				log.Warn("Connection reconciliation probe failed", "connection_id", connection.ID, "error", pingErr)
 			}
 		}(connection)
+	}
+	wg.Wait()
+}
+
+func (c *Cron) probeConnection(ctx context.Context, connection db.Connection) error {
+	switch connection.Type {
+	case "http":
+		return c.pingHttpConnection(ctx, connection)
+	case "tcp":
+		return c.pingTcpConnection(ctx, connection)
+	default:
+		return fmt.Errorf("unsupported connection type %q", connection.Type)
 	}
 }

--- a/internal/server/cron/ping_test.go
+++ b/internal/server/cron/ping_test.go
@@ -1,0 +1,91 @@
+package cron
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	serverdb "github.com/amalshaji/portr/internal/server/db"
+	"github.com/amalshaji/portr/internal/server/service"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestPingActiveConnectionsIsBoundedAndIsolatesFailures(t *testing.T) {
+	database, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := database.AutoMigrate(&serverdb.Connection{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	connections := make([]serverdb.Connection, 0, 42)
+	for index := 0; index < 40; index++ {
+		connections = append(connections, serverdb.Connection{ID: fmt.Sprintf("healthy-%d", index), Type: "http", Status: "active"})
+	}
+	connections = append(connections,
+		serverdb.Connection{ID: "inactive", Type: "http", Status: "active"},
+		serverdb.Connection{ID: "transient", Type: "http", Status: "active"},
+	)
+	if err := database.Create(&connections).Error; err != nil {
+		t.Fatalf("create connections: %v", err)
+	}
+
+	var current atomic.Int32
+	var maximum atomic.Int32
+	cron := &Cron{
+		service: service.New(&serverdb.Db{Conn: database}),
+	}
+	probe := func(_ context.Context, connection serverdb.Connection) error {
+		active := current.Add(1)
+		defer current.Add(-1)
+		for {
+			observed := maximum.Load()
+			if active <= observed || maximum.CompareAndSwap(observed, active) {
+				break
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+		switch connection.ID {
+		case "inactive":
+			return ErrInactiveTunnel
+		case "transient":
+			return errors.New("temporary network failure")
+		default:
+			return nil
+		}
+	}
+
+	cron.pingActiveConnectionsWithProbe(context.Background(), probe)
+	if got := maximum.Load(); got > maxConcurrentPings {
+		t.Fatalf("expected at most %d concurrent probes, got %d", maxConcurrentPings, got)
+	}
+
+	var inactive serverdb.Connection
+	if err := database.First(&inactive, "id = ?", "inactive").Error; err != nil {
+		t.Fatalf("load inactive connection: %v", err)
+	}
+	if inactive.Status != "closed" {
+		t.Fatalf("expected inactive connection to close, got %q", inactive.Status)
+	}
+	var transient serverdb.Connection
+	if err := database.First(&transient, "id = ?", "transient").Error; err != nil {
+		t.Fatalf("load transient connection: %v", err)
+	}
+	if transient.Status != "active" {
+		t.Fatalf("expected transient failure to remain active, got %q", transient.Status)
+	}
+}
+
+func TestPingRejectsMissingRouteMetadata(t *testing.T) {
+	cron := &Cron{}
+	if !errors.Is(cron.pingHttpConnection(context.Background(), serverdb.Connection{}), ErrInactiveTunnel) {
+		t.Fatal("missing HTTP subdomain should be inactive")
+	}
+	if !errors.Is(cron.pingTcpConnection(context.Background(), serverdb.Connection{}), ErrInactiveTunnel) {
+		t.Fatal("missing TCP port should be inactive")
+	}
+}

--- a/internal/server/cron/tasks.go
+++ b/internal/server/cron/tasks.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-type CronFunc func(*Cron)
+type CronFunc func(context.Context, *Cron)
 
 type Job struct {
 	Name     string
@@ -17,8 +17,8 @@ var crons = []Job{
 	{
 		Name:     "Ping active connections",
 		Interval: 10 * time.Second,
-		Function: func(c *Cron) {
-			c.pingActiveConnections(context.Background())
+		Function: func(ctx context.Context, c *Cron) {
+			c.pingActiveConnections(ctx)
 		},
 	},
 }

--- a/internal/server/proxy/proxy.go
+++ b/internal/server/proxy/proxy.go
@@ -53,12 +53,16 @@ func New(config *config.Config) *Proxy {
 	}
 	p.server = &http.Server{
 		Addr:              p.GetServerAddr(),
-		Handler:           http.HandlerFunc(p.handleRequest),
+		Handler:           p,
 		ReadHeaderTimeout: 10 * time.Second,
 		IdleTimeout:       90 * time.Second,
 		MaxHeaderBytes:    1 << 20,
 	}
 	return p
+}
+
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	p.handleRequest(w, r)
 }
 
 // AddBackend adds a backend to a subdomain, creating the subdomain entry if needed.

--- a/internal/server/proxy/proxy.go
+++ b/internal/server/proxy/proxy.go
@@ -1,17 +1,16 @@
 package proxy
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
-	"maps"
-	"slices"
-
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -21,11 +20,12 @@ import (
 )
 
 type Proxy struct {
-	config *config.Config
-	routes map[string][]string // subdomain -> list of backends (host:port)
-	rrIdx  map[string]int      // round-robin index per subdomain
-	lock   sync.RWMutex
-	server *http.Server
+	config    *config.Config
+	routes    map[string][]string // subdomain -> list of backends (host:port)
+	rrIdx     map[string]int      // round-robin index per subdomain
+	lock      sync.RWMutex
+	server    *http.Server
+	transport *http.Transport
 }
 
 func (p *Proxy) GetServerAddr() string {
@@ -33,56 +33,32 @@ func (p *Proxy) GetServerAddr() string {
 }
 
 func New(config *config.Config) *Proxy {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     false,
+		MaxIdleConns:          256,
+		MaxIdleConnsPerHost:   64,
+		IdleConnTimeout:       90 * time.Second,
+		ExpectContinueTimeout: time.Second,
+	}
 	p := &Proxy{
-		config: config,
-		routes: make(map[string][]string),
-		rrIdx:  make(map[string]int),
-		server: nil,
+		config:    config,
+		routes:    make(map[string][]string),
+		rrIdx:     make(map[string]int),
+		transport: transport,
 	}
-	p.server = &http.Server{Addr: p.GetServerAddr()}
+	p.server = &http.Server{
+		Addr:              p.GetServerAddr(),
+		Handler:           http.HandlerFunc(p.handleRequest),
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       90 * time.Second,
+		MaxHeaderBytes:    1 << 20,
+	}
 	return p
-}
-
-// GetRoute is kept for backward compatibility and returns the first backend if available.
-func (p *Proxy) GetRoute(src string) (string, error) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	backends, ok := p.routes[src]
-	if !ok || len(backends) == 0 {
-		log.Error("Route not found", "subdomain", src)
-		return "", fmt.Errorf("route not found")
-	}
-	return backends[0], nil
-}
-
-// AddRoute is kept for backward compatibility and only allows adding a new subdomain once with a single backend.
-func (p *Proxy) AddRoute(src, dst string) error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	_, ok := p.routes[src]
-	if ok {
-		log.Error("Route already added", "subdomain", src)
-		return fmt.Errorf("route already added")
-	}
-	p.routes[src] = []string{dst}
-	p.rrIdx[src] = 0
-	return nil
-}
-
-// RemoveRoute removes all backends for the subdomain.
-func (p *Proxy) RemoveRoute(src string) error {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	_, ok := p.routes[src]
-	if !ok {
-		log.Error("Route not found", "subdomain", src)
-		return fmt.Errorf("route not found")
-	}
-	delete(p.routes, src)
-	delete(p.rrIdx, src)
-	return nil
 }
 
 // AddBackend adds a backend to a subdomain, creating the subdomain entry if needed.
@@ -137,22 +113,6 @@ func (p *Proxy) RemoveBackend(src, dst string) error {
 	return nil
 }
 
-// GetNextBackend returns the next backend target for the subdomain using round-robin.
-func (p *Proxy) GetNextBackend(src string) (string, error) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	list, ok := p.routes[src]
-	if !ok || len(list) == 0 {
-		log.Error("Route not found", "subdomain", src)
-		return "", fmt.Errorf("route not found")
-	}
-	i := p.rrIdx[src]
-	target := list[i]
-	p.rrIdx[src] = (i + 1) % len(list)
-	return target, nil
-}
-
 func unregisteredSubdomainError(w http.ResponseWriter, subdomain string) {
 	w.Header().Set("X-Portr-Error", "true")
 	w.Header().Set("X-Portr-Error-Reason", "unregistered-subdomain")
@@ -167,154 +127,110 @@ func connectionLostError(w http.ResponseWriter) {
 	w.Write([]byte(utils.ConnectionLost()))
 }
 
-func (p *Proxy) reverseProxy(target *url.URL, subdomain, backend string) *httputil.ReverseProxy {
-	rp := httputil.NewSingleHostReverseProxy(target)
-	// Used for upgraded (WebSocket) connections. Backend lifecycle is owned
-	// solely by the SSH layer (added on tunnel connect, removed on tunnel
-	// disconnect), so the proxy never mutates the route pool here. An EOF after
-	// a successful upgrade is a normal stream close, not a failure.
-	rp.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
-		if !errors.Is(err, io.EOF) {
-			log.Error("Error from proxy", "error", err, "subdomain", subdomain, "backend", backend)
-		}
-		connectionLostError(res)
-	}
-	return rp
-}
-
 func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	subdomain := p.config.ExtractSubdomain(r.Host)
-	// For upgraded connections (e.g., WebSocket), don't retry — stream directly
-	if isUpgradeRequest(r) {
-		target, err := p.GetNextBackend(subdomain)
-		if err != nil {
-			unregisteredSubdomainError(w, subdomain)
-			return
-		}
-		proxy := p.reverseProxy(&url.URL{Scheme: "http", Host: target}, subdomain, target)
-		proxy.ServeHTTP(w, r)
-		return
-	}
-
-	// Buffer the request body so we can retry on transport errors
-	var bodyBytes []byte
-	if r.Body != nil {
-		var err error
-		bodyBytes, err = io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "failed to read request body", http.StatusBadRequest)
-			return
-		}
-		// Reset original body for safety
-		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-	}
-
-	// Determine max attempts (bounded by number of backends and a small constant)
-	maxAttempts := p.backendCount(subdomain)
-	if maxAttempts == 0 {
+	backends, err := p.nextBackends(subdomain, 3)
+	if err != nil {
 		unregisteredSubdomainError(w, subdomain)
 		return
 	}
-	if maxAttempts > 3 {
-		maxAttempts = 3
+	if isUpgradeRequest(r) || !isReplaySafe(r) {
+		backends = backends[:1]
 	}
 
-	for attempt := 0; attempt < maxAttempts; attempt++ {
-		target, err := p.GetNextBackend(subdomain)
-		if err != nil {
-			unregisteredSubdomainError(w, subdomain)
-			return
+	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: "http", Host: backends[0]})
+	proxy.Transport = &backendTransport{
+		base:      p.transport,
+		backends:  backends,
+		subdomain: subdomain,
+	}
+	proxy.ErrorHandler = func(res http.ResponseWriter, _ *http.Request, err error) {
+		if !errors.Is(err, io.EOF) {
+			log.Error("Error from proxy", "error", err, "subdomain", subdomain)
 		}
+		connectionLostError(res)
+	}
+	proxy.ServeHTTP(w, r)
+}
 
-		// Build reverse proxy for this target with an error handler that signals retry
-		failed := false
-		rp := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: "http", Host: target})
-		rp.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
-			// Don't evict — the backend may just be transiently failing while the
-			// tunnel is healthy. Round-robin to the next backend for this request;
-			// the SSH layer removes backends when the tunnel actually drops.
-			log.Error("Error from proxy (will retry)", "error", err, "subdomain", subdomain, "backend", target)
-			failed = true
-			// Do not write to client here; allow retry loop to proceed
-		}
+func (p *Proxy) nextBackends(src string, limit int) ([]string, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
 
-		// Buffer writes so we only send to client on successful attempt
-		bw := newBufferResponseWriter()
-
-		// Clone request and reset body for this attempt
-		req2 := r.Clone(r.Context())
-		if bodyBytes != nil {
-			req2.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-		}
-
-		rp.ServeHTTP(bw, req2)
-
-		if !failed {
-			bw.flushTo(w)
-			return
-		}
-		// else try next backend
+	list := p.routes[src]
+	if len(list) == 0 {
+		return nil, fmt.Errorf("route not found")
+	}
+	if limit > len(list) {
+		limit = len(list)
 	}
 
-	// All attempts failed
-	connectionLostError(w)
-}
-
-// bufferResponseWriter buffers response status, headers, and body until flushed.
-type bufferResponseWriter struct {
-	header      http.Header
-	body        bytes.Buffer
-	statusCode  int
-	wroteHeader bool
-}
-
-func newBufferResponseWriter() *bufferResponseWriter {
-	return &bufferResponseWriter{header: make(http.Header), statusCode: http.StatusOK}
-}
-
-func (b *bufferResponseWriter) Header() http.Header { return b.header }
-
-func (b *bufferResponseWriter) WriteHeader(status int) {
-	if b.wroteHeader {
-		return
+	start := p.rrIdx[src] % len(list)
+	result := make([]string, 0, limit)
+	for offset := 0; offset < limit; offset++ {
+		result = append(result, list[(start+offset)%len(list)])
 	}
-	b.wroteHeader = true
-	b.statusCode = status
+	p.rrIdx[src] = (start + 1) % len(list)
+	return result, nil
 }
 
-func (b *bufferResponseWriter) Write(p []byte) (int, error) {
-	if !b.wroteHeader {
-		b.WriteHeader(http.StatusOK)
+func isReplaySafe(r *http.Request) bool {
+	if r.Body != nil && r.Body != http.NoBody {
+		return false
 	}
-	return b.body.Write(p)
-}
-
-func (b *bufferResponseWriter) flushTo(w http.ResponseWriter) {
-	// Copy headers
-	dst := w.Header()
-	maps.Copy(dst, b.header)
-	w.WriteHeader(b.statusCode)
-	_, _ = w.Write(b.body.Bytes())
-}
-
-func isUpgradeRequest(r *http.Request) bool {
-	if r.Header.Get("Connection") == "Upgrade" || r.Header.Get("Upgrade") != "" {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
 		return true
+	default:
+		return false
+	}
+}
+
+type backendTransport struct {
+	base      http.RoundTripper
+	backends  []string
+	subdomain string
+}
+
+func (t *backendTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	var lastErr error
+	for attempt, backend := range t.backends {
+		outbound := request.Clone(request.Context())
+		outboundURL := *request.URL
+		outboundURL.Scheme = "http"
+		outboundURL.Host = backend
+		outbound.URL = &outboundURL
+
+		response, err := t.base.RoundTrip(outbound)
+		if err == nil {
+			return response, nil
+		}
+		if response != nil && response.Body != nil {
+			_ = response.Body.Close()
+		}
+		lastErr = err
+		log.Warn("Tunnel backend transport failed", "error", err, "subdomain", t.subdomain, "backend", backend, "attempt", attempt+1)
+		if request.Context().Err() != nil {
+			break
+		}
+	}
+	return nil, lastErr
+}
+
+func isUpgradeRequest(request *http.Request) bool {
+	if request.Header.Get("Upgrade") == "" {
+		return false
+	}
+	for _, token := range strings.Split(request.Header.Get("Connection"), ",") {
+		if strings.EqualFold(strings.TrimSpace(token), "upgrade") {
+			return true
+		}
 	}
 	return false
 }
 
-// backendCount returns the number of backends for a subdomain.
-func (p *Proxy) backendCount(src string) int {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-	return len(p.routes[src])
-}
-
 func (p *Proxy) Start() {
 	log.Info("Starting proxy server", "port", p.GetServerAddr())
-
-	http.HandleFunc("/", p.handleRequest)
 
 	if err := p.server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatal("Failed to start proxy server", "error", err)
@@ -331,6 +247,7 @@ func (p *Proxy) Shutdown(_ context.Context) {
 		log.Error("Failed to stop proxy server", "error", err)
 		return
 	}
+	p.transport.CloseIdleConnections()
 
 	log.Info("Stopped proxy server")
 }

--- a/internal/server/proxy/proxy_pool_test.go
+++ b/internal/server/proxy/proxy_pool_test.go
@@ -2,11 +2,14 @@ package proxy
 
 import (
 	"bufio"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	serverConfig "github.com/amalshaji/portr/internal/server/config"
 )
@@ -27,12 +30,12 @@ func TestProxy_AddBackendAndRoundRobin(t *testing.T) {
 	}
 
 	// Round robin over three backends
-	got1, _ := p.GetNextBackend(sub)
-	got2, _ := p.GetNextBackend(sub)
-	got3, _ := p.GetNextBackend(sub)
-	got4, _ := p.GetNextBackend(sub)
+	got1, _ := p.nextBackends(sub, 1)
+	got2, _ := p.nextBackends(sub, 1)
+	got3, _ := p.nextBackends(sub, 1)
+	got4, _ := p.nextBackends(sub, 1)
 
-	if got1 != "127.0.0.1:1000" || got2 != "127.0.0.1:1001" || got3 != "127.0.0.1:1002" || got4 != "127.0.0.1:1000" {
+	if got1[0] != "127.0.0.1:1000" || got2[0] != "127.0.0.1:1001" || got3[0] != "127.0.0.1:1002" || got4[0] != "127.0.0.1:1000" {
 		t.Fatalf("round robin order unexpected: %v, %v, %v, %v", got1, got2, got3, got4)
 	}
 }
@@ -49,11 +52,11 @@ func TestProxy_RemoveBackend(t *testing.T) {
 		t.Fatalf("remove backend: %v", err)
 	}
 
-	got, err := p.GetNextBackend(sub)
+	got, err := p.nextBackends(sub, 1)
 	if err != nil {
 		t.Fatalf("get next backend: %v", err)
 	}
-	if got != "127.0.0.1:1001" {
+	if got[0] != "127.0.0.1:1001" {
 		t.Fatalf("expected remaining backend, got %v", got)
 	}
 
@@ -61,7 +64,7 @@ func TestProxy_RemoveBackend(t *testing.T) {
 	if err := p.RemoveBackend(sub, "127.0.0.1:1001"); err != nil {
 		t.Fatalf("remove last backend: %v", err)
 	}
-	if _, err := p.GetNextBackend(sub); err == nil {
+	if _, err := p.nextBackends(sub, 1); err == nil {
 		t.Fatalf("expected error after removing all backends")
 	}
 }
@@ -114,7 +117,7 @@ func TestReverseProxy_KeepsBackendOnNormalClose(t *testing.T) {
 
 	sendUpgrade(t, strings.TrimPrefix(srv.URL, "http://"), "sub.example.com")
 
-	if _, err := p.GetNextBackend("sub"); err != nil {
+	if _, err := p.nextBackends("sub", 1); err != nil {
 		t.Fatalf("backend evicted on normal close: %v", err)
 	}
 }
@@ -136,7 +139,203 @@ func TestReverseProxy_DoesNotEvictUnreachableBackend(t *testing.T) {
 
 	sendUpgrade(t, strings.TrimPrefix(srv.URL, "http://"), "sub.example.com")
 
-	if _, err := p.GetNextBackend("sub"); err != nil {
+	if _, err := p.nextBackends("sub", 1); err != nil {
 		t.Fatalf("proxy evicted backend it does not own: %v", err)
+	}
+}
+
+func deadBackendAddress(t *testing.T) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	address := listener.Addr().String()
+	_ = listener.Close()
+	return address
+}
+
+func TestProxyStreamsResponseBeforeBackendCompletes(t *testing.T) {
+	release := make(chan struct{})
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "first")
+		w.(http.Flusher).Flush()
+		<-release
+		_, _ = io.WriteString(w, "second")
+	}))
+	defer backend.Close()
+
+	p := newTestProxy("sub", strings.TrimPrefix(backend.URL, "http://"))
+	proxyServer := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer proxyServer.Close()
+
+	request, _ := http.NewRequest(http.MethodGet, proxyServer.URL, nil)
+	request.Host = "sub.example.com"
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		close(release)
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer response.Body.Close()
+
+	first := make([]byte, len("first"))
+	readDone := make(chan error, 1)
+	go func() {
+		_, readErr := io.ReadFull(response.Body, first)
+		readDone <- readErr
+	}()
+	select {
+	case err := <-readDone:
+		if err != nil {
+			close(release)
+			t.Fatalf("read first chunk: %v", err)
+		}
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("first response chunk was buffered")
+	}
+	if string(first) != "first" {
+		close(release)
+		t.Fatalf("unexpected first chunk %q", first)
+	}
+	close(release)
+	rest, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read remaining response: %v", err)
+	}
+	if string(rest) != "second" {
+		t.Fatalf("unexpected remaining response %q", rest)
+	}
+}
+
+func TestProxyRetriesReplaySafeRequest(t *testing.T) {
+	var calls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer backend.Close()
+
+	p := newTestProxy("sub", deadBackendAddress(t))
+	_ = p.AddBackend("sub", strings.TrimPrefix(backend.URL, "http://"))
+	proxyServer := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer proxyServer.Close()
+
+	request, _ := http.NewRequest(http.MethodGet, proxyServer.URL, nil)
+	request.Host = "sub.example.com"
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK || calls.Load() != 1 {
+		t.Fatalf("expected retry to live backend, status=%d calls=%d", response.StatusCode, calls.Load())
+	}
+}
+
+func TestProxyDoesNotRetryPost(t *testing.T) {
+	var calls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer backend.Close()
+
+	p := newTestProxy("sub", deadBackendAddress(t))
+	_ = p.AddBackend("sub", strings.TrimPrefix(backend.URL, "http://"))
+	proxyServer := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer proxyServer.Close()
+
+	request, _ := http.NewRequest(http.MethodPost, proxyServer.URL, strings.NewReader("side-effect"))
+	request.Host = "sub.example.com"
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", response.StatusCode)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("unsafe request retried %d times", calls.Load())
+	}
+}
+
+func TestProxyDoesNotRetryGetWithBody(t *testing.T) {
+	var calls atomic.Int32
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer backend.Close()
+
+	p := newTestProxy("sub", deadBackendAddress(t))
+	_ = p.AddBackend("sub", strings.TrimPrefix(backend.URL, "http://"))
+	proxyServer := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer proxyServer.Close()
+
+	request, _ := http.NewRequest(http.MethodGet, proxyServer.URL, nil)
+	request.Body = io.NopCloser(strings.NewReader("body-with-zero-content-length"))
+	request.ContentLength = 0
+	request.Host = "sub.example.com"
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", response.StatusCode)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("GET with body was retried %d times", calls.Load())
+	}
+}
+
+func TestProxyPreservesInformationalAndFinalStatus(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Link", "</style.css>; rel=preload")
+		w.WriteHeader(http.StatusEarlyHints)
+		w.Header().Del("Link")
+		w.WriteHeader(http.StatusTeapot)
+		_, _ = io.WriteString(w, "teapot")
+	}))
+	defer backend.Close()
+
+	p := newTestProxy("sub", strings.TrimPrefix(backend.URL, "http://"))
+	proxyServer := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer proxyServer.Close()
+	request, _ := http.NewRequest(http.MethodGet, proxyServer.URL, nil)
+	request.Host = "sub.example.com"
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusTeapot {
+		t.Fatalf("expected final status %d, got %d", http.StatusTeapot, response.StatusCode)
+	}
+}
+
+func TestProxyPreservesResponseTrailers(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Trailer", "X-Checksum")
+		_, _ = io.WriteString(w, "payload")
+		w.Header().Set("X-Checksum", "complete")
+	}))
+	defer backend.Close()
+
+	p := newTestProxy("sub", strings.TrimPrefix(backend.URL, "http://"))
+	proxyServer := httptest.NewServer(http.HandlerFunc(p.handleRequest))
+	defer proxyServer.Close()
+	request, _ := http.NewRequest(http.MethodGet, proxyServer.URL, nil)
+	request.Host = "sub.example.com"
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("request proxy: %v", err)
+	}
+	_, _ = io.ReadAll(response.Body)
+	_ = response.Body.Close()
+	if response.Trailer.Get("X-Checksum") != "complete" {
+		t.Fatalf("expected response trailer, got %q", response.Trailer.Get("X-Checksum"))
 	}
 }

--- a/internal/server/service/service.go
+++ b/internal/server/service/service.go
@@ -21,7 +21,7 @@ func New(db *db.Db) *Service {
 
 func (s *Service) GetReservedConnectionById(ctx context.Context, connectionId string) (*db.Connection, error) {
 	var connection db.Connection
-	err := s.db.Conn.Preload("CreatedBy").Where("id = ?", connectionId).First(&connection).Error
+	err := s.db.Conn.WithContext(ctx).Preload("CreatedBy").Where("id = ?", connectionId).First(&connection).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			log.Error("Connection not found", "connection_id", connectionId)
@@ -34,29 +34,38 @@ func (s *Service) GetReservedConnectionById(ctx context.Context, connectionId st
 	return &connection, nil
 }
 
-func (s *Service) AddPortToConnection(ctx context.Context, connectionId string, port uint32) error {
-	connection, err := s.GetReservedConnectionById(ctx, fmt.Sprint(connectionId))
-	if err != nil {
-		return err
-	}
-	connection.Port = &port
-	return s.db.Conn.Save(connection).Error
+func (s *Service) MarkConnectionAsActive(ctx context.Context, connectionId string) error {
+	return s.activateConnection(ctx, connectionId, nil)
 }
 
-func (s *Service) MarkConnectionAsActive(ctx context.Context, connectionId string) error {
-	return s.db.Conn.Model(&db.Connection{}).
+func (s *Service) MarkTCPConnectionAsActive(ctx context.Context, connectionId string, port uint32) error {
+	return s.activateConnection(ctx, connectionId, &port)
+}
+
+func (s *Service) activateConnection(ctx context.Context, connectionId string, port *uint32) error {
+	updates := map[string]any{"status": "active", "started_at": time.Now().UTC(), "closed_at": nil}
+	if port != nil {
+		updates["port"] = *port
+	}
+	return s.db.Conn.WithContext(ctx).Model(&db.Connection{}).
 		Where("id = ?", connectionId).
-		Updates(map[string]any{"status": "active", "started_at": time.Now().UTC()}).Error
+		Updates(updates).Error
 }
 
 func (s *Service) MarkConnectionAsClosed(ctx context.Context, connectionId string) error {
-	return s.db.Conn.Model(&db.Connection{}).
+	return s.db.Conn.WithContext(ctx).Model(&db.Connection{}).
 		Where("id = ?", connectionId).
 		Updates(map[string]any{"status": "closed", "closed_at": time.Now().UTC()}).Error
 }
 
-func (s *Service) GetAllActiveConnections(ctx context.Context) []db.Connection {
+func (s *Service) CloseAllActiveConnections(ctx context.Context) error {
+	return s.db.Conn.WithContext(ctx).Model(&db.Connection{}).
+		Where("status = ?", "active").
+		Updates(map[string]any{"status": "closed", "closed_at": time.Now().UTC()}).Error
+}
+
+func (s *Service) GetAllActiveConnections(ctx context.Context) ([]db.Connection, error) {
 	var connections []db.Connection
-	s.db.Conn.Where("status = ?", "active").Find(&connections)
-	return connections
+	result := s.db.Conn.WithContext(ctx).Where("status = ?", "active").Find(&connections)
+	return connections, result.Error
 }

--- a/internal/server/service/service_test.go
+++ b/internal/server/service/service_test.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	serverdb "github.com/amalshaji/portr/internal/server/db"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCloseAllActiveConnectionsReconcilesStartupState(t *testing.T) {
+	database, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := database.AutoMigrate(&serverdb.Connection{}); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	connections := []serverdb.Connection{
+		{ID: "stale-http", Type: "http", Status: "active"},
+		{ID: "stale-tcp", Type: "tcp", Status: "active"},
+		{ID: "reserved", Type: "http", Status: "reserved"},
+	}
+	if err := database.Create(&connections).Error; err != nil {
+		t.Fatalf("create connections: %v", err)
+	}
+
+	service := New(&serverdb.Db{Conn: database})
+	if err := service.CloseAllActiveConnections(context.Background()); err != nil {
+		t.Fatalf("reconcile active connections: %v", err)
+	}
+
+	for _, id := range []string{"stale-http", "stale-tcp"} {
+		var connection serverdb.Connection
+		if err := database.First(&connection, "id = ?", id).Error; err != nil {
+			t.Fatalf("load %s: %v", id, err)
+		}
+		if connection.Status != "closed" || connection.ClosedAt == nil {
+			t.Fatalf("expected %s closed, status=%q closed_at=%v", id, connection.Status, connection.ClosedAt)
+		}
+	}
+
+	var reserved serverdb.Connection
+	if err := database.First(&reserved, "id = ?", "reserved").Error; err != nil {
+		t.Fatalf("load reserved: %v", err)
+	}
+	if reserved.Status != "reserved" || reserved.ClosedAt != nil {
+		t.Fatalf("reserved connection changed: status=%q closed_at=%v", reserved.Status, reserved.ClosedAt)
+	}
+}

--- a/internal/server/ssh/forward_handler.go
+++ b/internal/server/ssh/forward_handler.go
@@ -1,0 +1,216 @@
+package sshd
+
+import (
+	"io"
+	"net"
+	"strconv"
+	"sync"
+
+	"github.com/charmbracelet/log"
+	sshserver "github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+const forwardedTCPChannelType = "forwarded-tcpip"
+
+type remoteForwardRequest struct {
+	BindAddr string
+	BindPort uint32
+}
+
+type remoteForwardSuccess struct {
+	BindPort uint32
+}
+
+type remoteForwardCancelRequest struct {
+	BindAddr string
+	BindPort uint32
+}
+
+type remoteForwardChannelData struct {
+	DestAddr   string
+	DestPort   uint32
+	OriginAddr string
+	OriginPort uint32
+}
+
+type boundForward struct {
+	closed sync.Once
+	close  func()
+}
+
+type forwardedTCPHandler struct {
+	mu       sync.Mutex
+	forwards map[string]*boundForward
+	onBound  func(sshserver.Context, string, uint32) error
+	onClosed func(sshserver.Context, string, uint32)
+}
+
+func (h *forwardedTCPHandler) HandleSSHRequest(ctx sshserver.Context, _ *sshserver.Server, req *gossh.Request) (bool, []byte) {
+	switch req.Type {
+	case "tcpip-forward":
+		return h.open(ctx, req)
+	case "cancel-tcpip-forward":
+		return h.cancel(req)
+	default:
+		return false, nil
+	}
+}
+
+func (h *forwardedTCPHandler) open(ctx sshserver.Context, req *gossh.Request) (bool, []byte) {
+	var payload remoteForwardRequest
+	if err := gossh.Unmarshal(req.Payload, &payload); err != nil {
+		return false, nil
+	}
+	if h.onBound == nil {
+		return false, []byte("port forwarding is disabled")
+	}
+
+	requestedAddr := net.JoinHostPort(payload.BindAddr, strconv.Itoa(int(payload.BindPort)))
+	listener, err := net.Listen("tcp", requestedAddr)
+	if err != nil {
+		return false, nil
+	}
+
+	_, portString, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		_ = listener.Close()
+		return false, nil
+	}
+	port, err := strconv.ParseUint(portString, 10, 32)
+	if err != nil {
+		_ = listener.Close()
+		return false, nil
+	}
+	boundPort := uint32(port)
+	boundAddr := net.JoinHostPort(payload.BindAddr, portString)
+
+	if err := h.onBound(ctx, payload.BindAddr, boundPort); err != nil {
+		_ = listener.Close()
+		log.Error("Failed to register bound SSH forward", "address", boundAddr, "error", err)
+		return false, nil
+	}
+
+	forward := &boundForward{}
+	h.mu.Lock()
+	if h.forwards == nil {
+		h.forwards = make(map[string]*boundForward)
+	}
+	h.forwards[boundAddr] = forward
+	h.mu.Unlock()
+
+	closeForward := func() {
+		forward.closed.Do(func() {
+			_ = listener.Close()
+			h.mu.Lock()
+			current := h.forwards[boundAddr]
+			if current == forward {
+				delete(h.forwards, boundAddr)
+			}
+			h.mu.Unlock()
+			if current == forward && h.onClosed != nil {
+				h.onClosed(ctx, payload.BindAddr, boundPort)
+			}
+		})
+	}
+	forward.close = closeForward
+
+	go func() {
+		<-ctx.Done()
+		closeForward()
+	}()
+	go h.accept(ctx, listener, payload.BindAddr, boundPort, closeForward)
+
+	return true, gossh.Marshal(&remoteForwardSuccess{BindPort: boundPort})
+}
+
+func (h *forwardedTCPHandler) cancel(req *gossh.Request) (bool, []byte) {
+	var payload remoteForwardCancelRequest
+	if err := gossh.Unmarshal(req.Payload, &payload); err != nil {
+		return false, nil
+	}
+
+	addr := net.JoinHostPort(payload.BindAddr, strconv.Itoa(int(payload.BindPort)))
+	h.mu.Lock()
+	forward := h.forwards[addr]
+	h.mu.Unlock()
+	if forward == nil {
+		return true, nil
+	}
+	forward.close()
+	return true, nil
+}
+
+func (h *forwardedTCPHandler) accept(
+	ctx sshserver.Context,
+	listener net.Listener,
+	destAddr string,
+	destPort uint32,
+	closeForward func(),
+) {
+	defer closeForward()
+	connection, ok := ctx.Value(sshserver.ContextKeyConn).(*gossh.ServerConn)
+	if !ok || connection == nil {
+		return
+	}
+
+	for {
+		localConn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+
+		originHost, originPortString, err := net.SplitHostPort(localConn.RemoteAddr().String())
+		if err != nil {
+			_ = localConn.Close()
+			continue
+		}
+		originPort, err := strconv.ParseUint(originPortString, 10, 32)
+		if err != nil {
+			_ = localConn.Close()
+			continue
+		}
+
+		payload := gossh.Marshal(&remoteForwardChannelData{
+			DestAddr:   destAddr,
+			DestPort:   destPort,
+			OriginAddr: originHost,
+			OriginPort: uint32(originPort),
+		})
+		go proxyForwardedConnection(connection, localConn, payload)
+	}
+}
+
+func proxyForwardedConnection(connection *gossh.ServerConn, localConn net.Conn, payload []byte) {
+	channel, requests, err := connection.OpenChannel(forwardedTCPChannelType, payload)
+	if err != nil {
+		_ = localConn.Close()
+		return
+	}
+	go gossh.DiscardRequests(requests)
+
+	results := make(chan error, 2)
+	go func() {
+		_, copyErr := io.Copy(channel, localConn)
+		_ = channel.CloseWrite()
+		results <- copyErr
+	}()
+	go func() {
+		_, copyErr := io.Copy(localConn, channel)
+		if tcp, ok := localConn.(*net.TCPConn); ok {
+			_ = tcp.CloseWrite()
+		}
+		results <- copyErr
+	}()
+	if firstErr := <-results; firstErr != nil {
+		_ = channel.Close()
+		_ = localConn.Close()
+	}
+	<-results
+	_ = channel.Close()
+	_ = localConn.Close()
+}
+
+func forwardKey(host string, port uint32) string {
+	return net.JoinHostPort(host, strconv.Itoa(int(port)))
+}

--- a/internal/server/ssh/forward_handler_test.go
+++ b/internal/server/ssh/forward_handler_test.go
@@ -1,0 +1,146 @@
+package sshd
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	sshserver "github.com/gliderlabs/ssh"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+type fakeSSHContext struct {
+	context.Context
+	sync.Mutex
+	user   string
+	values map[any]any
+}
+
+func (c *fakeSSHContext) User() string                        { return c.user }
+func (c *fakeSSHContext) SessionID() string                   { return "session" }
+func (c *fakeSSHContext) ClientVersion() string               { return "client" }
+func (c *fakeSSHContext) ServerVersion() string               { return "server" }
+func (c *fakeSSHContext) RemoteAddr() net.Addr                { return testNetworkAddr("remote") }
+func (c *fakeSSHContext) LocalAddr() net.Addr                 { return testNetworkAddr("local") }
+func (c *fakeSSHContext) Permissions() *sshserver.Permissions { return &sshserver.Permissions{} }
+func (c *fakeSSHContext) SetValue(key, value any)             { c.values[key] = value }
+func (c *fakeSSHContext) Value(key any) any {
+	if value, ok := c.values[key]; ok {
+		return value
+	}
+	return c.Context.Value(key)
+}
+
+type testNetworkAddr string
+
+func (a testNetworkAddr) Network() string { return string(a) }
+func (a testNetworkAddr) String() string  { return string(a) }
+
+func newFakeSSHContext(t *testing.T) (*fakeSSHContext, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	return &fakeSSHContext{
+		Context: ctx,
+		user:    "connection:secret",
+		values: map[any]any{
+			sshserver.ContextKeyConn: &gossh.ServerConn{},
+		},
+	}, cancel
+}
+
+func TestForwardHandlerDoesNotRegisterFailedBind(t *testing.T) {
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer occupied.Close()
+	_, portString, _ := net.SplitHostPort(occupied.Addr().String())
+	port, _ := strconv.Atoi(portString)
+
+	registered := false
+	handler := &forwardedTCPHandler{
+		onBound: func(sshserver.Context, string, uint32) error {
+			registered = true
+			return nil
+		},
+	}
+	ctx, cancel := newFakeSSHContext(t)
+	defer cancel()
+	request := &gossh.Request{
+		Type:    "tcpip-forward",
+		Payload: gossh.Marshal(&remoteForwardRequest{BindAddr: "127.0.0.1", BindPort: uint32(port)}),
+	}
+	ok, _ := handler.HandleSSHRequest(ctx, nil, request)
+	if ok {
+		t.Fatal("expected occupied port bind to fail")
+	}
+	if registered {
+		t.Fatal("failed bind was registered as a backend")
+	}
+}
+
+func TestForwardHandlerRegistersOnlyAfterBind(t *testing.T) {
+	closed := make(chan struct{}, 1)
+	handler := &forwardedTCPHandler{
+		onBound: func(_ sshserver.Context, host string, port uint32) error {
+			probe, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(int(port))))
+			if err == nil {
+				_ = probe.Close()
+				t.Fatal("forward callback ran before the port was bound")
+			}
+			return nil
+		},
+		onClosed: func(sshserver.Context, string, uint32) {
+			closed <- struct{}{}
+		},
+	}
+	ctx, cancel := newFakeSSHContext(t)
+	defer cancel()
+	request := &gossh.Request{
+		Type:    "tcpip-forward",
+		Payload: gossh.Marshal(&remoteForwardRequest{BindAddr: "127.0.0.1"}),
+	}
+	ok, response := handler.HandleSSHRequest(ctx, nil, request)
+	if !ok {
+		t.Fatal("expected dynamic bind to succeed")
+	}
+	var success remoteForwardSuccess
+	if err := gossh.Unmarshal(response, &success); err != nil || success.BindPort == 0 {
+		t.Fatalf("invalid bind response port=%d err=%v", success.BindPort, err)
+	}
+
+	cancelRequest := &gossh.Request{
+		Type: "cancel-tcpip-forward",
+		Payload: gossh.Marshal(&remoteForwardCancelRequest{
+			BindAddr: "127.0.0.1",
+			BindPort: success.BindPort,
+		}),
+	}
+	if canceled, _ := handler.HandleSSHRequest(ctx, nil, cancelRequest); !canceled {
+		t.Fatal("expected forward cancellation to succeed")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("forward close callback was not invoked")
+	}
+}
+
+func TestForwardHandlerCancelIsIdempotent(t *testing.T) {
+	handler := &forwardedTCPHandler{}
+	request := &gossh.Request{
+		Type: "cancel-tcpip-forward",
+		Payload: gossh.Marshal(&remoteForwardCancelRequest{
+			BindAddr: "127.0.0.1",
+			BindPort: 29999,
+		}),
+	}
+	ctx, cancel := newFakeSSHContext(t)
+	defer cancel()
+	if ok, _ := handler.HandleSSHRequest(ctx, nil, request); !ok {
+		t.Fatal("canceling an already-closed forward should succeed")
+	}
+}

--- a/internal/server/ssh/lease_test.go
+++ b/internal/server/ssh/lease_test.go
@@ -1,0 +1,94 @@
+package sshd
+
+import (
+	"testing"
+
+	serverconfig "github.com/amalshaji/portr/internal/server/config"
+	serverdb "github.com/amalshaji/portr/internal/server/db"
+	"github.com/amalshaji/portr/internal/server/proxy"
+	"github.com/amalshaji/portr/internal/server/service"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newLeaseTestServer(t *testing.T) (*SshServer, *gorm.DB, *fakeSSHContext) {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := database.AutoMigrate(&serverdb.TeamUser{}, &serverdb.Connection{}); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	teamUser := serverdb.TeamUser{SecretKey: "secret"}
+	if err := database.Create(&teamUser).Error; err != nil {
+		t.Fatalf("create team user: %v", err)
+	}
+	subdomain := "pooled"
+	connection := serverdb.Connection{
+		ID:          "connection",
+		Type:        "http",
+		Subdomain:   &subdomain,
+		Status:      "reserved",
+		CreatedByID: teamUser.ID,
+	}
+	if err := database.Create(&connection).Error; err != nil {
+		t.Fatalf("create connection: %v", err)
+	}
+
+	proxyServer := proxy.New(&serverconfig.Config{Domain: "example.com"})
+	sshServer := New(
+		&serverconfig.SshConfig{},
+		proxyServer,
+		service.New(&serverdb.Db{Conn: database}),
+	)
+	ctx, cancel := newFakeSSHContext(t)
+	t.Cleanup(cancel)
+	return sshServer, database, ctx
+}
+
+func TestPooledConnectionClosesOnlyAfterLastForward(t *testing.T) {
+	server, database, ctx := newLeaseTestServer(t)
+	if err := server.activateForward(ctx, "127.0.0.1", 20001); err != nil {
+		t.Fatalf("activate first forward: %v", err)
+	}
+	if err := server.activateForward(ctx, "127.0.0.1", 20002); err != nil {
+		t.Fatalf("activate second forward: %v", err)
+	}
+
+	server.closeForward(ctx, "127.0.0.1", 20001)
+	var connection serverdb.Connection
+	if err := database.First(&connection, "id = ?", "connection").Error; err != nil {
+		t.Fatalf("load connection: %v", err)
+	}
+	if connection.Status != "active" {
+		t.Fatalf("expected pool to remain active, got %q", connection.Status)
+	}
+
+	server.closeForward(ctx, "127.0.0.1", 20002)
+	if err := database.First(&connection, "id = ?", "connection").Error; err != nil {
+		t.Fatalf("reload connection: %v", err)
+	}
+	if connection.Status != "closed" || connection.ClosedAt == nil {
+		t.Fatalf("expected pool to close after last lease, status=%q closed_at=%v", connection.Status, connection.ClosedAt)
+	}
+}
+
+func TestReactivatedConnectionClearsClosedTimestamp(t *testing.T) {
+	server, database, ctx := newLeaseTestServer(t)
+	if err := server.activateForward(ctx, "127.0.0.1", 20001); err != nil {
+		t.Fatalf("activate forward: %v", err)
+	}
+	server.closeForward(ctx, "127.0.0.1", 20001)
+	if err := server.activateForward(ctx, "127.0.0.1", 20002); err != nil {
+		t.Fatalf("reactivate forward: %v", err)
+	}
+
+	var connection serverdb.Connection
+	if err := database.First(&connection, "id = ?", "connection").Error; err != nil {
+		t.Fatalf("load connection: %v", err)
+	}
+	if connection.Status != "active" || connection.ClosedAt != nil {
+		t.Fatalf("expected clean active state, status=%q closed_at=%v", connection.Status, connection.ClosedAt)
+	}
+}

--- a/internal/server/ssh/sshd.go
+++ b/internal/server/ssh/sshd.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/amalshaji/portr/internal/constants"
@@ -20,17 +20,32 @@ import (
 )
 
 type SshServer struct {
-	config  *config.SshConfig
-	proxy   *proxy.Proxy
-	service *service.Service
-	server  *ssh.Server
+	config   *config.SshConfig
+	proxy    *proxy.Proxy
+	service  *service.Service
+	server   *ssh.Server
+	leaseMu  sync.Mutex
+	forwards map[string]*connectionLeases
 }
+
+type forwardLease struct {
+	connectionType string
+	subdomain      string
+}
+
+type connectionLeases struct {
+	mu       sync.Mutex
+	forwards map[string]forwardLease
+}
+
+type reservedConnectionContextKey struct{}
 
 func New(config *config.SshConfig, proxy *proxy.Proxy, service *service.Service) *SshServer {
 	return &SshServer{
-		config:  config,
-		proxy:   proxy,
-		service: service,
+		config:   config,
+		proxy:    proxy,
+		service:  service,
+		forwards: make(map[string]*connectionLeases),
 	}
 }
 
@@ -39,25 +54,141 @@ func (s *SshServer) GetServerAddr() string {
 }
 
 func (s *SshServer) GetReservedConnectionFromSshContext(ctx ssh.Context) (*db.Connection, error) {
-	userSplit := strings.Split(ctx.User(), ":")
-	if len(userSplit) != 2 {
-		return nil, fmt.Errorf("invalid user format")
+	if cached, ok := ctx.Value(reservedConnectionContextKey{}).(*db.Connection); ok && cached != nil {
+		return cached, nil
+	}
+	reservedConnection, err := s.authenticateConnection(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ctx.SetValue(reservedConnectionContextKey{}, reservedConnection)
+	return reservedConnection, nil
+}
+
+func (s *SshServer) authenticateConnection(ctx ssh.Context) (*db.Connection, error) {
+	connectionID, secretKey, err := connectionCredentials(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	connectionId, secretKey := userSplit[0], userSplit[1]
-
-	reservedConnection, err := s.service.GetReservedConnectionById(ctx, connectionId)
+	reservedConnection, err := s.service.GetReservedConnectionById(ctx, connectionID)
 	if err != nil {
 		log.Error("Failed to get reserved connection", "error", err)
 		return nil, fmt.Errorf("failed to get reserved connection")
 	}
 
 	if reservedConnection.CreatedBy.SecretKey != secretKey {
-		log.Error("Connection not created by the user", "connection_id", connectionId)
+		log.Error("Connection not created by the user", "connection_id", connectionID)
 		return nil, fmt.Errorf("connection not created by the user")
 	}
 
 	return reservedConnection, nil
+}
+
+func connectionCredentials(ctx ssh.Context) (string, string, error) {
+	userSplit := strings.SplitN(ctx.User(), ":", 2)
+	if len(userSplit) != 2 {
+		return "", "", fmt.Errorf("invalid user format")
+	}
+	return userSplit[0], userSplit[1], nil
+}
+
+func (s *SshServer) activateForward(ctx ssh.Context, host string, port uint32) error {
+	reservedConnection, err := s.GetReservedConnectionFromSshContext(ctx)
+	if err != nil {
+		return err
+	}
+
+	backend := forwardKey(host, port)
+	lease := forwardLease{connectionType: reservedConnection.Type}
+	switch reservedConnection.Type {
+	case string(constants.Tcp):
+	case string(constants.Http):
+		if reservedConnection.Subdomain == nil || *reservedConnection.Subdomain == "" {
+			return fmt.Errorf("http connection has no subdomain")
+		}
+		lease.subdomain = *reservedConnection.Subdomain
+	default:
+		return fmt.Errorf("unsupported connection type %q", reservedConnection.Type)
+	}
+
+	connectionLeases := s.leasesForConnection(reservedConnection.ID)
+	connectionLeases.mu.Lock()
+	defer connectionLeases.mu.Unlock()
+	if _, exists := connectionLeases.forwards[backend]; exists {
+		return nil
+	}
+
+	firstForward := len(connectionLeases.forwards) == 0
+	if reservedConnection.Type == string(constants.Tcp) {
+		if !firstForward {
+			return fmt.Errorf("tcp connection already has an active forward")
+		}
+		if err := s.service.MarkTCPConnectionAsActive(ctx, reservedConnection.ID, port); err != nil {
+			return err
+		}
+	} else {
+		if err := s.proxy.AddBackend(lease.subdomain, backend); err != nil {
+			return err
+		}
+		if firstForward {
+			if err := s.service.MarkConnectionAsActive(ctx, reservedConnection.ID); err != nil {
+				_ = s.proxy.RemoveBackend(lease.subdomain, backend)
+				return err
+			}
+		}
+	}
+
+	connectionLeases.forwards[backend] = lease
+	return nil
+}
+
+func (s *SshServer) leasesForConnection(connectionID string) *connectionLeases {
+	s.leaseMu.Lock()
+	defer s.leaseMu.Unlock()
+	leases := s.forwards[connectionID]
+	if leases == nil {
+		leases = &connectionLeases{forwards: make(map[string]forwardLease)}
+		s.forwards[connectionID] = leases
+	}
+	return leases
+}
+
+func (s *SshServer) closeForward(ctx ssh.Context, host string, port uint32) {
+	connectionID, _, err := connectionCredentials(ctx)
+	if err != nil {
+		return
+	}
+	backend := forwardKey(host, port)
+
+	s.leaseMu.Lock()
+	connectionLeases := s.forwards[connectionID]
+	s.leaseMu.Unlock()
+	if connectionLeases == nil {
+		return
+	}
+	connectionLeases.mu.Lock()
+	defer connectionLeases.mu.Unlock()
+	lease, exists := connectionLeases.forwards[backend]
+	if !exists {
+		return
+	}
+
+	if lease.connectionType != string(constants.Tcp) {
+		if err := s.proxy.RemoveBackend(lease.subdomain, backend); err != nil {
+			log.Error("Failed to remove tunnel backend", "connection_id", connectionID, "backend", backend, "error", err)
+		}
+	}
+	delete(connectionLeases.forwards, backend)
+	if len(connectionLeases.forwards) != 0 {
+		return
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.service.MarkConnectionAsClosed(closeCtx, connectionID); err != nil {
+		log.Error("Failed to mark connection as closed", "connection_id", connectionID, "error", err)
+	}
 }
 
 func (s *SshServer) Start() {
@@ -95,7 +226,10 @@ func (s *SshServer) Shutdown(_ context.Context) {
 
 // Build constructs the ssh.Server with all handlers, without starting it.
 func (s *SshServer) Build() *ssh.Server {
-	forwardHandler := &ssh.ForwardedTCPHandler{}
+	forwardHandler := &forwardedTCPHandler{
+		onBound:  s.activateForward,
+		onClosed: s.closeForward,
+	}
 
 	requestHandlers := map[string]ssh.RequestHandler{
 		"tcpip-forward":        forwardHandler.HandleSSHRequest,
@@ -103,67 +237,21 @@ func (s *SshServer) Build() *ssh.Server {
 	}
 
 	// Respond OK to ssh application keepalive requests (global request)
-	requestHandlers["keepalive@openssh.com"] = func(ctx ssh.Context, srv *ssh.Server, req *gossh.Request) (bool, []byte) {
+	requestHandlers["keepalive@openssh.com"] = func(ssh.Context, *ssh.Server, *gossh.Request) (bool, []byte) {
 		return true, nil
 	}
 
 	server := &ssh.Server{
 		Addr: s.GetServerAddr(),
 		Handler: ssh.Handler(func(sh ssh.Session) {
-			select {}
-		}),
-		ReversePortForwardingCallback: ssh.ReversePortForwardingCallback(func(ctx ssh.Context, host string, port uint32) bool {
-			reservedConnection, err := s.GetReservedConnectionFromSshContext(ctx)
-			if err != nil {
-				return false
-			}
-
-			proxyTarget := fmt.Sprintf("%s:%d", host, port)
-
-			if reservedConnection.Type == string(constants.Tcp) {
-				err = s.service.AddPortToConnection(ctx, reservedConnection.ID, port)
-				if err != nil {
-					log.Error("Failed to add port to connection", "connection_id", reservedConnection.ID, "port", port, "error", err)
-					return false
-				}
-			} else {
-				// Add this backend to the subdomain's pool
-				err = s.proxy.AddBackend(*reservedConnection.Subdomain, proxyTarget)
-				if err != nil {
-					log.Error("Failed to add backend", "connection_id", reservedConnection.ID, "subdomain", *reservedConnection.Subdomain, "backend", proxyTarget, "error", err)
-					return false
-				}
-			}
-
-			err = s.service.MarkConnectionAsActive(ctx, reservedConnection.ID)
-			if err != nil {
-				log.Error("Failed to mark connection as active", "connection_id", reservedConnection.ID, "error", err)
-				return false
-			}
-
-			go func() {
-				<-ctx.Done()
-
-				err = s.service.MarkConnectionAsClosed(context.Background(), reservedConnection.ID)
-				if err != nil {
-					log.Error("Failed to mark connection as closed", "connection_id", reservedConnection.ID, "error", err)
-				}
-
-				if reservedConnection.Type == string(constants.Http) {
-					// Remove only this backend from the pool
-					backend := fmt.Sprintf("%s:%d", host, port)
-					err := s.proxy.RemoveBackend(*reservedConnection.Subdomain, backend)
-					if err != nil {
-						log.Error("Failed to remove backend", "connection_id", reservedConnection.ID, "subdomain", *reservedConnection.Subdomain, "backend", backend, "error", err)
-					}
-				}
-			}()
-
-			return true
+			<-sh.Context().Done()
 		}),
 		RequestHandlers: requestHandlers,
-		PasswordHandler: func(ctx ssh.Context, password string) bool {
-			_, err := s.GetReservedConnectionFromSshContext(ctx)
+		PasswordHandler: func(ctx ssh.Context, _ string) bool {
+			reservedConnection, err := s.authenticateConnection(ctx)
+			if err == nil {
+				ctx.SetValue(reservedConnectionContextKey{}, reservedConnection)
+			}
 			return err == nil
 		},
 	}

--- a/internal/utils/port.go
+++ b/internal/utils/port.go
@@ -1,15 +1,9 @@
 package utils
 
 func GenerateRandomHttpPorts() []int {
-	var startPort int = 20000
-	var endPort int = 30000
-
-	return GenerateRandomNumbers(startPort, endPort, 10)
+	return GenerateRandomNumbers(20000, 30000, 10)
 }
 
 func GenerateRandomTcpPorts() []int {
-	var startPort int = 30001
-	var endPort int = 40001
-
-	return GenerateRandomNumbers(startPort, endPort, 10)
+	return GenerateRandomNumbers(30001, 40001, 10)
 }

--- a/internal/utils/port_test.go
+++ b/internal/utils/port_test.go
@@ -8,21 +8,18 @@ func TestGenerateRandomHttpPorts(t *testing.T) {
 	ports := GenerateRandomHttpPorts()
 
 	if len(ports) != 10 {
-		t.Errorf("Expected 10 ports, got %d", len(ports))
+		t.Fatalf("expected 10 ports, got %d", len(ports))
 	}
 
+	seen := make(map[int]bool, len(ports))
 	for i, port := range ports {
 		if port < 20000 || port > 30000 {
-			t.Errorf("Port[%d] = %d is outside expected range [20000-30000]", i, port)
+			t.Errorf("port[%d] = %d is outside expected range [20000-30000]", i, port)
 		}
-	}
-
-	portMap := make(map[int]bool)
-	for _, port := range ports {
-		if portMap[port] {
-			t.Errorf("Duplicate port found: %d", port)
+		if seen[port] {
+			t.Errorf("duplicate port found: %d", port)
 		}
-		portMap[port] = true
+		seen[port] = true
 	}
 }
 

--- a/skills/portr-cli/SKILL.md
+++ b/skills/portr-cli/SKILL.md
@@ -81,7 +81,6 @@ Global config keys:
 - `health_check_interval`: health check interval in seconds. Default `3`.
 - `health_check_max_retries`: max health check retry count. Default `10`.
 - `disable_tui`: run without the interactive terminal UI.
-- `enable_http_reverse_proxy`: enable the HTTP reverse-proxy path when supported by the running binary.
 - `disable_update_check`: suppress release update checks.
 - `insecure_skip_host_key_verification`: skip SSH host key verification. Default `true`.
 

--- a/skills/portr-cli/references/commands.md
+++ b/skills/portr-cli/references/commands.md
@@ -25,7 +25,7 @@ This file mirrors the CLI surface for quick lookup. The skill body contains the 
 
 ## Config Keys
 
-- Global: `server_url`, `ssh_url`, `tunnel_url`, `secret_key`, `use_localhost`, `debug`, `use_vite`, `dashboard_port`, `disable_dashboard`, `enable_request_logging`, `connection_log_retention_days`, `health_check_interval`, `health_check_max_retries`, `disable_tui`, `enable_http_reverse_proxy`, `disable_update_check`, `insecure_skip_host_key_verification`.
+- Global: `server_url`, `ssh_url`, `tunnel_url`, `secret_key`, `use_localhost`, `debug`, `use_vite`, `dashboard_port`, `disable_dashboard`, `enable_request_logging`, `connection_log_retention_days`, `health_check_interval`, `health_check_max_retries`, `disable_tui`, `disable_update_check`, `insecure_skip_host_key_verification`.
 - Tunnel: `name`, `type`, `host`, `port`, `subdomain`, `pool_size`, `response_format`, `response_tmpl`, `response_tmpl_file`.
 
 ## App Server API

--- a/tests/tunnel_data_flow_test.go
+++ b/tests/tunnel_data_flow_test.go
@@ -1,0 +1,381 @@
+package tests_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	clientconfig "github.com/amalshaji/portr/internal/client/config"
+	clientdb "github.com/amalshaji/portr/internal/client/db"
+	clientssh "github.com/amalshaji/portr/internal/client/ssh"
+	"github.com/amalshaji/portr/internal/constants"
+	serverconfig "github.com/amalshaji/portr/internal/server/config"
+	serverdb "github.com/amalshaji/portr/internal/server/db"
+	"github.com/amalshaji/portr/internal/server/proxy"
+	"github.com/amalshaji/portr/internal/server/service"
+	sshd "github.com/amalshaji/portr/internal/server/ssh"
+	"github.com/glebarez/sqlite"
+	sshserver "github.com/gliderlabs/ssh"
+	"golang.org/x/net/websocket"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+const (
+	testConnectionID = "ci-data-flow-connection"
+	testSecretKey    = "ci-data-flow-secret"
+	testSubdomain    = "ci-data-flow"
+	testPublicHost   = testSubdomain + ".example.test"
+	testTimeout      = 10 * time.Second
+)
+
+type tunnelHarness struct {
+	proxy     *proxy.Proxy
+	client    *clientssh.SshClient
+	cancel    context.CancelFunc
+	clientErr chan error
+	sshServer *sshserver.Server
+	sshErr    chan error
+}
+
+func openTestDatabase(t *testing.T, name string, models ...any) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), name+".sqlite")), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open %s database: %v", name, err)
+	}
+	if err := database.AutoMigrate(models...); err != nil {
+		t.Fatalf("migrate %s database: %v", name, err)
+	}
+	return database
+}
+
+func backendAddress(t *testing.T, rawURL string) (string, int) {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("parse backend URL: %v", err)
+	}
+	host, portText, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("split backend address: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse backend port: %v", err)
+	}
+	return host, port
+}
+
+func startTunnelHarness(t *testing.T, backendURL string) *tunnelHarness {
+	t.Helper()
+
+	serverDatabase := openTestDatabase(t, "server", &serverdb.TeamUser{}, &serverdb.Connection{})
+	teamUser := serverdb.TeamUser{SecretKey: testSecretKey, Role: "member"}
+	if err := serverDatabase.Create(&teamUser).Error; err != nil {
+		t.Fatalf("create tunnel user: %v", err)
+	}
+	subdomain := testSubdomain
+	connection := serverdb.Connection{
+		ID:          testConnectionID,
+		Type:        string(constants.Http),
+		Subdomain:   &subdomain,
+		Status:      "reserved",
+		CreatedByID: teamUser.ID,
+	}
+	if err := serverDatabase.Create(&connection).Error; err != nil {
+		t.Fatalf("create reserved connection: %v", err)
+	}
+
+	serverConfig := &serverconfig.Config{
+		Ssh:    serverconfig.SshConfig{Host: "127.0.0.1"},
+		Proxy:  serverconfig.ProxyConfig{Host: "127.0.0.1"},
+		Domain: "example.test",
+		Debug:  true,
+	}
+	proxyServer := proxy.New(serverConfig)
+	sshServer := sshd.New(
+		&serverConfig.Ssh,
+		proxyServer,
+		service.New(&serverdb.Db{Conn: serverDatabase}),
+	).Build()
+	sshListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for SSH server: %v", err)
+	}
+	sshErr := make(chan error, 1)
+	go func() {
+		sshErr <- sshServer.Serve(sshListener)
+	}()
+
+	clientDatabase := openTestDatabase(
+		t,
+		"client",
+		&clientdb.Request{},
+		&clientdb.WebSocketSession{},
+		&clientdb.WebSocketEvent{},
+	)
+	backendHost, backendPort := backendAddress(t, backendURL)
+	client := clientssh.New(clientconfig.ClientConfig{
+		SshUrl:                          sshListener.Addr().String(),
+		SecretKey:                       testSecretKey,
+		ConnectionID:                    testConnectionID,
+		HealthCheckInterval:             60,
+		HealthCheckMaxRetries:           1,
+		DisableTerminalLogs:             true,
+		InsecureSkipHostKeyVerification: true,
+		EnableRequestLogging:            true,
+		Tunnel: clientconfig.Tunnel{
+			Name:      "ci-data-flow",
+			Subdomain: testSubdomain,
+			Host:      backendHost,
+			Port:      backendPort,
+			Type:      constants.Http,
+		},
+	}, &clientdb.Db{Conn: clientDatabase}, nil, nil)
+
+	started := make(chan struct{}, 1)
+	client.SetEventHandler(func(event clientssh.Event) {
+		if event.Type == clientssh.EventStarted {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+		}
+	})
+	clientContext, cancel := context.WithCancel(context.Background())
+	clientErr := make(chan error, 1)
+	go func() {
+		clientErr <- client.Start(clientContext)
+	}()
+
+	select {
+	case <-started:
+	case err := <-clientErr:
+		cancel()
+		_ = sshServer.Close()
+		t.Fatalf("tunnel client stopped before becoming ready: %v", err)
+	case <-time.After(testTimeout):
+		cancel()
+		_ = sshServer.Close()
+		t.Fatal("timed out waiting for tunnel client readiness")
+	}
+
+	harness := &tunnelHarness{
+		proxy:     proxyServer,
+		client:    client,
+		cancel:    cancel,
+		clientErr: clientErr,
+		sshServer: sshServer,
+		sshErr:    sshErr,
+	}
+	t.Cleanup(func() { harness.close(t) })
+	return harness
+}
+
+func (h *tunnelHarness) close(t *testing.T) {
+	t.Helper()
+	shutdownContext, cancelShutdown := context.WithTimeout(context.Background(), testTimeout)
+	defer cancelShutdown()
+	if err := h.client.Shutdown(shutdownContext); err != nil &&
+		!errors.Is(err, context.Canceled) &&
+		!strings.Contains(strings.ToLower(err.Error()), "closed network connection") {
+		t.Errorf("shut down tunnel client: %v", err)
+	}
+	h.cancel()
+	select {
+	case err := <-h.clientErr:
+		if err != nil {
+			t.Errorf("tunnel client exited with error: %v", err)
+		}
+	case <-time.After(testTimeout):
+		t.Error("timed out waiting for tunnel client shutdown")
+	}
+	if err := h.sshServer.Close(); err != nil && !errors.Is(err, sshserver.ErrServerClosed) {
+		t.Errorf("close SSH server: %v", err)
+	}
+	select {
+	case err := <-h.sshErr:
+		if err != nil && !errors.Is(err, sshserver.ErrServerClosed) && !errors.Is(err, net.ErrClosed) {
+			t.Errorf("SSH server exited with error: %v", err)
+		}
+	case <-time.After(testTimeout):
+		t.Error("timed out waiting for SSH server shutdown")
+	}
+}
+
+func TestTunnelDataFlowHTTP(t *testing.T) {
+	releaseResponse := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseResponse) }) }
+	t.Cleanup(release)
+
+	requestSeen := make(chan error, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err == nil && string(body) != "request-through-tunnel" {
+			err = fmt.Errorf("unexpected request body %q", body)
+		}
+		if err == nil && r.Header.Get("X-Data-Flow") != "ci" {
+			err = fmt.Errorf("request header was not preserved")
+		}
+		requestSeen <- err
+
+		w.Header().Set("Trailer", "X-Tunnel-Trailer")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, "first-chunk")
+		w.(http.Flusher).Flush()
+		select {
+		case <-releaseResponse:
+		case <-r.Context().Done():
+			return
+		}
+		_, _ = io.WriteString(w, "second-chunk")
+		w.Header().Set("X-Tunnel-Trailer", "complete")
+	}))
+	defer backend.Close()
+
+	harness := startTunnelHarness(t, backend.URL)
+	publicServer := httptest.NewServer(harness.proxy)
+	defer publicServer.Close()
+
+	request, err := http.NewRequest(http.MethodPost, publicServer.URL+"/stream?source=ci", strings.NewReader("request-through-tunnel"))
+	if err != nil {
+		t.Fatalf("create public request: %v", err)
+	}
+	request.Host = testPublicHost
+	request.Header.Set("X-Data-Flow", "ci")
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		release()
+		t.Fatalf("send request through tunnel: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusCreated {
+		release()
+		t.Fatalf("unexpected response status %d", response.StatusCode)
+	}
+	select {
+	case err := <-requestSeen:
+		if err != nil {
+			release()
+			t.Fatal(err)
+		}
+	case <-time.After(testTimeout):
+		release()
+		t.Fatal("local backend did not receive tunneled request")
+	}
+
+	firstChunk := make([]byte, len("first-chunk"))
+	firstRead := make(chan error, 1)
+	go func() {
+		_, readErr := io.ReadFull(response.Body, firstChunk)
+		firstRead <- readErr
+	}()
+	select {
+	case err := <-firstRead:
+		if err != nil {
+			release()
+			t.Fatalf("read first streamed response chunk: %v", err)
+		}
+	case <-time.After(testTimeout):
+		release()
+		t.Fatal("response was buffered instead of streamed through the tunnel")
+	}
+	if string(firstChunk) != "first-chunk" {
+		release()
+		t.Fatalf("unexpected first response chunk %q", firstChunk)
+	}
+
+	release()
+	rest, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read final response chunk: %v", err)
+	}
+	if string(rest) != "second-chunk" {
+		t.Fatalf("unexpected final response chunk %q", rest)
+	}
+	if response.Trailer.Get("X-Tunnel-Trailer") != "complete" {
+		t.Fatalf("response trailer was not preserved: %q", response.Trailer.Get("X-Tunnel-Trailer"))
+	}
+}
+
+func TestTunnelDataFlowWebSocket(t *testing.T) {
+	backendMessage := make(chan string, 1)
+	backendError := make(chan error, 1)
+	backend := httptest.NewServer(websocket.Handler(func(connection *websocket.Conn) {
+		var message string
+		if err := websocket.Message.Receive(connection, &message); err != nil {
+			backendError <- err
+			return
+		}
+		backendMessage <- message
+		backendError <- websocket.Message.Send(connection, "echo:"+message)
+	}))
+	defer backend.Close()
+
+	harness := startTunnelHarness(t, backend.URL)
+	publicServer := httptest.NewServer(harness.proxy)
+	defer publicServer.Close()
+	publicURL, err := url.Parse(publicServer.URL)
+	if err != nil {
+		t.Fatalf("parse public proxy URL: %v", err)
+	}
+	rawConnection, err := net.DialTimeout("tcp", publicURL.Host, testTimeout)
+	if err != nil {
+		t.Fatalf("dial public proxy: %v", err)
+	}
+	websocketConfig, err := websocket.NewConfig("ws://"+testPublicHost+"/echo", "http://"+testPublicHost)
+	if err != nil {
+		_ = rawConnection.Close()
+		t.Fatalf("create websocket config: %v", err)
+	}
+	connection, err := websocket.NewClient(websocketConfig, rawConnection)
+	if err != nil {
+		_ = rawConnection.Close()
+		t.Fatalf("upgrade websocket through tunnel: %v", err)
+	}
+	defer connection.Close()
+	_ = connection.SetDeadline(time.Now().Add(testTimeout))
+
+	if err := websocket.Message.Send(connection, "websocket-through-tunnel"); err != nil {
+		t.Fatalf("send websocket frame through tunnel: %v", err)
+	}
+	var response string
+	if err := websocket.Message.Receive(connection, &response); err != nil {
+		t.Fatalf("receive websocket frame through tunnel: %v", err)
+	}
+	if response != "echo:websocket-through-tunnel" {
+		t.Fatalf("unexpected websocket response %q", response)
+	}
+	select {
+	case message := <-backendMessage:
+		if message != "websocket-through-tunnel" {
+			t.Fatalf("local backend received unexpected websocket message %q", message)
+		}
+	case <-time.After(testTimeout):
+		t.Fatal("local backend did not receive websocket frame")
+	}
+	select {
+	case err := <-backendError:
+		if err != nil {
+			t.Fatalf("local websocket backend failed: %v", err)
+		}
+	case <-time.After(testTimeout):
+		t.Fatal("local websocket backend did not send its response")
+	}
+}


### PR DESCRIPTION
## Summary

- make SSH transport establishment atomic and supervise health checks, reconnects, and shutdown from one lifecycle loop
- register reverse forwards only after successful binds while preserving compatibility with older servers
- stream HTTP requests, responses, and WebSocket frames with bounded asynchronous inspector capture
- move safe HTTP retries into the transport layer so status codes, trailers, and streaming semantics remain intact
- track pooled SSH leases correctly, reconcile stale persisted connections at startup, and bound server health probes
- exercise the complete public proxy → SSH reverse-forward → client tunnel → local backend path for streaming HTTP and bidirectional WebSockets in CI
- add focused regression coverage for reconnects, failed binds, pooling, streaming, retries, half-closes, capture limits, and reconciliation

## Why

The previous tunnel path could report a live SSH client without a working remote listener, mark pooled connections closed while workers were still active, register stale routes before bind success, buffer large payloads, and retry unsafe requests. The lifecycle and ownership boundaries are now explicit so failures recover without corrupting routing or request semantics.

The new end-to-end WebSocket test also exposed a real deadlock: Go's HTTP server could not interrupt its background read while hijacking an SSH channel because SSH channels do not support read deadlines. The client now supplies deadline-aware buffered reads without dropping frame bytes.

## Compatibility and impact

- new clients continue to work with older servers by retaining non-zero HTTP forward ports
- existing configs containing `enable_http_reverse_proxy` still load; the deprecated option is ignored because streaming is now the only HTTP path
- inspector request and response bodies are capped at 1 MiB while byte counters retain full payload sizes
- unsafe requests are never retried; bodyless GET, HEAD, and OPTIONS requests retry only on pre-response transport errors
- valid large WebSocket frames are streamed without imposing the temporary 16 MiB forwarding limit
- CI integration tests are hermetic: they use loopback sockets and temporary SQLite databases, with no deployed service or secrets

## Validation

- `go test -race -v ./tests -run '^TestTunnelDataFlow' -count=1 -timeout=2m`
- focused race suite across client SSH, server proxy, server SSH, and full-stack tunnel tests
- `go test ./... -count=1 -timeout=5m`
- `go vet ./...`
- `go build ./...`
- `git diff --check`