### PR TITLE
fix: restore frontend verification gates

### DIFF
--- a/internal/client/dashboard/ui-v2/src/pages/home-page.tsx
+++ b/internal/client/dashboard/ui-v2/src/pages/home-page.tsx
@@ -127,6 +127,7 @@ function TopBar({
       </div>
       <div className="flex-1" />
       <button
+        aria-label="Refresh tunnels"
         onClick={onRefresh}
         className="flex items-center gap-1.5 rounded px-2 py-1 font-mono text-[11px] transition-colors hover:bg-muted"
         style={{ color: "var(--muted-foreground)" }}

--- a/internal/client/dashboard/ui-v2/src/pages/tunnel-page.test.tsx
+++ b/internal/client/dashboard/ui-v2/src/pages/tunnel-page.test.tsx
@@ -56,6 +56,6 @@ describe("TunnelPage", () => {
       ).toBeNull()
     })
 
-    expect(screen.getByText("No request traces")).toBeTruthy()
+    expect(screen.getByText(/no requests match filter/i)).toBeTruthy()
   })
 })

--- a/internal/client/dashboard/ui-v2/src/pages/tunnel-page.tsx
+++ b/internal/client/dashboard/ui-v2/src/pages/tunnel-page.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { useNavigate, useParams, useSearchParams } from "react-router-dom"
+import { RefreshCw } from "lucide-react"
 import { toast } from "sonner"
 
 import { ServerUnavailableBanner } from "@/components/server-unavailable-banner"
@@ -38,11 +39,15 @@ function dedupeRequests(first: RequestSummary[], rest: RequestSummary[]) {
 function TopBar({
   subdomain,
   localport,
+  refreshing,
   onBack,
+  onRefresh,
 }: {
   subdomain: string
   localport: string
+  refreshing: boolean
   onBack: () => void
+  onRefresh: () => void
 }) {
   return (
     <header
@@ -64,6 +69,14 @@ function TopBar({
         </span>
       </div>
       <div className="flex-1" />
+      <button
+        aria-label="Refresh tunnel"
+        onClick={onRefresh}
+        className="flex items-center gap-1.5 rounded px-2 py-1 font-mono text-[11px] transition-colors hover:bg-muted"
+        style={{ color: "var(--muted-foreground)" }}
+      >
+        <RefreshCw className={`size-3 ${refreshing ? "animate-spin" : ""}`} />
+      </button>
       <ThemeToggle />
     </header>
   )
@@ -87,6 +100,7 @@ export function TunnelPage() {
   const [selectedSession, setSelectedSession] = React.useState<WebSocketSession | null>(null)
   const [selectedSessionEvents, setSelectedSessionEvents] = React.useState<WebSocketEvent[]>([])
   const [loading, setLoading] = React.useState(true)
+  const [refreshing, setRefreshing] = React.useState(false)
   const [pollingError, setPollingError] = React.useState<string | null>(null)
   const [replayOpen, setReplayOpen] = React.useState(false)
 
@@ -108,7 +122,8 @@ export function TunnelPage() {
 
   const loadSummary = React.useEffectEvent(async (refresh = false) => {
     if (!tunnel) return
-    if (!refresh) setLoading(true)
+    if (refresh) setRefreshing(true)
+    else setLoading(true)
     try {
       const [reqData, sessData] = await Promise.all([
         getRequests(tunnel.subdomain, tunnel.localport, {
@@ -132,6 +147,7 @@ export function TunnelPage() {
       setPollingError(err instanceof Error ? err.message : null)
     } finally {
       setLoading(false)
+      setRefreshing(false)
     }
   })
 
@@ -250,7 +266,9 @@ export function TunnelPage() {
       <TopBar
         subdomain={tunnel.subdomain}
         localport={tunnel.localport}
+        refreshing={refreshing}
         onBack={() => navigate("/")}
+        onRefresh={() => loadSummary(true)}
       />
 
       <div className="relative z-10 w-full px-6 pb-6 pt-5">

--- a/internal/server/admin/web-v2/eslint.config.js
+++ b/internal/server/admin/web-v2/eslint.config.js
@@ -19,5 +19,11 @@ export default tseslint.config([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+    },
   },
 ])

--- a/internal/server/admin/web-v2/src/components/MetricsChart.tsx
+++ b/internal/server/admin/web-v2/src/components/MetricsChart.tsx
@@ -11,6 +11,7 @@ import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
+  type ChartConfig,
 } from "@/components/ui/chart";
 import type { ChartData } from "@/types";
 
@@ -18,6 +19,13 @@ interface MetricsChartProps {
   chartData: ChartData;
   isLoading: boolean;
 }
+
+type MetricDataPoint = { timestamp: string; value: number };
+type ProcessedMetricDataPoint = {
+  timestamp: number;
+  timestampLabel: string;
+  value: number;
+};
 
 // Humanize number formatting for Y-axis labels
 const humanizeNumber = (
@@ -54,9 +62,9 @@ function MetricChart({
 }: {
   title: string;
   description: string;
-  data: any[];
+  data: ProcessedMetricDataPoint[];
   dataKey: string;
-  config: any;
+  config: ChartConfig;
   isLoading: boolean;
   isPercentage?: boolean;
 }) {
@@ -205,7 +213,7 @@ function MetricChart({
 
 export function MetricsChart({ chartData, isLoading }: MetricsChartProps) {
   // Transform data for individual charts
-  const processMetricData = (metricData: any[]) => {
+  const processMetricData = (metricData: MetricDataPoint[] | undefined) => {
     if (!metricData) return [];
 
     // Ensure we're showing the most recent data by sorting chronologically
@@ -227,13 +235,13 @@ export function MetricsChart({ chartData, isLoading }: MetricsChartProps) {
   };
 
   // Individual chart configurations
-  const memoryUsageConfig = {
+  const memoryUsageConfig: ChartConfig = {
     value: {
       label: "Memory Usage (MB)",
     },
   };
 
-  const cpuUsageConfig = {
+  const cpuUsageConfig: ChartConfig = {
     value: {
       label: "CPU Usage (%)",
     },

--- a/internal/server/admin/web-v2/src/main.tsx
+++ b/internal/server/admin/web-v2/src/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.tsx";
 // add the beginning of your app entry
-// @ts-ignore
+// @ts-expect-error vite modulepreload polyfill has no bundled type declaration
 import "vite/modulepreload-polyfill";
 
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary
- Make dashboard refresh controls accessible and restore client Vitest pass.
- Add a tunnel-page refresh control wired to existing refresh behavior.
- Remove admin UI lint errors while preserving shadcn fast-refresh warnings.

## Tests
- `bun run --cwd internal/client/dashboard/ui-v2 test`
- `bun run --cwd internal/client/dashboard/ui-v2 typecheck`
- `bun run --cwd internal/client/dashboard/ui-v2 lint`
- `bun run --cwd internal/server/admin/web-v2 tsc --noEmit`
- `bun run --cwd internal/server/admin/web-v2 lint`
