### PR TITLE
fix: require token for network app-server binds

### DIFF
--- a/cmd/portr/app_server.go
+++ b/cmd/portr/app_server.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -41,6 +43,20 @@ func appServerCmd() *cli.Command {
 	}
 }
 
+func requiresAppServerToken(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" || strings.EqualFold(host, "localhost") {
+		return false
+	}
+
+	ip := net.ParseIP(strings.Trim(host, "[]"))
+	if ip != nil {
+		return !ip.IsLoopback()
+	}
+
+	return true
+}
+
 func startAppServer(c *cli.Context) error {
 	cfg, err := config.Load(c.String("config"))
 	if err != nil {
@@ -50,9 +66,15 @@ func startAppServer(c *cli.Context) error {
 		return err
 	}
 
+	host := c.String("host")
+	token := strings.TrimSpace(c.String("token"))
+	if requiresAppServerToken(host) && token == "" {
+		return fmt.Errorf("--token or PORTR_APP_SERVER_TOKEN is required when binding app-server to %s", host)
+	}
+
 	manager := appserver.NewManager(cfg, db.New(&cfg))
-	api := appserver.NewServer(manager, c.String("token"))
-	addr := fmt.Sprintf("%s:%d", c.String("host"), c.Int("port"))
+	api := appserver.NewServer(manager, token)
+	addr := fmt.Sprintf("%s:%d", host, c.Int("port"))
 
 	errCh := make(chan error, 1)
 	go func() {

--- a/cmd/portr/app_server_test.go
+++ b/cmd/portr/app_server_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestRequiresAppServerToken(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want bool
+	}{
+		{name: "all IPv4 interfaces", host: "0.0.0.0", want: true},
+		{name: "all IPv6 interfaces", host: "::", want: true},
+		{name: "documentation IP", host: "192.0.2.10", want: true},
+		{name: "hostname", host: "example.com", want: true},
+		{name: "loopback IPv4", host: "127.0.0.1", want: false},
+		{name: "localhost", host: "localhost", want: false},
+		{name: "loopback IPv6", host: "::1", want: false},
+		{name: "bracketed loopback IPv6", host: "[::1]", want: false},
+		{name: "empty host", host: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requiresAppServerToken(tt.host); got != tt.want {
+				t.Fatalf("requiresAppServerToken(%q) = %v, want %v", tt.host, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -83,30 +83,36 @@ Command flags:
 
 ## Authentication
 
-The app-server API is unauthenticated unless you pass a token. For local-only
-development that may be enough, but any shared or non-loopback binding should
-use a token.
+The app-server API is unauthenticated only when it is bound to loopback. Portr
+requires `--token` or `PORTR_APP_SERVER_TOKEN` when you bind the app server to a
+non-loopback address such as `0.0.0.0`, `::`, or a LAN address.
 
 ```bash
-PORTR_APP_SERVER_TOKEN="change-me" portr app-server
+PORTR_APP_SERVER_TOKEN="<choose-a-token>" portr app-server
 ```
 
 Or:
 
 ```bash
-portr app-server --token "change-me"
+portr app-server --token "<choose-a-token>"
+```
+
+For example, to bind on all interfaces:
+
+```bash
+PORTR_APP_SERVER_TOKEN="<choose-a-token>" portr app-server --host 0.0.0.0
 ```
 
 When a token is configured, every API request must include:
 
 ```http
-Authorization: Bearer change-me
+Authorization: Bearer <choose-a-token>
 ```
 
 Example:
 
 ```bash
-curl -H "Authorization: Bearer change-me" \
+curl -H "Authorization: Bearer <choose-a-token>" \
   http://127.0.0.1:7778/api/v1/tunnels
 ```
 


### PR DESCRIPTION
## Summary
- Require `--token`/`PORTR_APP_SERVER_TOKEN` for non-loopback app-server binds.
- Add host classification tests.
- Update app-server docs for the enforced authentication behavior.

## Tests
- `go test ./cmd/portr -run TestRequiresAppServerToken -count=1`
- `go test ./internal/client/appserver -count=1`
- `go test ./cmd/portr ./internal/client/appserver -count=1`
- `go test ./...`
- `bun run --cwd docs-v2 mdx && bun run --cwd docs-v2 tsc --noEmit`
