### PR TITLE
fix: validate admin api inputs

### DIFF
--- a/internal/server/admin/api/auth/handlers.go
+++ b/internal/server/admin/api/auth/handlers.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"net/mail"
+	"strings"
 
 	"github.com/amalshaji/portr/internal/server/admin/models"
 	"github.com/amalshaji/portr/internal/server/admin/services"
@@ -55,9 +57,27 @@ func (h *Handler) Login(c *fiber.Ctx) error {
 		})
 	}
 
+	input.Email = strings.TrimSpace(input.Email)
+	parsedEmail, parseErr := mail.ParseAddress(input.Email)
+	if input.Email == "" || parseErr != nil || parsedEmail.Address != input.Email {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"email": "Enter a valid email address",
+		})
+	}
+	if strings.TrimSpace(input.Password) == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"password": "Password is required",
+		})
+	}
+
 	// Check if this is the first user
 	var userCount int64
 	h.db.Model(&models.User{}).Count(&userCount)
+	if userCount == 0 && len(input.Password) < 8 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"password": "Password must be at least 8 characters",
+		})
+	}
 
 	var user *models.User
 	var err error

--- a/internal/server/admin/api/connection/handlers.go
+++ b/internal/server/admin/api/connection/handlers.go
@@ -2,10 +2,12 @@ package connection
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/amalshaji/portr/internal/server/admin/middleware"
 	"github.com/amalshaji/portr/internal/server/admin/models"
+	"github.com/amalshaji/portr/internal/utils"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/session"
 	"gorm.io/gorm"
@@ -164,24 +166,44 @@ func (h *Handler) CreateConnection(c *fiber.Ctx) error {
 		})
 	}
 
+	secretKey := strings.TrimSpace(input.SecretKey)
+	if secretKey == "" {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Secret key is required",
+		})
+	}
+	if input.ConnectionType != models.ConnectionTypeHTTP && input.ConnectionType != models.ConnectionTypeTCP {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"message": "Connection type must be either 'http' or 'tcp'",
+		})
+	}
+	if input.ConnectionType == models.ConnectionTypeHTTP {
+		if input.Subdomain == nil || strings.TrimSpace(*input.Subdomain) == "" {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"message": "Subdomain is required for HTTP connections",
+			})
+		}
+
+		subdomain := strings.TrimSpace(*input.Subdomain)
+		if err := utils.ValidateSubdomain(subdomain); err != nil {
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"message": "Invalid subdomain",
+			})
+		}
+		input.Subdomain = &subdomain
+	}
+
 	// Find team user by secret key
 	var teamUser models.TeamUser
-	err := h.db.Preload("Team").Where("secret_key = ?", input.SecretKey).First(&teamUser).Error
+	err := h.db.Preload("Team").Where("secret_key = ?", secretKey).First(&teamUser).Error
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
 			"message": "Invalid secret key",
 		})
 	}
 
-	// Validate subdomain for HTTP connections
+	// Check if subdomain is already in use for HTTP connections
 	if input.ConnectionType == models.ConnectionTypeHTTP {
-		if input.Subdomain == nil || *input.Subdomain == "" {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-				"message": "Subdomain is required for HTTP connections",
-			})
-		}
-
-		// Check if subdomain is already in use
 		var existingConn models.Connection
 		err := h.db.Where("subdomain = ? AND status IN (?, ?)",
 			*input.Subdomain,

--- a/internal/server/admin/api/user/handlers.go
+++ b/internal/server/admin/api/user/handlers.go
@@ -1,6 +1,8 @@
 package user
 
 import (
+	"strings"
+
 	"github.com/amalshaji/portr/internal/server/admin/middleware"
 	"github.com/amalshaji/portr/internal/server/admin/models"
 	"github.com/gofiber/fiber/v2"
@@ -39,12 +41,12 @@ type TeamUserResponse struct {
 }
 
 type UserResponse struct {
-	ID          uint                 `json:"id"`
-	Email       string               `json:"email"`
-	FirstName   *string              `json:"first_name"`
-	LastName    *string              `json:"last_name"`
-	IsSuperuser bool                 `json:"is_superuser"`
-	GithubUser  *GithubUserResponse  `json:"github_user,omitempty"`
+	ID          uint                `json:"id"`
+	Email       string              `json:"email"`
+	FirstName   *string             `json:"first_name"`
+	LastName    *string             `json:"last_name"`
+	IsSuperuser bool                `json:"is_superuser"`
+	GithubUser  *GithubUserResponse `json:"github_user,omitempty"`
 }
 
 type GithubUserResponse struct {
@@ -194,6 +196,12 @@ func (h *Handler) ChangePassword(c *fiber.Ctx) error {
 	if err := c.BodyParser(&input); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
 			"error": "Invalid input",
+		})
+	}
+
+	if strings.TrimSpace(input.Password) == "" || len(input.Password) < 8 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+			"error": "Password must be at least 8 characters",
 		})
 	}
 

--- a/tests/server/admin_auth_test.go
+++ b/tests/server/admin_auth_test.go
@@ -85,6 +85,40 @@ func TestLogin_SuccessSetsSessionCookie(t *testing.T) {
 	}
 }
 
+func TestLogin_RejectsInvalidInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{name: "empty email", payload: `{"email":"","password":"password123"}`},
+		{name: "invalid email", payload: `{"email":"not-an-email","password":"password123"}`},
+		{name: "empty password", payload: `{"email":"user@example.com","password":""}`},
+		{name: "short first-signup password", payload: `{"email":"user@example.com","password":"short"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, cleanup := NewTestDB(t)
+			defer cleanup()
+
+			srv := NewTestServer(t, db)
+
+			req := httptest.NewRequest("POST", "/api/v1/auth/login", strings.NewReader(tt.payload))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp := DoRequest(t, srv, req)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected status 400 Bad Request for invalid login input, got %d", resp.StatusCode)
+			}
+			if setCookie := resp.Header.Get("Set-Cookie"); strings.Contains(setCookie, "portr_session=") {
+				t.Fatalf("expected no session cookie for invalid input, got %q", setCookie)
+			}
+		})
+	}
+}
+
 func TestLogout_RequiresAuthAndSucceedsWithSession(t *testing.T) {
 	db, cleanup := NewTestDB(t)
 	defer cleanup()

--- a/tests/server/admin_connection_test.go
+++ b/tests/server/admin_connection_test.go
@@ -205,6 +205,105 @@ func TestCreateConnection_SecretKeyInvalid_Unauthorized(t *testing.T) {
 	}
 }
 
+func TestCreateConnection_MissingSecretKey_BadRequest(t *testing.T) {
+	db, cleanup := NewTestDB(t)
+	defer cleanup()
+
+	srv := NewTestServer(t, db)
+
+	payload := map[string]interface{}{
+		"secret_key":      "",
+		"connection_type": "http",
+		"subdomain":       "some-sub",
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/v1/connections/", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := DoRequest(t, srv, req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected status 400 Bad Request for missing secret key, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var count int64
+	if err := db.Model(&models.Connection{}).Count(&count).Error; err != nil {
+		t.Fatalf("count connections: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no connections to be created, got %d", count)
+	}
+}
+
+func TestCreateConnection_UnsupportedType_BadRequest(t *testing.T) {
+	db, cleanup := NewTestDB(t)
+	defer cleanup()
+
+	srv := NewTestServer(t, db)
+
+	payload := map[string]interface{}{
+		"secret_key":      "dummy-secret",
+		"connection_type": "udp",
+		"subdomain":       "some-sub",
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/v1/connections/", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := DoRequest(t, srv, req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected status 400 Bad Request for unsupported type, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var count int64
+	if err := db.Model(&models.Connection{}).Count(&count).Error; err != nil {
+		t.Fatalf("count connections: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no connections to be created, got %d", count)
+	}
+}
+
+func TestCreateConnection_InvalidSubdomain_BadRequest(t *testing.T) {
+	db, cleanup := NewTestDB(t)
+	defer cleanup()
+
+	srv := NewTestServer(t, db)
+
+	payload := map[string]interface{}{
+		"secret_key":      "dummy-secret",
+		"connection_type": "http",
+		"subdomain":       "bad subdomain",
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	req := httptest.NewRequest("POST", "/api/v1/connections/", bytes.NewReader(payloadBytes))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := DoRequest(t, srv, req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected status 400 Bad Request for invalid subdomain, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	var count int64
+	if err := db.Model(&models.Connection{}).Count(&count).Error; err != nil {
+		t.Fatalf("count connections: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no connections to be created, got %d", count)
+	}
+}
+
 func TestCreateConnection_SubdomainConflict_Conflict(t *testing.T) {
 	db, cleanup := NewTestDB(t)
 	defer cleanup()

--- a/tests/server/admin_user_test.go
+++ b/tests/server/admin_user_test.go
@@ -185,6 +185,49 @@ func TestChangePassword_SucceedsAndPersists(t *testing.T) {
 	}
 }
 
+func TestChangePassword_RejectsInvalidPassword(t *testing.T) {
+	tests := []struct {
+		name     string
+		password string
+	}{
+		{name: "empty", password: ""},
+		{name: "whitespace", password: "   "},
+		{name: "short", password: "abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, cleanup := NewTestDB(t)
+			defer cleanup()
+
+			srv := NewTestServer(t, db)
+
+			user := CreateTestUser(t, db, "invalidpass@example.com", false)
+			sess := CreateSessionForUser(t, db, user)
+
+			payloadBytes, _ := json.Marshal(map[string]interface{}{"password": tt.password})
+			req := httptest.NewRequest("PATCH", "/api/v1/user/me/change-password", bytes.NewReader(payloadBytes))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Cookie", SessionCookieValue(sess))
+
+			resp := DoRequest(t, srv, req)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected status 400 Bad Request for invalid password, got %d", resp.StatusCode)
+			}
+
+			var persisted models.User
+			if err := db.First(&persisted, user.ID).Error; err != nil {
+				t.Fatalf("failed to reload user from DB: %v", err)
+			}
+			if !persisted.CheckPassword("password123") {
+				t.Fatalf("expected original password to remain valid")
+			}
+		})
+	}
+}
+
 func TestRotateSecretKey_SucceedsForTeamUser(t *testing.T) {
 	db, cleanup := NewTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- Reject invalid login and password-change inputs before persistence.
- Validate connection secret key, connection type, and HTTP subdomains.
- Add admin API regression coverage for invalid inputs.

## Tests
- `go test ./tests/server -run 'Test(ChangePassword|CreateConnection|Login)' -count=1`
- `go test ./...`
- `go build ./...`
