### PR TITLE
fix: restrict client config file permissions

### DIFF
--- a/cmd/portr/updates.go
+++ b/cmd/portr/updates.go
@@ -25,21 +25,25 @@ type UpdateInfo struct {
 func createUpdatesFileIfNotExists() error {
 	if _, err := os.Stat(UpdatesFilePath); err != nil {
 		if os.IsNotExist(err) {
-			f, err := os.Create(UpdatesFilePath)
+			f, err := os.OpenFile(UpdatesFilePath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 			if err != nil {
 				return err
 			}
-			defer f.Close()
 
 			if _, err := f.WriteString("{}"); err != nil {
+				_ = f.Close()
 				return err
 			}
-		} else {
-			return err
+			if err := f.Close(); err != nil {
+				return err
+			}
+
+			return os.Chmod(UpdatesFilePath, 0o600)
 		}
+		return err
 	}
 
-	return nil
+	return os.Chmod(UpdatesFilePath, 0o600)
 }
 
 func getUpdateState() (UpdateInfo, error) {
@@ -130,11 +134,11 @@ func getLatestRelease() error {
 		return err
 	}
 
-	if err := os.WriteFile(UpdatesFilePath, data, 0644); err != nil {
+	if err := os.WriteFile(UpdatesFilePath, data, 0o600); err != nil {
 		return err
 	}
 
-	return nil
+	return os.Chmod(UpdatesFilePath, 0o600)
 }
 
 func getVersionToUpdate() (string, error) {

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -326,13 +326,15 @@ func initConfig() error {
 		return nil
 	}
 
-	f, err := os.Create(DefaultConfigPath)
+	f, err := os.OpenFile(DefaultConfigPath, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	if err := f.Close(); err != nil {
+		return err
+	}
 
-	return nil
+	return os.Chmod(DefaultConfigPath, 0o600)
 }
 
 func EditConfig() error {
@@ -366,6 +368,14 @@ func EditConfig() error {
 	return nil
 }
 
+func writeDefaultConfigFile(data []byte) error {
+	if err := os.WriteFile(DefaultConfigPath, data, 0o600); err != nil {
+		return err
+	}
+
+	return os.Chmod(DefaultConfigPath, 0o600)
+}
+
 func SetConfig(config string) error {
 	if !checkDefaultConfigFileExists() {
 		err := initConfig()
@@ -374,7 +384,7 @@ func SetConfig(config string) error {
 		}
 	}
 
-	return os.WriteFile(DefaultConfigPath, []byte(config), 0644)
+	return writeDefaultConfigFile([]byte(config))
 }
 
 func writeConfigNode(configNode *yaml.Node) error {
@@ -389,7 +399,7 @@ func writeConfigNode(configNode *yaml.Node) error {
 		return err
 	}
 
-	return os.WriteFile(DefaultConfigPath, buf.Bytes(), 0644)
+	return writeDefaultConfigFile(buf.Bytes())
 }
 
 func setConfigMapValue(mappingNode *yaml.Node, key, value string) {

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -166,6 +166,47 @@ func TestUpdateConfigValuesPopulatesEmptyConfig(t *testing.T) {
 	}
 }
 
+func assertPrivateFileMode(t *testing.T, path string) {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected private file permissions, got %v", info.Mode().Perm())
+	}
+}
+
+func TestSetConfigWritesPrivateConfigFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	useDefaultConfigPath(t, configPath)
+
+	if err := SetConfig("secret_key: dummy-token\n"); err != nil {
+		t.Fatalf("set config: %v", err)
+	}
+
+	assertPrivateFileMode(t, configPath)
+}
+
+func TestUpdateConfigValuesCorrectsExistingConfigFilePermissions(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	useDefaultConfigPath(t, configPath)
+
+	if err := os.WriteFile(configPath, []byte("secret_key: old-token\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := os.Chmod(configPath, 0o644); err != nil {
+		t.Fatalf("chmod config: %v", err)
+	}
+
+	if err := updateConfigValues([][2]string{{"secret_key", "new-token"}}); err != nil {
+		t.Fatalf("update config values: %v", err)
+	}
+
+	assertPrivateFileMode(t, configPath)
+}
+
 func TestGetDashboardDisableLabel(t *testing.T) {
 	cfg := Config{
 		DisableDashboard: true,

--- a/internal/utils/dir.go
+++ b/internal/utils/dir.go
@@ -1,14 +1,24 @@
 package utils
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
 func EnsureDirExists(path string) error {
-	_, err := os.Stat(path)
+	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		err = os.MkdirAll(path, os.ModePerm)
-		if err != nil {
+		if err := os.MkdirAll(path, 0o700); err != nil {
 			return err
 		}
+		return os.Chmod(path, 0o700)
 	}
-	return nil
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s exists and is not a directory", path)
+	}
+
+	return os.Chmod(path, 0o700)
 }

--- a/internal/utils/dir_test.go
+++ b/internal/utils/dir_test.go
@@ -2,17 +2,58 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-const randomFolderName = "portr_test_123456"
+func TestEnsureDirExistsCreatesPrivateDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "portr", "config")
 
-func TestEnsureDirExists(t *testing.T) {
-	_ = EnsureDirExists(randomFolderName)
-	defer os.Remove(randomFolderName)
+	if err := EnsureDirExists(path); err != nil {
+		t.Fatalf("ensure dir exists: %v", err)
+	}
 
-	_, err := os.Stat(randomFolderName)
-	assert.Nil(t, err)
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat directory: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("expected directory, got %v", info.Mode())
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected private directory permissions, got %v", info.Mode().Perm())
+	}
+}
+
+func TestEnsureDirExistsCorrectsExistingDirectoryPermissions(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "portr")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatalf("create directory: %v", err)
+	}
+	if err := os.Chmod(path, 0o755); err != nil {
+		t.Fatalf("chmod directory: %v", err)
+	}
+
+	if err := EnsureDirExists(path); err != nil {
+		t.Fatalf("ensure dir exists: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat directory: %v", err)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Fatalf("expected private directory permissions, got %v", info.Mode().Perm())
+	}
+}
+
+func TestEnsureDirExistsRejectsFiles(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config")
+	if err := os.WriteFile(path, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if err := EnsureDirExists(path); err == nil {
+		t.Fatal("expected error for file path, got nil")
+	}
 }


### PR DESCRIPTION
## Summary
- Create/correct Portr config directory permissions to owner-only.
- Write config and update-state files as owner-only.
- Add filesystem permission regression tests.

## Tests
- `go test ./internal/utils ./internal/client/config ./cmd/portr -count=1`
- `go test ./...`
- `go build ./...`
