### PR TITLE
fix: exclude node_modules from go checks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -34,7 +34,9 @@ Contributing to another codebase is not as simple as code changes, it is also ab
 
 Run checks from the repo root before opening a pull request:
 
-- `go test ./...`
-- `go build ./...`
+- `make testgo`
+- `make buildgo`
 - `pnpm --dir internal/client/dashboard/ui build`
 - `bun --cwd internal/server/admin/web-v2 run build` when you touch the admin UI
+
+The Go Make targets exclude frontend `node_modules`, which can contain Go files after dependency installation.

--- a/.github/workflows/portr-server.yml
+++ b/.github/workflows/portr-server.yml
@@ -55,10 +55,10 @@ jobs:
           cache: true
 
       - name: Build server
-        run: go build -v ./...
+        run: go build -v $(./scripts/go-packages.sh --build)
 
       - name: Test real tunnel data flow
         run: go test -race -v ./tests -run '^TestTunnelDataFlow' -count=1 -timeout=2m
 
       - name: Test server
-        run: go test -v ./...
+        run: go test -v $(./scripts/go-packages.sh)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 The repo root is flattened. Go entrypoints live in `cmd/portr` and `cmd/portrd`, with shared application code under `internal/`. Use `internal/server/admin` for admin server work, `internal/server/admin/web-v2` for the React + shadcn admin UI, and `internal/client/dashboard/ui-v2` for the client dashboard. Keep integration coverage in `tests/`, database changes in `migrations/`, and product docs in `docs-v2/`. Do not add new code under the legacy `tunnel/` path.
 
 ## Build, Test, and Development Commands
-Use `go build ./...` to compile all Go packages and binaries. Run `go test ./...` before opening a PR. Build the CLI with `make buildcli`, which outputs `./portr`.
+Use `make buildgo` to compile repo-owned Go packages and `make testgo` before opening a PR. These targets exclude frontend `node_modules`, which can contain Go files after dependency installation. Build the CLI with `make buildcli`, which outputs `./portr`.
 
 For the client dashboard:
 - `bun --cwd internal/client/dashboard/ui-v2 install`

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
 buildcli:
 	go build -o portr ./cmd/portr
 
+gopackages:
+	./scripts/go-packages.sh
+
+buildgo:
+	go build $$(./scripts/go-packages.sh --build)
+
+testgo:
+	go test $$(./scripts/go-packages.sh)
+
 installclient:
 	bun --cwd internal/client/dashboard/ui-v2 install
 

--- a/scripts/go-packages.sh
+++ b/scripts/go-packages.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+case "${1:-}" in
+  "")
+    go list ./...
+    ;;
+  --build)
+    go list -f '{{if .GoFiles}}{{.ImportPath}}{{end}}' ./...
+    ;;
+  *)
+    echo "usage: $0 [--build]" >&2
+    exit 2
+    ;;
+esac | grep -v '/node_modules/' | grep .


### PR DESCRIPTION
## Summary
- Add a repo-owned Go package listing helper that filters frontend `node_modules`.
- Wire CI and Make targets through the helper.
- Update contributor/agent guidance for safe Go checks.

## Tests
- `./scripts/go-packages.sh | grep node_modules` exits 1
- `./scripts/go-packages.sh | grep internal/client/dashboard/ui-v2/dist`
- `make testgo`
- `make buildgo`
