### PR TITLE
fix: harden production container defaults

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,4 @@
-PORTR_DB_URL=postgres://postgres:postgres@localhost:5432/postgres
+PORTR_DB_URL=postgres://postgres:<choose-a-strong-secret>@localhost:5432/postgres
 PORTR_DOMAIN=example.com
 
 PORTR_SERVER_URL=https://example.com
@@ -20,5 +20,5 @@ PORTR_TUNNEL_DEBUG=false
 CLOUDFLARE_API_TOKEN=
 
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+POSTGRES_PASSWORD=<choose-a-strong-secret>
 POSTGRES_DB=postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,14 +37,18 @@ LABEL maintainer="Amal Shaji" \
     org.opencontainers.image.description="Server for Portr" \
     org.opencontainers.image.source="https://github.com/amalshaji/portr"
 
-RUN apk --no-cache add ca-certificates curl
+RUN apk --no-cache add ca-certificates curl \
+    && addgroup -S portr \
+    && adduser -S -G portr -h /app portr
 
 WORKDIR /app
 
 COPY --from=builder /app/portrd /app/
 COPY --from=builder /app/migrations /app/migrations
 
-RUN mkdir -p /app/data
+RUN mkdir -p /app/data && chown -R portr:portr /app
+
+USER portr
 
 EXPOSE 2222 8000 8001
 

--- a/docs-v2/content/docs/server/start-the-tunnel-server.mdx
+++ b/docs-v2/content/docs/server/start-the-tunnel-server.mdx
@@ -32,7 +32,7 @@ PORTR_ADMIN_GITHUB_CLIENT_ID= #optional
 PORTR_ADMIN_GITHUB_CLIENT_SECRET= #optional
 
 PORTR_DOMAIN=example.com
-PORTR_DB_URL=postgres://postgres:postgres@postgres:5432/postgres
+PORTR_DB_URL=postgres://postgres:<choose-a-strong-secret>@postgres:5432/postgres
 
 PORTR_SERVER_URL=https://example.com
 PORTR_SSH_URL=example.com:2222
@@ -43,9 +43,15 @@ PORTR_SSH_HOST_KEY= # PEM-encoded Ed25519 private key
 CLOUDFLARE_API_TOKEN=
 
 POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
+POSTGRES_PASSWORD=<choose-a-strong-secret>
 POSTGRES_DB=postgres
 ```
+
+<Callout type="warn">
+  Generate unique credentials for each deployment. Replace every placeholder in
+  the `.env` file, and use the same database secret in `POSTGRES_PASSWORD` and
+  `PORTR_DB_URL`.
+</Callout>
 
 ### Environment Variable Reference
 
@@ -90,6 +96,10 @@ Run the following command to start all services:
 ```shell
 docker compose -f docker-compose.prod.yaml up -d
 ```
+
+The server container runs as a non-root user. If you keep the default `./data`
+bind mount, make sure that directory is writable by the container user before
+starting the service.
 
 ### Access the admin dashboard
 


### PR DESCRIPTION
## Summary
- Run the production server image as a non-root `portr` user.
- Keep `/app/data` writable by that user.
- Replace default production DB credentials in template/docs with placeholders.

## Tests
- `go test ./...`
- `bun run --cwd docs-v2 mdx && bun run --cwd docs-v2 tsc --noEmit`
- `docker build -t portr-hardening-test .`
- `docker run --rm --entrypoint id portr-hardening-test`
