### PR TITLE
fix: update server_url, ssh_url and tunnel_url on auth set

### DIFF
--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -392,14 +392,28 @@ func writeConfigNode(configNode *yaml.Node) error {
 	return os.WriteFile(DefaultConfigPath, buf.Bytes(), 0644)
 }
 
-func SetConfigToken(token string) error {
+func setConfigMapValue(mappingNode *yaml.Node, key, value string) {
+	for i := 0; i < len(mappingNode.Content)-1; i += 2 {
+		if mappingNode.Content[i].Value == key {
+			mappingNode.Content[i+1] = &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Tag:   "!!str",
+				Value: value,
+			}
+			return
+		}
+	}
+
+	mappingNode.Content = append(mappingNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key},
+		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value},
+	)
+}
+
+func updateConfigValues(entries [][2]string) error {
 	configBytes, err := os.ReadFile(DefaultConfigPath)
 	if err != nil {
 		return err
-	}
-
-	if len(bytes.TrimSpace(configBytes)) == 0 {
-		return os.WriteFile(DefaultConfigPath, []byte(fmt.Sprintf("secret_key: %s\n", token)), 0644)
 	}
 
 	var configNode yaml.Node
@@ -417,24 +431,35 @@ func SetConfigToken(token string) error {
 	}
 
 	mappingNode := configNode.Content[0]
-	for i := 0; i < len(mappingNode.Content)-1; i += 2 {
-		if mappingNode.Content[i].Value == "secret_key" {
-			mappingNode.Content[i+1] = &yaml.Node{
-				Kind:  yaml.ScalarNode,
-				Tag:   "!!str",
-				Value: token,
-			}
-
-			return writeConfigNode(&configNode)
-		}
+	for _, entry := range entries {
+		setConfigMapValue(mappingNode, entry[0], entry[1])
 	}
 
-	mappingNode.Content = append(mappingNode.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "secret_key"},
-		&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: token},
-	)
-
 	return writeConfigNode(&configNode)
+}
+
+func updateAuthValues(token string, downloadedConfig string) error {
+	var downloaded struct {
+		ServerUrl string `yaml:"server_url"`
+		SshUrl    string `yaml:"ssh_url"`
+	}
+	if err := yaml.Unmarshal([]byte(downloadedConfig), &downloaded); err != nil {
+		return err
+	}
+
+	entries := [][2]string{{"secret_key", token}}
+	if downloaded.ServerUrl != "" {
+		// the server doesn't send tunnel_url; tunnels are served on the server_url domain
+		entries = append(entries,
+			[2]string{"server_url", downloaded.ServerUrl},
+			[2]string{"tunnel_url", downloaded.ServerUrl},
+		)
+	}
+	if downloaded.SshUrl != "" {
+		entries = append(entries, [2]string{"ssh_url", downloaded.SshUrl})
+	}
+
+	return updateConfigValues(entries)
 }
 
 func GetConfig(token string, remote string) error {
@@ -467,7 +492,7 @@ func GetConfig(token string, remote string) error {
 	}
 
 	if configFileExists {
-		return SetConfigToken(token)
+		return updateAuthValues(token, response.Message)
 	}
 
 	return SetConfig(response.Message)

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -80,7 +80,7 @@ func TestLoadAcceptsDeprecatedHTTPReverseProxyOption(t *testing.T) {
 	}
 }
 
-func TestGetConfigUpdatesOnlyTokenWhenDefaultConfigExists(t *testing.T) {
+func TestGetConfigUpdatesAuthValuesWhenDefaultConfigExists(t *testing.T) {
 	configPath := filepath.Join(t.TempDir(), "config.yaml")
 	useDefaultConfigPath(t, configPath)
 
@@ -125,14 +125,44 @@ tunnels:
 	if !strings.Contains(configContent, "secret_key: new-token") {
 		t.Fatalf("expected token to be updated, got: %s", configContent)
 	}
-	if !strings.Contains(configContent, "server_url: existing.example.com") {
-		t.Fatalf("expected existing server_url to be preserved, got: %s", configContent)
+	if !strings.Contains(configContent, "server_url: downloaded.example.com") {
+		t.Fatalf("expected server_url to be updated, got: %s", configContent)
+	}
+	if !strings.Contains(configContent, "ssh_url: downloaded.example.com:2222") {
+		t.Fatalf("expected ssh_url to be updated, got: %s", configContent)
+	}
+	if !strings.Contains(configContent, "tunnel_url: downloaded.example.com") {
+		t.Fatalf("expected tunnel_url to be updated, got: %s", configContent)
 	}
 	if !strings.Contains(configContent, "name: api") || !strings.Contains(configContent, "subdomain: api-dev") {
 		t.Fatalf("expected existing tunnel to be preserved, got: %s", configContent)
 	}
-	if strings.Contains(configContent, "downloaded.example.com") || strings.Contains(configContent, "name: downloaded") {
-		t.Fatalf("expected downloaded template not to overwrite existing config, got: %s", configContent)
+	if strings.Contains(configContent, "name: downloaded") {
+		t.Fatalf("expected downloaded tunnels not to overwrite existing config, got: %s", configContent)
+	}
+}
+
+func TestUpdateConfigValuesPopulatesEmptyConfig(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	useDefaultConfigPath(t, configPath)
+
+	if err := os.WriteFile(configPath, []byte(""), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	entries := [][2]string{{"secret_key", "tok"}, {"server_url", "s.example.com"}}
+	if err := updateConfigValues(entries); err != nil {
+		t.Fatalf("update config values: %v", err)
+	}
+
+	configBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	configContent := string(configBytes)
+
+	if !strings.Contains(configContent, "secret_key: tok") || !strings.Contains(configContent, "server_url: s.example.com") {
+		t.Fatalf("expected values to be written to empty config, got: %s", configContent)
 	}
 }
 


### PR DESCRIPTION
## Problem

When a config file already exists, `portr auth set` only updates `secret_key`. Stale `server_url`, `ssh_url`, and `tunnel_url` values keep pointing at the old server, so switching servers requires manually editing the config.

## Change

- `portr auth set` now applies `server_url` and `ssh_url` from the downloaded config, and sets `tunnel_url` to the downloaded `server_url` (the server does not send `tunnel_url`; tunnels are served on the server_url domain).
- Local tunnels and all other settings in the existing config are preserved — only the auth-related keys are touched.
- `SetConfigToken` generalized into `updateConfigValues` (multi-key update on the YAML node, updating in place or appending), with the auth allowlist in a new `updateAuthValues` helper. The redundant empty-file fast path with hand-rolled YAML serialization was removed; the existing zero-node branch handles it.
- Fresh-install path (no config file) unchanged: downloaded config written wholesale.

## Tests

- `TestGetConfigUpdatesAuthValuesWhenDefaultConfigExists` (renamed): asserts all four keys update from the download while existing tunnels are preserved and the downloaded tunnel template does not overwrite them.
- `TestUpdateConfigValuesPopulatesEmptyConfig`: covers the empty-config-file path after removing the fast path.