### PR TITLE
Fix Docker admin asset build

### DIFF
--- a/.github/workflows/portr-server.yml
+++ b/.github/workflows/portr-server.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build client
         run: bun run --cwd internal/client/dashboard/ui-v2 build
 
+      - name: Build Docker web assets
+        run: docker build --target web-builder .
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN bun install --frozen-lockfile
 
 COPY internal/server/admin/web-v2 ./
 
-RUN bun run build
+RUN bun run build:app
 
 FROM golang:1.25-alpine AS builder
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY internal/server/admin/web-v2/package.json internal/server/admin/web-v2/bun.
 RUN bun install --frozen-lockfile
 
 COPY internal/server/admin/web-v2 ./
+COPY assets/brand/portr-mark.svg ./public/portr-mark.svg
 
 RUN bun run build:app
 

--- a/internal/server/admin/web-v2/package.json
+++ b/internal/server/admin/web-v2/package.json
@@ -7,7 +7,8 @@
     "prebuild": "../../../../scripts/sync-brand-assets.sh --check",
     "dev": "vite",
     "predev": "../../../../scripts/sync-brand-assets.sh --check",
-    "build": "tsc -b && vite build",
+    "build": "bun run build:app",
+    "build:app": "tsc -b && vite build",
     "lint": "eslint .",
     "test": "vitest run",
     "preview": "vite preview"


### PR DESCRIPTION
## Summary
- separate the admin TypeScript/Vite bundle from the repository-wide prebuild asset check
- use the bundle-only command inside the isolated Docker web-builder stage
- add a pull-request Docker web-builder smoke test so this filesystem boundary is checked before merge

## Root cause
The admin prebuild hook referenced ../../../../scripts/sync-brand-assets.sh, but the Docker stage copies only the admin package into /app/web. The relative path therefore resolved to a script that was not present in the image.

## Validation
- ./scripts/sync-brand-assets.sh --check
- bun run lint (0 errors; 7 existing warnings)
- bun run test (13 tests passed)
- bun run build
- docker build --target web-builder .
- actionlint -ignore SC2046 .github/workflows/portr-server.yml
- make buildgo
- make testgo

Failed run: https://github.com/amalshaji/portr/actions/runs/30839738780/job/91773571227