### PR TITLE
fix: stop leaking team secret keys

### DIFF
--- a/internal/server/admin/api/team/handlers.go
+++ b/internal/server/admin/api/team/handlers.go
@@ -50,6 +50,13 @@ type TeamUserForTeamResponse struct {
 	CreatedAt string       `json:"created_at"`
 }
 
+type TeamUserListResponse struct {
+	ID        uint         `json:"id"`
+	User      UserResponse `json:"user"`
+	Role      string       `json:"role"`
+	CreatedAt string       `json:"created_at"`
+}
+
 type UserResponse struct {
 	ID          uint                `json:"id"`
 	Email       string              `json:"email"`
@@ -224,7 +231,7 @@ func (h *Handler) GetTeamUsers(c *fiber.Ctx) error {
 	}
 
 	// Build response
-	var items []TeamUserForTeamResponse
+	var items []TeamUserListResponse
 	for _, tu := range teamUsers {
 		userResp := UserResponse{
 			ID:          tu.User.ID,
@@ -240,11 +247,10 @@ func (h *Handler) GetTeamUsers(c *fiber.Ctx) error {
 			}
 		}
 
-		items = append(items, TeamUserForTeamResponse{
+		items = append(items, TeamUserListResponse{
 			ID:        tu.ID,
 			User:      userResp,
 			Role:      tu.Role,
-			SecretKey: tu.SecretKey,
 			CreatedAt: tu.CreatedAt.Format("2006-01-02T15:04:05Z"),
 		})
 	}

--- a/internal/server/admin/web-v2/src/types/index.ts
+++ b/internal/server/admin/web-v2/src/types/index.ts
@@ -30,7 +30,6 @@ export interface TeamUser {
   team: Team
   user: User
   role: "admin" | "member"
-  secret_key: string
 }
 
 export interface InstanceSettings {

--- a/tests/server/admin_team_users_test.go
+++ b/tests/server/admin_team_users_test.go
@@ -62,17 +62,24 @@ func TestListTeamUsers_ReturnsUsers(t *testing.T) {
 		t.Fatalf("expected non-empty data array, got: %v", body["data"])
 	}
 
-	// Ensure emails present
+	// Ensure emails present and secret keys are not exposed.
 	foundOwner, foundMember := false, false
 	for _, item := range data {
-		if m, ok := item.(map[string]interface{}); ok {
-			if userObj, ok := m["user"].(map[string]interface{}); ok {
-				if userObj["email"] == owner.Email {
-					foundOwner = true
-				}
-				if userObj["email"] == member.Email {
-					foundMember = true
-				}
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			t.Fatalf("expected team user object in response, got: %v", item)
+		}
+
+		if _, exists := m["secret_key"]; exists {
+			t.Fatalf("team user list response must not expose secret_key")
+		}
+
+		if userObj, ok := m["user"].(map[string]interface{}); ok {
+			if userObj["email"] == owner.Email {
+				foundOwner = true
+			}
+			if userObj["email"] == member.Email {
+				foundMember = true
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- Remove `secret_key` from team user list responses.
- Keep current-user/add-user secret-key behavior unchanged.
- Add regression coverage and update admin UI list type.

## Tests
- `go test ./tests/server -run TestListTeamUsers_ReturnsUsers -count=1`
- `go test ./...`
- `go build ./...`
- `bun run --cwd internal/server/admin/web-v2 tsc --noEmit`
