### PR TITLE
fix: clamp admin pagination inputs

### DIFF
--- a/internal/server/admin/api/connection/handlers.go
+++ b/internal/server/admin/api/connection/handlers.go
@@ -74,7 +74,13 @@ func (h *Handler) GetConnections(c *fiber.Ctx) error {
 	// Parse query parameters
 	queryType := c.Query("type", "recent") // active or recent
 	page := c.QueryInt("page", 1)
+	if page < 1 {
+		page = 1
+	}
 	pageSize := c.QueryInt("page_size", 10)
+	if pageSize < 1 {
+		pageSize = 10
+	}
 	if pageSize > 100 {
 		pageSize = 100
 	}

--- a/internal/server/admin/api/team/handlers.go
+++ b/internal/server/admin/api/team/handlers.go
@@ -197,7 +197,13 @@ func (h *Handler) GetTeamUsers(c *fiber.Ctx) error {
 
 	// Parse pagination parameters
 	page := c.QueryInt("page", 1)
+	if page < 1 {
+		page = 1
+	}
 	pageSize := c.QueryInt("page_size", 10)
+	if pageSize < 1 {
+		pageSize = 10
+	}
 	if pageSize > 100 {
 		pageSize = 100
 	}

--- a/tests/server/admin_connection_test.go
+++ b/tests/server/admin_connection_test.go
@@ -88,6 +88,44 @@ func TestGetConnections_AsTeamUser_ReturnsConnections(t *testing.T) {
 	}
 }
 
+func TestGetConnections_ClampsInvalidPagination(t *testing.T) {
+	db, cleanup := NewTestDB(t)
+	defer cleanup()
+
+	srv := NewTestServer(t, db)
+
+	user := CreateTestUser(t, db, "connclamp@example.com", false)
+	team, teamUser := CreateTeamAndTeamUser(t, db, "Conn Clamp Team", user, "admin")
+	subdomain := "connclamp"
+	conn := models.NewConnection(models.ConnectionTypeHTTP, &subdomain, teamUser)
+	if err := db.Create(conn).Error; err != nil {
+		t.Fatalf("failed to create connection in DB: %v", err)
+	}
+	sess := CreateSessionForUser(t, db, user)
+
+	req := httptest.NewRequest("GET", "/api/v1/connections/?page=-10&page_size=-50", nil)
+	req.Header.Set("Cookie", SessionCookieValue(sess))
+	req.Header.Set("X-Team-Slug", team.Slug)
+
+	resp := DoRequest(t, srv, req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 OK for clamped pagination, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if _, ok := body["count"].(float64); !ok {
+		t.Fatalf("expected count in response, got: %v", body)
+	}
+	if _, ok := body["data"].([]interface{}); !ok {
+		t.Fatalf("expected data array in response, got: %v", body)
+	}
+}
+
 func TestCreateConnection_HTTP_Success(t *testing.T) {
 	db, cleanup := NewTestDB(t)
 	defer cleanup()

--- a/tests/server/admin_team_users_test.go
+++ b/tests/server/admin_team_users_test.go
@@ -81,6 +81,39 @@ func TestListTeamUsers_ReturnsUsers(t *testing.T) {
 	}
 }
 
+func TestListTeamUsers_ClampsInvalidPagination(t *testing.T) {
+	db, cleanup := NewTestDB(t)
+	defer cleanup()
+
+	srv := NewTestServer(t, db)
+
+	owner := CreateTestUser(t, db, "listclamp@example.com", false)
+	_, ownerTeamUser := CreateTeamAndTeamUser(t, db, "List Clamp Team", owner, "admin")
+	sess := CreateSessionForUser(t, db, owner)
+
+	req := httptest.NewRequest("GET", "/api/v1/team/users?page=-10&page_size=-50", nil)
+	req.Header.Set("Cookie", SessionCookieValue(sess))
+	req.Header.Set("X-Team-Slug", ownerTeamUser.Team.Slug)
+
+	resp := DoRequest(t, srv, req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK for clamped pagination, got %d", resp.StatusCode)
+	}
+
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if _, ok := body["count"].(float64); !ok {
+		t.Fatalf("expected numeric count in response, got: %v", body["count"])
+	}
+	if _, ok := body["data"].([]interface{}); !ok {
+		t.Fatalf("expected data array in response, got: %v", body["data"])
+	}
+}
+
 func TestRemoveUser_AsAdmin_RemovesTeamUserAndUserDeletedIfNoOtherTeams(t *testing.T) {
 	db, cleanup := NewTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- Clamp negative/zero admin pagination values before computing offsets.
- Add regression tests for team users and connections list endpoints.

## Tests
- `go test ./tests/server -run 'Test(ListTeamUsers|GetConnections)' -count=1`
- `go test ./tests/server -count=1`
- `go test ./...`
- `go build ./...`
