### PR TITLE
Fix README logo contrast across themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 <div align="center">
-  <img src="assets/brand/portr-mark.svg" height="300px">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/brand/portr-mark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="assets/brand/portr-mark-on-light.svg">
+    <img alt="Portr" src="assets/brand/portr-mark-on-light.svg" height="300">
+  </picture>
 </div>
 
 <br />

--- a/assets/brand/portr-mark-on-light.svg
+++ b/assets/brand/portr-mark-on-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Portr">
+  <path d="M20.8 49.8A24.5 24.5 0 1 1 43.2 49.8L38.6 37.4a11.5 11.5 0 1 0-13.2 0Z" fill="#071b2d" />
+  <path d="m29.5 34.5-3 8.5h11l-3-8.5Z" fill="#39cbd1" />
+  <path d="m26.5 45-5.7 14.3Q32 64 43.2 59.3L37.5 45Z" fill="#39cbd1" />
+  <path d="m32 29-3.2 5.4q-.6 1.1.7 1.1h5q1.3 0 .7-1.1Z" fill="#071b2d" />
+</svg>


### PR DESCRIPTION
## Summary
- use GitHub's theme-aware picture markup for the README logo
- keep the existing transparent cream mark for dark mode
- add the same vector geometry in navy for light mode, with no surrounding background block
- add accessible alternative text to the README image

## Validation
- rendered and inspected both color schemes in a browser
- confirmed light mode selects portr-mark-on-light.svg on white
- confirmed dark mode selects the existing portr-mark.svg on GitHub's dark background
- xmllint --noout assets/brand/portr-mark.svg assets/brand/portr-mark-on-light.svg
- scripts/sync-brand-assets.sh --check
- verified both SVGs are geometry-identical after color substitution