### PR TITLE
Fix docs and admin favicons across themes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN bun install --frozen-lockfile
 
 COPY internal/server/admin/web-v2 ./
 COPY assets/brand/portr-mark.svg ./public/portr-mark.svg
+COPY assets/brand/portr-mark-on-light.svg ./public/portr-mark-on-light.svg
 
 RUN bun run build:app
 

--- a/docs-v2/app/layout.tsx
+++ b/docs-v2/app/layout.tsx
@@ -31,8 +31,18 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://portr.dev"),
   manifest: "/site.webmanifest",
   icons: {
-    icon: [{ url: "/portr-mark.svg", type: "image/svg+xml" }],
-    shortcut: "/portr-mark.svg",
+    icon: [
+      {
+        url: "/portr-mark-on-light.svg",
+        type: "image/svg+xml",
+        media: "(prefers-color-scheme: light)",
+      },
+      {
+        url: "/portr-mark.svg",
+        type: "image/svg+xml",
+        media: "(prefers-color-scheme: dark)",
+      },
+    ],
   },
   alternates: {
     canonical: "/",

--- a/docs-v2/public/portr-mark-on-light.svg
+++ b/docs-v2/public/portr-mark-on-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Portr">
+  <path d="M20.8 49.8A24.5 24.5 0 1 1 43.2 49.8L38.6 37.4a11.5 11.5 0 1 0-13.2 0Z" fill="#071b2d" />
+  <path d="m29.5 34.5-3 8.5h11l-3-8.5Z" fill="#39cbd1" />
+  <path d="m26.5 45-5.7 14.3Q32 64 43.2 59.3L37.5 45Z" fill="#39cbd1" />
+  <path d="m32 29-3.2 5.4q-.6 1.1.7 1.1h5q1.3 0 .7-1.1Z" fill="#071b2d" />
+</svg>

--- a/internal/client/dashboard/ui-v2/dist/static/portr-mark-on-light.svg
+++ b/internal/client/dashboard/ui-v2/dist/static/portr-mark-on-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Portr">
+  <path d="M20.8 49.8A24.5 24.5 0 1 1 43.2 49.8L38.6 37.4a11.5 11.5 0 1 0-13.2 0Z" fill="#071b2d" />
+  <path d="m29.5 34.5-3 8.5h11l-3-8.5Z" fill="#39cbd1" />
+  <path d="m26.5 45-5.7 14.3Q32 64 43.2 59.3L37.5 45Z" fill="#39cbd1" />
+  <path d="m32 29-3.2 5.4q-.6 1.1.7 1.1h5q1.3 0 .7-1.1Z" fill="#071b2d" />
+</svg>

--- a/internal/client/dashboard/ui-v2/public/portr-mark-on-light.svg
+++ b/internal/client/dashboard/ui-v2/public/portr-mark-on-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Portr">
+  <path d="M20.8 49.8A24.5 24.5 0 1 1 43.2 49.8L38.6 37.4a11.5 11.5 0 1 0-13.2 0Z" fill="#071b2d" />
+  <path d="m29.5 34.5-3 8.5h11l-3-8.5Z" fill="#39cbd1" />
+  <path d="m26.5 45-5.7 14.3Q32 64 43.2 59.3L37.5 45Z" fill="#39cbd1" />
+  <path d="m32 29-3.2 5.4q-.6 1.1.7 1.1h5q1.3 0 .7-1.1Z" fill="#071b2d" />
+</svg>

--- a/internal/server/admin/static/index.html
+++ b/internal/server/admin/static/index.html
@@ -2,7 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/static/portr-mark.svg" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/static/portr-mark-on-light.svg"
+      media="(prefers-color-scheme: light)"
+    />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/static/portr-mark.svg"
+      media="(prefers-color-scheme: dark)"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portr Admin</title>
     <script type="module" crossorigin src="/static/assets/index-CvaZmlvk.js"></script>

--- a/internal/server/admin/static/portr-mark-on-light.svg
+++ b/internal/server/admin/static/portr-mark-on-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Portr">
+  <path d="M20.8 49.8A24.5 24.5 0 1 1 43.2 49.8L38.6 37.4a11.5 11.5 0 1 0-13.2 0Z" fill="#071b2d" />
+  <path d="m29.5 34.5-3 8.5h11l-3-8.5Z" fill="#39cbd1" />
+  <path d="m26.5 45-5.7 14.3Q32 64 43.2 59.3L37.5 45Z" fill="#39cbd1" />
+  <path d="m32 29-3.2 5.4q-.6 1.1.7 1.1h5q1.3 0 .7-1.1Z" fill="#071b2d" />
+</svg>

--- a/internal/server/admin/templates/index.html
+++ b/internal/server/admin/templates/index.html
@@ -3,7 +3,18 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" href="/static/portr-mark.svg" type="image/svg+xml" />
+    <link
+      rel="icon"
+      href="/static/portr-mark-on-light.svg"
+      type="image/svg+xml"
+      media="(prefers-color-scheme: light)"
+    />
+    <link
+      rel="icon"
+      href="/static/portr-mark.svg"
+      type="image/svg+xml"
+      media="(prefers-color-scheme: dark)"
+    />
     <title>
       Portr - Expose local http, tcp or websocket connections to the public
       internet

--- a/internal/server/admin/web-v2/index.html
+++ b/internal/server/admin/web-v2/index.html
@@ -2,7 +2,18 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/portr-mark.svg" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/portr-mark-on-light.svg"
+      media="(prefers-color-scheme: light)"
+    />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/portr-mark.svg"
+      media="(prefers-color-scheme: dark)"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Portr Admin</title>
   </head>

--- a/internal/server/admin/web-v2/public/portr-mark-on-light.svg
+++ b/internal/server/admin/web-v2/public/portr-mark-on-light.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Portr">
+  <path d="M20.8 49.8A24.5 24.5 0 1 1 43.2 49.8L38.6 37.4a11.5 11.5 0 1 0-13.2 0Z" fill="#071b2d" />
+  <path d="m29.5 34.5-3 8.5h11l-3-8.5Z" fill="#39cbd1" />
+  <path d="m26.5 45-5.7 14.3Q32 64 43.2 59.3L37.5 45Z" fill="#39cbd1" />
+  <path d="m32 29-3.2 5.4q-.6 1.1.7 1.1h5q1.3 0 .7-1.1Z" fill="#071b2d" />
+</svg>

--- a/scripts/sync-brand-assets.sh
+++ b/scripts/sync-brand-assets.sh
@@ -3,26 +3,36 @@
 set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-source_asset="$root/assets/brand/portr-mark.svg"
-targets=(
-  "$root/docs-v2/public/portr-mark.svg"
-  "$root/internal/client/dashboard/ui-v2/public/portr-mark.svg"
-  "$root/internal/client/dashboard/ui-v2/dist/static/portr-mark.svg"
-  "$root/internal/server/admin/web-v2/public/portr-mark.svg"
-  "$root/internal/server/admin/static/portr-mark.svg"
+assets=(
+  "portr-mark.svg"
+  "portr-mark-on-light.svg"
+)
+target_directories=(
+  "$root/docs-v2/public"
+  "$root/internal/client/dashboard/ui-v2/public"
+  "$root/internal/client/dashboard/ui-v2/dist/static"
+  "$root/internal/server/admin/web-v2/public"
+  "$root/internal/server/admin/static"
 )
 
 if [[ "${1:-}" == "--check" ]]; then
   status=0
-  for target in "${targets[@]}"; do
-    if ! cmp -s "$source_asset" "$target"; then
-      echo "brand asset is out of sync: ${target#$root/}" >&2
-      status=1
-    fi
+  for asset in "${assets[@]}"; do
+    source_asset="$root/assets/brand/$asset"
+    for target_directory in "${target_directories[@]}"; do
+      target="$target_directory/$asset"
+      if ! cmp -s "$source_asset" "$target"; then
+        echo "brand asset is out of sync: ${target#$root/}" >&2
+        status=1
+      fi
+    done
   done
   exit "$status"
 fi
 
-for target in "${targets[@]}"; do
-  install -m 0644 "$source_asset" "$target"
+for asset in "${assets[@]}"; do
+  source_asset="$root/assets/brand/$asset"
+  for target_directory in "${target_directories[@]}"; do
+    install -m 0644 "$source_asset" "$target_directory/$asset"
+  done
 done


### PR DESCRIPTION
## Summary
- serve the navy/cyan transparent Portr mark for light browser chrome and the cream/cyan transparent mark for dark browser chrome
- apply the theme-aware favicon declarations to docs and both admin entry points
- keep both canonical mark colorways synchronized across built and public assets

## Validation
- `bun run --cwd docs-v2 build`
- `bun run --cwd internal/server/admin/web-v2 build`
- `bun run --cwd internal/server/admin/web-v2 lint` (passes with 7 existing warnings)
- `bun run --cwd internal/server/admin/web-v2 test` (13 tests)
- `./scripts/sync-brand-assets.sh --check`
- `bash -n scripts/sync-brand-assets.sh`
- `xmllint --noout` on source and generated SVG assets
- real-browser verification in light and dark color schemes for docs and admin