### PR TITLE
fix: validate oauth next redirects

### DIFF
--- a/internal/server/admin/api/auth/handlers.go
+++ b/internal/server/admin/api/auth/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"strings"
 
 	"github.com/amalshaji/portr/internal/server/admin/models"
 	"github.com/amalshaji/portr/internal/server/admin/services"
@@ -33,6 +34,21 @@ func NewHandler(db *gorm.DB, store *session.Store, cfg *serverConfig.AdminConfig
 type LoginInput struct {
 	Email    string `json:"email" validate:"required,email"`
 	Password string `json:"password" validate:"required"`
+}
+
+func safeNextPath(raw string) (string, bool) {
+	path := strings.TrimSpace(raw)
+	if path == "" || !strings.HasPrefix(path, "/") || strings.HasPrefix(path, "//") {
+		return "", false
+	}
+
+	for i := 0; i < len(path); i++ {
+		if path[i] < 0x20 || path[i] == 0x7f {
+			return "", false
+		}
+	}
+
+	return path, true
 }
 
 func (h *Handler) GetAuthConfig(c *fiber.Ctx) error {
@@ -195,10 +211,13 @@ func (h *Handler) GitHubLogin(c *fiber.Ctx) error {
 	}
 
 	// Handle next URL parameter for post-login redirect
-	nextURL := c.Query("next")
-	if nextURL != "" {
+	if nextURL, ok := safeNextPath(c.Query("next")); ok {
 		sess.Set("portr_next_url", nextURL)
-		sess.Save()
+		if err := sess.Save(); err != nil {
+			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+				"error": "Failed to save session",
+			})
+		}
 	}
 
 	authURL := h.githubService.GetAuthURL(state)
@@ -310,8 +329,10 @@ func (h *Handler) GitHubCallback(c *fiber.Ctx) error {
 	sess.Save()
 
 	if nextURL != nil {
-		if nextURLStr, ok := nextURL.(string); ok && nextURLStr != "" {
-			return c.Redirect(nextURLStr, fiber.StatusFound)
+		if nextURLStr, ok := nextURL.(string); ok {
+			if safePath, ok := safeNextPath(nextURLStr); ok {
+				return c.Redirect(safePath, fiber.StatusFound)
+			}
 		}
 	}
 

--- a/internal/server/admin/api/auth/handlers_test.go
+++ b/internal/server/admin/api/auth/handlers_test.go
@@ -1,0 +1,35 @@
+package auth
+
+import "testing"
+
+func TestSafeNextPath(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		ok   bool
+	}{
+		{name: "admin path", raw: "/team/overview", want: "/team/overview", ok: true},
+		{name: "query string", raw: "/team/users?page=2", want: "/team/users?page=2", ok: true},
+		{name: "root", raw: "/", want: "/", ok: true},
+		{name: "trim whitespace", raw: " /team/overview ", want: "/team/overview", ok: true},
+		{name: "https url", raw: "https://example.invalid/path", ok: false},
+		{name: "http url", raw: "http://example.invalid/path", ok: false},
+		{name: "protocol relative", raw: "//example.invalid/path", ok: false},
+		{name: "javascript", raw: "javascript:alert(1)", ok: false},
+		{name: "newline", raw: "/team/overview\nLocation: https://example.invalid", ok: false},
+		{name: "carriage return", raw: "/team/overview\rLocation: https://example.invalid", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := safeNextPath(tt.raw)
+			if ok != tt.ok {
+				t.Fatalf("expected ok=%v, got %v", tt.ok, ok)
+			}
+			if got != tt.want {
+				t.Fatalf("expected path %q, got %q", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Restrict GitHub OAuth `next` redirects to safe relative paths.
- Revalidate stored session redirect values at callback time.
- Add package-level sanitizer tests.

## Tests
- `go test ./internal/server/admin/api/auth -count=1`
- `go test ./tests/server -run Auth -count=1`
- `go test ./...`
- `go build ./...`
