### PR TITLE
fix: honor request logging persistence flag

### DIFF
--- a/docs-v2/content/docs/client/request-logs.mdx
+++ b/docs-v2/content/docs/client/request-logs.mdx
@@ -14,6 +14,10 @@ the local inspector UI.
 Portr stores HTTP request logs in `~/.portr/db.sqlite`. The `logs` command only
 queries data that has already been captured on the current machine.
 
+If `enable_request_logging: false` is set in the client config, new HTTP and
+WebSocket traffic is not written to the local log database, so it will not appear
+in `portr logs`, replay, or the inspector history.
+
 <Callout type="info">
   `portr logs` works with stored HTTP tunnel requests. It does not stream live TCP
   traffic and it does not require the dashboard UI to be open.

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -200,7 +200,7 @@ These options apply to the entire client configuration:
 - **dashboard_port**: Local port for the inspector dashboard (default: 7777)
 - **disable_dashboard**: Disable the local inspector dashboard completely (default: false)
 - **disable_update_check**: Disable automatic update checks and notifications (default: false)
-- **enable_request_logging**: Enable detailed HTTP request logging (default: true)
+- **enable_request_logging**: Persist local HTTP and WebSocket inspector logs for `portr logs`, replay, and the dashboard (default: true)
 - **connection_log_retention_days**: Auto-delete connection logs older than N days (default: 0, disabled)
 - **health_check_interval**: Health check interval in seconds (default: 3)
 - **health_check_max_retries**: Maximum health check retry attempts (default: 10)

--- a/internal/client/ssh/capture.go
+++ b/internal/client/ssh/capture.go
@@ -226,7 +226,15 @@ type queuedCaptureTask struct {
 	task   captureTask
 }
 
+func (s *SshClient) requestLoggingEnabled() bool {
+	return s != nil && s.config.EnableRequestLogging
+}
+
 func (s *SshClient) submitCapture(task captureTask) bool {
+	if !s.requestLoggingEnabled() {
+		return false
+	}
+
 	s.mu.Lock()
 	if s.recorder == nil {
 		s.recorder = newCaptureRecorder()
@@ -241,6 +249,10 @@ func (s *SshClient) submitCapture(task captureTask) bool {
 }
 
 func (s *SshClient) submitCaptureContext(ctx context.Context, task captureTask) bool {
+	if !s.requestLoggingEnabled() {
+		return false
+	}
+
 	s.mu.Lock()
 	if s.recorder == nil {
 		s.recorder = newCaptureRecorder()

--- a/internal/client/ssh/local_server_error_test.go
+++ b/internal/client/ssh/local_server_error_test.go
@@ -105,8 +105,11 @@ func TestHTTPTunnelReusesForwardedConnection(t *testing.T) {
 
 	remoteConn, clientConn := net.Pipe()
 	client := &SshClient{
-		config: clientcfg.ClientConfig{Tunnel: clientcfg.Tunnel{Name: "test", Subdomain: "test", Port: 3000}},
-		db:     newTestRequestStore(t),
+		config: clientcfg.ClientConfig{
+			EnableRequestLogging: true,
+			Tunnel:               clientcfg.Tunnel{Name: "test", Subdomain: "test", Port: 3000},
+		},
+		db: newTestRequestStore(t),
 	}
 	done := make(chan struct{})
 	go func() {

--- a/internal/client/ssh/logging_test.go
+++ b/internal/client/ssh/logging_test.go
@@ -38,11 +38,10 @@ func newTestRequestStore(t *testing.T) *clientdb.Db {
 	return &clientdb.Db{Conn: conn}
 }
 
-func TestLogHttpRequestPersistsWhenRequestLoggingDisabled(t *testing.T) {
-	store := newTestRequestStore(t)
-	client := &SshClient{
+func newLoggingTestClient(store *clientdb.Db, enabled bool) *SshClient {
+	return &SshClient{
 		config: clientcfg.ClientConfig{
-			EnableRequestLogging: false,
+			EnableRequestLogging: enabled,
 			Tunnel: clientcfg.Tunnel{
 				Name:      "test-server",
 				Subdomain: "test-server",
@@ -51,7 +50,9 @@ func TestLogHttpRequestPersistsWhenRequestLoggingDisabled(t *testing.T) {
 		},
 		db: store,
 	}
+}
 
+func newHTTPLogFixtures() (*http.Request, *http.Response) {
 	request := httptest.NewRequest(
 		http.MethodPost,
 		"https://test-server.go-v1.portr.dev/requests/json",
@@ -64,6 +65,59 @@ func TestLogHttpRequestPersistsWhenRequestLoggingDisabled(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 	}
+
+	return request, response
+}
+
+func newWebSocketLogFixtures() (*http.Request, *http.Response) {
+	request := httptest.NewRequest(
+		http.MethodGet,
+		"https://test-server.go-v1.portr.dev/ws/echo",
+		nil,
+	)
+	request.Host = "test-server.go-v1.portr.dev"
+	request.Header.Set("Connection", "Upgrade")
+	request.Header.Set("Upgrade", "websocket")
+	request.Header.Set("Sec-WebSocket-Version", "13")
+
+	response := &http.Response{
+		StatusCode: http.StatusSwitchingProtocols,
+		Header: http.Header{
+			"Connection": []string{"Upgrade"},
+			"Upgrade":    []string{"websocket"},
+		},
+	}
+
+	return request, response
+}
+
+func TestLogHttpRequestDoesNotPersistWhenRequestLoggingDisabled(t *testing.T) {
+	store := newTestRequestStore(t)
+	client := newLoggingTestClient(store, false)
+	request, response := newHTTPLogFixtures()
+
+	client.logHttpRequest(
+		"req-1",
+		request,
+		[]byte(`{"ok":true}`),
+		response,
+		[]byte(`{"saved":true}`),
+		42,
+	)
+
+	var count int64
+	if err := store.Conn.Model(&clientdb.Request{}).Count(&count).Error; err != nil {
+		t.Fatalf("count requests: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expected no stored requests, got %d", count)
+	}
+}
+
+func TestLogHttpRequestPersistsWhenRequestLoggingEnabled(t *testing.T) {
+	store := newTestRequestStore(t)
+	client := newLoggingTestClient(store, true)
+	request, response := newHTTPLogFixtures()
 
 	client.logHttpRequest(
 		"req-1",
@@ -83,48 +137,70 @@ func TestLogHttpRequestPersistsWhenRequestLoggingDisabled(t *testing.T) {
 	}
 }
 
-func TestLogWebSocketSessionPersistsWhenRequestLoggingDisabled(t *testing.T) {
+func TestLogWebSocketSessionDoesNotPersistWhenRequestLoggingDisabled(t *testing.T) {
 	store := newTestRequestStore(t)
-	client := &SshClient{
-		config: clientcfg.ClientConfig{
-			EnableRequestLogging: false,
-			Tunnel: clientcfg.Tunnel{
-				Name:      "test-server",
-				Subdomain: "test-server",
-				Port:      8010,
-			},
-		},
-		db: store,
+	client := newLoggingTestClient(store, false)
+	request, response := newWebSocketLogFixtures()
+
+	sessionID := client.logWebSocketSession("handshake-1", request, response)
+	if sessionID != "" {
+		t.Fatalf("expected no websocket session id when logging is disabled, got %q", sessionID)
 	}
 
-	request := httptest.NewRequest(
-		http.MethodGet,
-		"https://test-server.go-v1.portr.dev/ws/echo",
-		nil,
-	)
-	request.Host = "test-server.go-v1.portr.dev"
-	request.Header.Set("Connection", "Upgrade")
-	request.Header.Set("Upgrade", "websocket")
-	request.Header.Set("Sec-WebSocket-Version", "13")
+	client.recordWebSocketEvent("session-1", "client", &webSocketFrame{
+		Opcode:        1,
+		IsFinal:       true,
+		Payload:       []byte("hello"),
+		PayloadLength: len("hello"),
+	})
 
-	response := &http.Response{
-		StatusCode: http.StatusSwitchingProtocols,
-		Header: http.Header{
-			"Connection": []string{"Upgrade"},
-			"Upgrade":    []string{"websocket"},
-		},
+	var sessionCount int64
+	if err := store.Conn.Model(&clientdb.WebSocketSession{}).Count(&sessionCount).Error; err != nil {
+		t.Fatalf("count websocket sessions: %v", err)
 	}
+	if sessionCount != 0 {
+		t.Fatalf("expected no stored websocket sessions, got %d", sessionCount)
+	}
+
+	var eventCount int64
+	if err := store.Conn.Model(&clientdb.WebSocketEvent{}).Count(&eventCount).Error; err != nil {
+		t.Fatalf("count websocket events: %v", err)
+	}
+	if eventCount != 0 {
+		t.Fatalf("expected no stored websocket events, got %d", eventCount)
+	}
+}
+
+func TestLogWebSocketSessionPersistsWhenRequestLoggingEnabled(t *testing.T) {
+	store := newTestRequestStore(t)
+	client := newLoggingTestClient(store, true)
+	request, response := newWebSocketLogFixtures()
 
 	sessionID := client.logWebSocketSession("handshake-1", request, response)
 	if sessionID == "" {
 		t.Fatal("expected websocket session id to be created")
 	}
 
-	var count int64
-	if err := store.Conn.Model(&clientdb.WebSocketSession{}).Count(&count).Error; err != nil {
+	client.recordWebSocketEvent(sessionID, "client", &webSocketFrame{
+		Opcode:        1,
+		IsFinal:       true,
+		Payload:       []byte("hello"),
+		PayloadLength: len("hello"),
+	})
+
+	var sessionCount int64
+	if err := store.Conn.Model(&clientdb.WebSocketSession{}).Count(&sessionCount).Error; err != nil {
 		t.Fatalf("count websocket sessions: %v", err)
 	}
-	if count != 1 {
-		t.Fatalf("expected 1 stored websocket session, got %d", count)
+	if sessionCount != 1 {
+		t.Fatalf("expected 1 stored websocket session, got %d", sessionCount)
+	}
+
+	var eventCount int64
+	if err := store.Conn.Model(&clientdb.WebSocketEvent{}).Count(&eventCount).Error; err != nil {
+		t.Fatalf("count websocket events: %v", err)
+	}
+	if eventCount != 1 {
+		t.Fatalf("expected 1 stored websocket event, got %d", eventCount)
 	}
 }

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -413,6 +413,10 @@ func (s *SshClient) logHttpRequestSized(
 	bytesIn int64,
 	bytesOut int64,
 ) {
+	if !s.requestLoggingEnabled() {
+		return
+	}
+
 	requestHeaders := make(map[string][]string)
 	for key, values := range request.Header {
 		if key == "X-Portr-Ping-Request" && len(values) > 0 {
@@ -488,10 +492,6 @@ func (s *SshClient) logHttpRequestSized(
 		} else {
 			tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
 		}
-	}
-
-	if !s.config.EnableRequestLogging {
-		return
 	}
 
 	if s.tui != nil {

--- a/internal/client/ssh/websocket.go
+++ b/internal/client/ssh/websocket.go
@@ -143,6 +143,10 @@ func (s *SshClient) logWebSocketSession(handshakeRequestID string, request *http
 }
 
 func (s *SshClient) logWebSocketSessionWithID(sessionID, handshakeRequestID string, request *http.Request, response *http.Response) string {
+	if !s.requestLoggingEnabled() {
+		return ""
+	}
+
 	requestHeadersBytes, err := json.Marshal(request.Header)
 	if err != nil {
 		if s.config.Debug {
@@ -185,6 +189,9 @@ func (s *SshClient) logWebSocketSessionWithID(sessionID, handshakeRequestID stri
 }
 
 func (s *SshClient) recordWebSocketEvent(sessionID string, direction string, frame *webSocketFrame) {
+	if !s.requestLoggingEnabled() {
+		return
+	}
 	if sessionID == "" || frame == nil {
 		return
 	}
@@ -238,6 +245,9 @@ func (s *SshClient) recordWebSocketEvent(sessionID string, direction string, fra
 }
 
 func (s *SshClient) closeWebSocketSession(sessionID string, err error) {
+	if !s.requestLoggingEnabled() {
+		return
+	}
 	if sessionID == "" {
 		return
 	}


### PR DESCRIPTION
## Summary
- Make `enable_request_logging: false` skip HTTP/WebSocket persistence, not just terminal output.
- Guard capture queue and direct persistence paths.
- Update tests and docs for the privacy behavior.

## Tests
- `go test ./internal/client/ssh -count=1`
- `go test ./internal/client/... -count=1`
- `go test ./...`
- `bun run --cwd docs-v2 mdx && bun run --cwd docs-v2 tsc --noEmit`
