### PR TITLE
fix: sandbox inspector html previews

### DIFF
--- a/internal/client/dashboard/handler/tunnels.go
+++ b/internal/client/dashboard/handler/tunnels.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"mime"
 	"strconv"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/amalshaji/portr/internal/client/db"
@@ -173,6 +175,16 @@ func (h *Handler) GetWebSocketSession(c *fiber.Ctx) error {
 	})
 }
 
+func isHTMLContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+
+	mediaType = strings.ToLower(mediaType)
+	return mediaType == "text/html" || strings.HasSuffix(mediaType, "+html")
+}
+
 func (h *Handler) RenderResponse(c *fiber.Ctx) error {
 	requestID := c.Params("id")
 	request, err := h.service.GetRequestById(requestID)
@@ -209,6 +221,11 @@ func (h *Handler) RenderResponse(c *fiber.Ctx) error {
 	contentLength := headersMap["Content-Length"]
 	if len(contentLength) == 0 {
 		contentLength = []string{fmt.Sprintf("%d", len(body))}
+	}
+
+	if isHTMLContentType(contentType[0]) {
+		c.Response().Header.Set("Content-Security-Policy", "sandbox")
+		c.Response().Header.Set("X-Content-Type-Options", "nosniff")
 	}
 
 	c.Response().Header.Set("Content-Type", contentType[0])

--- a/internal/client/dashboard/handler/tunnels_test.go
+++ b/internal/client/dashboard/handler/tunnels_test.go
@@ -4,13 +4,15 @@ import (
 	"encoding/json"
 	"io"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/db"
 	"github.com/amalshaji/portr/internal/client/dashboard/service"
+	"github.com/amalshaji/portr/internal/client/db"
 	"github.com/glebarez/sqlite"
 	"github.com/gofiber/fiber/v2"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -126,6 +128,56 @@ func TestGetRequestByIdOverHTTP(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != fiber.StatusNotFound {
 		t.Fatalf("expected 404 for missing request, got %d", resp.StatusCode)
+	}
+}
+
+func TestRenderResponseAddsSandboxHeadersForHTML(t *testing.T) {
+	app, conn := newTestApp(t)
+	body := []byte("<html><body>preview</body></html>")
+	headers, err := json.Marshal(map[string][]string{
+		"Content-Type":   {"text/html; charset=utf-8"},
+		"Content-Length": {strconv.Itoa(len(body))},
+	})
+	if err != nil {
+		t.Fatalf("marshal headers: %v", err)
+	}
+
+	if err := conn.Create(&db.Request{
+		ID:                 "html-response",
+		Subdomain:          "alpha",
+		Localport:          3000,
+		Url:                "/preview",
+		Method:             "GET",
+		ResponseHeaders:    datatypes.JSON(headers),
+		ResponseBody:       body,
+		ResponseStatusCode: fiber.StatusOK,
+		LoggedAt:           time.Now(),
+	}).Error; err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	resp, err := app.Test(httptest.NewRequest("GET", "/api/tunnels/render/html-response?type=response", nil))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Content-Security-Policy"); got != "sandbox" {
+		t.Fatalf("expected sandbox CSP header, got %q", got)
+	}
+	if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("expected nosniff header, got %q", got)
+	}
+
+	rendered, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if string(rendered) != string(body) {
+		t.Fatalf("expected body %q, got %q", string(body), string(rendered))
 	}
 }
 

--- a/internal/client/dashboard/ui-v2/src/components/payload-viewer.test.tsx
+++ b/internal/client/dashboard/ui-v2/src/components/payload-viewer.test.tsx
@@ -42,6 +42,8 @@ describe("PayloadViewer", () => {
     render(<PayloadViewer request={makeRequest()} type="response" />)
 
     const iframe = screen.getByTitle("Response body")
+    expect(iframe.getAttribute("sandbox")).toBe("")
+    expect(iframe.getAttribute("referrerpolicy")).toBe("no-referrer")
     expect(iframe.getAttribute("scrolling")).toBe("yes")
     expect(iframe.parentElement?.className.includes("h-full")).toBe(true)
   })

--- a/internal/client/dashboard/ui-v2/src/components/payload-viewer.tsx
+++ b/internal/client/dashboard/ui-v2/src/components/payload-viewer.tsx
@@ -210,6 +210,8 @@ export function PayloadViewer({ request, type }: PayloadViewerProps) {
       <div className="min-h-0 h-full overflow-hidden border bg-background">
         <iframe
           className="block h-[26rem] min-h-[18rem] w-full bg-white xl:h-full"
+          referrerPolicy="no-referrer"
+          sandbox=""
           scrolling="yes"
           src={renderUrl}
           title={readOnlyLabel(type)}


### PR DESCRIPTION
## Summary
- Add a strict sandbox and no-referrer policy to HTML preview iframes.
- Add server-side sandbox CSP/nosniff headers for rendered HTML payloads.
- Cover both frontend iframe attributes and handler headers.

## Tests
- `go test ./internal/client/dashboard/handler -count=1`
- `bun run --cwd internal/client/dashboard/ui-v2 test -- src/components/payload-viewer.test.tsx`
- `bun run --cwd internal/client/dashboard/ui-v2 typecheck`
- `go test ./...`
