### PR TITLE
Add tunnel groups to client config

### DIFF
--- a/cmd/portr/start.go
+++ b/cmd/portr/start.go
@@ -29,7 +29,7 @@ func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 		if err := tunnelFromCli.Validate(); err != nil {
 			return err
 		}
-		cfg.Tunnels = []config.Tunnel{*tunnelFromCli}
+		cfg.ReplaceTunnels(*tunnelFromCli)
 	}
 
 	if err := cfg.Validate(); err != nil {
@@ -130,8 +130,9 @@ func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 
 func startCmd() *cli.Command {
 	return &cli.Command{
-		Name:  "start",
-		Usage: "Start the tunnels from the config file",
+		Name:      "start",
+		Usage:     "Start the tunnels from the config file",
+		ArgsUsage: "[names or groups...]",
 		Action: func(c *cli.Context) error {
 			return startTunnels(c, nil)
 		},

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -195,6 +195,31 @@ Start all configured tunnels:
 portr start
 ```
 
+### Start a group
+
+Name a set of tunnels with `groups`, then start the whole set with one word:
+
+```yaml
+tunnels:
+  - name: web
+    port: 3000
+  - name: api
+    port: 8000
+  - name: pg
+    type: tcp
+    port: 5432
+
+groups:
+  frontend: [web, api]
+```
+
+```bash
+portr start frontend
+portr start frontend pg
+```
+
+A group name must not match a tunnel name, and every member must be the name of an existing tunnel.
+
 <Callout type="info">
   For more details about available commands and options, run `portr --help`.
 </Callout>
@@ -208,6 +233,7 @@ These options apply to the entire client configuration:
 - **server_url**: The Portr server URL
 - **ssh_url**: The SSH server URL for tunnel connections
 - **secret_key**: Your authentication secret key
+- **groups**: Named sets of tunnel names; `portr start <group>` starts every tunnel in the set
 - **disable_tui**: Disable the interactive terminal interface (default: false)
 - **dashboard_port**: Local port for the inspector dashboard (default: 7777)
 - **disable_dashboard**: Disable the local inspector dashboard completely (default: false)

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"sync"
 	"time"
 
@@ -124,10 +123,12 @@ func (c *Client) runFatalWorker(name string, fn func() error) {
 func (c *Client) Start(ctx context.Context, services ...string) error {
 	var clientConfigs []config.ClientConfig
 
-	for _, tunnel := range c.config.Tunnels {
-		if len(services) > 0 && !slices.Contains(services, tunnel.Name) {
-			continue
-		}
+	tunnels := c.config.SelectTunnels(services)
+	if len(tunnels) == 0 {
+		return c.config.NoMatchingTunnelsError(services)
+	}
+
+	for _, tunnel := range tunnels {
 		clientConfigs = append(clientConfigs, config.ClientConfig{
 			ServerUrl:                       c.config.ServerUrl,
 			SshUrl:                          c.config.SshUrl,
@@ -143,10 +144,6 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 			DisableTUI:                      c.config.DisableTUI,
 			InsecureSkipHostKeyVerification: *c.config.InsecureSkipHostKeyVerification,
 		})
-	}
-
-	if len(clientConfigs) == 0 {
-		return fmt.Errorf("please enter a valid service name")
 	}
 
 	var err error

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/amalshaji/portr/internal/constants"
@@ -142,24 +143,25 @@ var DefaultRedactHeaders = []string{
 }
 
 type Config struct {
-	ServerUrl                       string   `yaml:"server_url"`
-	SshUrl                          string   `yaml:"ssh_url"`
-	TunnelUrl                       string   `yaml:"tunnel_url"`
-	SecretKey                       string   `yaml:"secret_key"`
-	Tunnels                         []Tunnel `yaml:"tunnels"`
-	UseLocalHost                    bool     `yaml:"use_localhost"`
-	Debug                           bool     `yaml:"debug"`
-	UseVite                         bool     `yaml:"use_vite"`
-	DashboardPort                   int      `yaml:"dashboard_port"`
-	DisableDashboard                bool     `yaml:"disable_dashboard"`
-	EnableRequestLogging            *bool    `yaml:"enable_request_logging"`
-	RedactHeaders                   []string `yaml:"redact_headers"`
-	ConnectionLogRetentionDays      int      `yaml:"connection_log_retention_days"`
-	HealthCheckInterval             int      `yaml:"health_check_interval"`
-	HealthCheckMaxRetries           int      `yaml:"health_check_max_retries"`
-	DisableTUI                      bool     `yaml:"disable_tui"`
-	DisableUpdateCheck              bool     `yaml:"disable_update_check"`
-	InsecureSkipHostKeyVerification *bool    `yaml:"insecure_skip_host_key_verification"`
+	ServerUrl                       string              `yaml:"server_url"`
+	SshUrl                          string              `yaml:"ssh_url"`
+	TunnelUrl                       string              `yaml:"tunnel_url"`
+	SecretKey                       string              `yaml:"secret_key"`
+	Tunnels                         []Tunnel            `yaml:"tunnels"`
+	Groups                          map[string][]string `yaml:"groups"`
+	UseLocalHost                    bool                `yaml:"use_localhost"`
+	Debug                           bool                `yaml:"debug"`
+	UseVite                         bool                `yaml:"use_vite"`
+	DashboardPort                   int                 `yaml:"dashboard_port"`
+	DisableDashboard                bool                `yaml:"disable_dashboard"`
+	EnableRequestLogging            *bool               `yaml:"enable_request_logging"`
+	RedactHeaders                   []string            `yaml:"redact_headers"`
+	ConnectionLogRetentionDays      int                 `yaml:"connection_log_retention_days"`
+	HealthCheckInterval             int                 `yaml:"health_check_interval"`
+	HealthCheckMaxRetries           int                 `yaml:"health_check_max_retries"`
+	DisableTUI                      bool                `yaml:"disable_tui"`
+	DisableUpdateCheck              bool                `yaml:"disable_update_check"`
+	InsecureSkipHostKeyVerification *bool               `yaml:"insecure_skip_host_key_verification"`
 }
 
 func (c *Config) SetDefaults() {
@@ -215,13 +217,88 @@ func (c Config) Validate() error {
 		return fmt.Errorf("dashboard_port must be between 1 and 65535")
 	}
 
+	tunnelNames := make(map[string]bool, len(c.Tunnels))
 	for _, tunnel := range c.Tunnels {
 		if err := tunnel.Validate(); err != nil {
 			return err
 		}
+		if tunnel.Name != "" {
+			tunnelNames[tunnel.Name] = true
+		}
+	}
+
+	for group, members := range c.Groups {
+		if tunnelNames[group] {
+			return fmt.Errorf("group %q conflicts with a tunnel of the same name", group)
+		}
+		if len(members) == 0 {
+			return fmt.Errorf("group %q must reference at least one tunnel", group)
+		}
+		for _, member := range members {
+			if !tunnelNames[member] {
+				return fmt.Errorf("group %q references unknown tunnel %q", group, member)
+			}
+		}
 	}
 
 	return nil
+}
+
+// ReplaceTunnels swaps in tunnels defined outside the config file. Groups are
+// dropped because they can only reference tunnels from the config file.
+func (c *Config) ReplaceTunnels(tunnels ...Tunnel) {
+	c.Tunnels = tunnels
+	c.Groups = nil
+}
+
+// SelectTunnels returns the tunnels matching the given tunnel or group names.
+// Passing no names selects every tunnel.
+func (c Config) SelectTunnels(services []string) []Tunnel {
+	if len(services) == 0 {
+		return c.Tunnels
+	}
+
+	names := c.expandGroups(services)
+
+	var selected []Tunnel
+	for _, tunnel := range c.Tunnels {
+		if slices.Contains(names, tunnel.Name) {
+			selected = append(selected, tunnel)
+		}
+	}
+	return selected
+}
+
+func (c Config) expandGroups(services []string) []string {
+	expanded := make([]string, 0, len(services))
+	for _, service := range services {
+		if members, ok := c.Groups[service]; ok {
+			expanded = append(expanded, members...)
+			continue
+		}
+		expanded = append(expanded, service)
+	}
+	return expanded
+}
+
+func (c Config) NoMatchingTunnelsError(services []string) error {
+	var available []string
+	for _, tunnel := range c.Tunnels {
+		if tunnel.Name != "" {
+			available = append(available, tunnel.Name)
+		}
+	}
+	for group := range c.Groups {
+		available = append(available, group+" (group)")
+	}
+
+	if len(available) == 0 {
+		return fmt.Errorf("no named tunnels configured; run `portr config edit` to add one")
+	}
+	slices.Sort(available)
+
+	return fmt.Errorf("no tunnel or group matched %s; available: %s",
+		strings.Join(services, ", "), strings.Join(available, ", "))
 }
 
 func (c Config) GetAdminAddress() string {

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -426,6 +427,213 @@ func TestValidateRejectsStubTunnelWithoutSubdomain(t *testing.T) {
 		t.Fatal("expected missing subdomain error")
 	}
 	if !strings.Contains(err.Error(), "subdomain is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func groupedTunnelsConfig() Config {
+	return Config{
+		Tunnels: []Tunnel{
+			{Name: "web", Port: 3000},
+			{Name: "api", Port: 8000},
+			{Name: "pg", Type: constants.Tcp, Port: 5432},
+		},
+		Groups: map[string][]string{"frontend": {"web", "api"}},
+	}
+}
+
+func selectedTunnelNames(tunnels []Tunnel) []string {
+	names := make([]string, 0, len(tunnels))
+	for _, tunnel := range tunnels {
+		names = append(names, tunnel.Name)
+	}
+	return names
+}
+
+func TestSelectTunnelsExpandsGroup(t *testing.T) {
+	cfg := groupedTunnelsConfig()
+
+	got := selectedTunnelNames(cfg.SelectTunnels([]string{"frontend"}))
+
+	want := []string{"web", "api"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSelectTunnelsCombinesGroupAndTunnelNames(t *testing.T) {
+	cfg := groupedTunnelsConfig()
+
+	got := selectedTunnelNames(cfg.SelectTunnels([]string{"frontend", "pg"}))
+
+	want := []string{"web", "api", "pg"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSelectTunnelsSelectsOverlappingTunnelOnce(t *testing.T) {
+	cfg := groupedTunnelsConfig()
+
+	got := selectedTunnelNames(cfg.SelectTunnels([]string{"frontend", "api"}))
+
+	want := []string{"web", "api"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSelectTunnelsWithoutServicesSelectsAll(t *testing.T) {
+	cfg := groupedTunnelsConfig()
+
+	got := selectedTunnelNames(cfg.SelectTunnels(nil))
+
+	want := []string{"web", "api", "pg"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestSelectTunnelsWithUnknownNameSelectsNothing(t *testing.T) {
+	cfg := groupedTunnelsConfig()
+
+	if got := cfg.SelectTunnels([]string{"frontnd"}); len(got) != 0 {
+		t.Fatalf("expected no tunnels, got %q", selectedTunnelNames(got))
+	}
+}
+
+func TestReplaceTunnelsDropsGroups(t *testing.T) {
+	cfg := groupedTunnelsConfig()
+
+	cfg.ReplaceTunnels(Tunnel{Name: "cli", Port: 4000})
+	cfg.SetDefaults()
+
+	if cfg.Groups != nil {
+		t.Fatalf("expected groups to be dropped, got %v", cfg.Groups)
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config after replacing tunnels, got %v", err)
+	}
+}
+
+func TestValidateRejectsGroupWithUnknownTunnel(t *testing.T) {
+	cfg := Config{
+		Tunnels: []Tunnel{{Name: "web", Port: 3000}},
+		Groups:  map[string][]string{"frontend": {"web", "missing"}},
+	}
+	cfg.SetDefaults()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected unknown tunnel error")
+	}
+	if !strings.Contains(err.Error(), "references unknown tunnel") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsGroupNameMatchingTunnelName(t *testing.T) {
+	cfg := Config{
+		Tunnels: []Tunnel{{Name: "web", Port: 3000}},
+		Groups:  map[string][]string{"web": {"web"}},
+	}
+	cfg.SetDefaults()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected group name conflict error")
+	}
+	if !strings.Contains(err.Error(), "conflicts with a tunnel") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsGroupMemberWithEmptyName(t *testing.T) {
+	cfg := Config{
+		Tunnels: []Tunnel{{Port: 3000}, {Name: "api", Port: 8000}},
+		Groups:  map[string][]string{"frontend": {""}},
+	}
+	cfg.SetDefaults()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected unnamed tunnel to be unreferenceable")
+	}
+	if !strings.Contains(err.Error(), "references unknown tunnel") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyGroup(t *testing.T) {
+	cfg := Config{
+		Tunnels: []Tunnel{{Name: "web", Port: 3000}},
+		Groups:  map[string][]string{"frontend": {}},
+	}
+	cfg.SetDefaults()
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected empty group error")
+	}
+	if !strings.Contains(err.Error(), "must reference at least one tunnel") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadParsesTunnelGroups(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	configContent := `tunnels:
+  - name: web
+    port: 3000
+  - name: api
+    port: 8000
+groups:
+  frontend: [web, api]
+`
+	if err := os.WriteFile(path, []byte(configContent), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	want := []string{"web", "api"}
+	if !slices.Equal(cfg.Groups["frontend"], want) {
+		t.Fatalf("expected %q, got %q", want, cfg.Groups["frontend"])
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected valid config, got %v", err)
+	}
+}
+
+func TestNoMatchingTunnelsErrorListsTunnelsAndGroups(t *testing.T) {
+	cfg := Config{
+		Tunnels: []Tunnel{{Name: "web", Port: 3000}, {Name: "api", Port: 8000}},
+		Groups:  map[string][]string{"frontend": {"web", "api"}},
+	}
+
+	err := cfg.NoMatchingTunnelsError([]string{"frontnd"})
+	if err == nil {
+		t.Fatal("expected no matching tunnels error")
+	}
+	if !strings.Contains(err.Error(), "frontnd") {
+		t.Fatalf("expected error to name the unknown service, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "available: api, frontend (group), web") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNoMatchingTunnelsErrorWithoutNamedTunnels(t *testing.T) {
+	cfg := Config{Tunnels: []Tunnel{{Port: 3000}}}
+
+	err := cfg.NoMatchingTunnelsError([]string{"web"})
+	if err == nil {
+		t.Fatal("expected no named tunnels error")
+	}
+	if !strings.Contains(err.Error(), "no named tunnels configured") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/skills/portr-cli/SKILL.md
+++ b/skills/portr-cli/SKILL.md
@@ -168,6 +168,9 @@ tunnels:
     subdomain: mock-dev
     response_format: application/json
     response_tmpl_file: ./response.json
+
+groups:
+  frontend: [app, mock]
 ```
 
 - `name`: identifier used by `portr start`.
@@ -178,16 +181,21 @@ tunnels:
 - `pool_size`: worker count for non-stub tunnels. Defaults to `2`; stubs use `1`.
 - `response_format`, `response_tmpl`, `response_tmpl_file`: stub response settings.
 
+Top-level `groups` maps a group name to tunnel names. A group name must not match a tunnel name, and every member must be an existing tunnel name.
+
 Start configured tunnels:
 
 ```bash
 portr start
 portr start app
 portr start app pg mock
+portr start frontend
+portr start frontend pg
 ```
 
 - No names starts all configured tunnels.
 - Passing names starts only those tunnel entries.
+- A group name expands to its tunnel names, and can be mixed with tunnel names.
 
 ## Request Logs
 

--- a/skills/portr-cli/references/commands.md
+++ b/skills/portr-cli/references/commands.md
@@ -19,14 +19,14 @@ This file mirrors the CLI surface for quick lookup. The skill body contains the 
 | `portr http <port>` | Expose a local HTTP/WebSocket port. | `--subdomain`, `-s` |
 | `portr tcp <port>` | Expose a local TCP port. | none |
 | `portr stub` | Serve a templated response through an HTTP tunnel. | `--subdomain`, `-s`; `--response-format`; `--response-tmpl`; `--response-tmpl-file` |
-| `portr start [names...]` | Start config-defined tunnels. | tunnel names as positional args |
+| `portr start [names or groups...]` | Start config-defined tunnels. | tunnel or group names as positional args |
 | `portr logs <subdomain> [filter]` | Read stored local HTTP request logs. | `--count`, `-n`; `--since`; `--json` |
 | `portr replay <request-id>` | Replay a stored HTTP request. | `--latest`; `--subdomain`; `--filter`; `--since`; `--method`; `--path`; `--header`; `--drop-header`; `--body`; `--body-file`; `--stdin`; `--body-encoding`; `--json` |
 | `portr app-server` | Run a local HTTP API for tunnel lifecycle control. | `--host`; `--port`; `--token`; `PORTR_APP_SERVER_TOKEN` |
 
 ## Config Keys
 
-- Global: `server_url`, `ssh_url`, `tunnel_url`, `secret_key`, `use_localhost`, `debug`, `use_vite`, `dashboard_port`, `disable_dashboard`, `enable_request_logging`, `connection_log_retention_days`, `health_check_interval`, `health_check_max_retries`, `disable_tui`, `disable_update_check`, `insecure_skip_host_key_verification`.
+- Global: `server_url`, `ssh_url`, `tunnel_url`, `secret_key`, `use_localhost`, `debug`, `use_vite`, `dashboard_port`, `disable_dashboard`, `enable_request_logging`, `connection_log_retention_days`, `health_check_interval`, `health_check_max_retries`, `disable_tui`, `disable_update_check`, `insecure_skip_host_key_verification`, `groups`.
 - Tunnel: `name`, `type`, `host`, `port`, `subdomain`, `pool_size`, `response_format`, `response_tmpl`, `response_tmpl_file`.
 
 ## Team Administration


### PR DESCRIPTION
Name a set of tunnels under a top-level `groups` key, then start the whole set with one word.

```yaml
tunnels:
  - name: web
    port: 3000
  - name: api
    port: 8000
  - name: pg
    type: tcp
    port: 5432

groups:
  frontend: [web, api]
```

```bash
portr start frontend       # web + api
portr start frontend pg    # groups and tunnel names mix freely
portr start                # all tunnels, unchanged
```

## Validation

`Config.Validate` rejects a group name that collides with a tunnel name, an empty group, and any member that is not an existing tunnel name. Nested groups fall out of the member rule for free — a group name is never in the tunnel-name set — so there is no recursion or cycle detection.

The empty-group rule is load-bearing rather than cosmetic. `Client.Start` treats an empty selection as "start everything", so `frontend: []` would silently start every tunnel. Rejecting it up front keeps the invariant that non-empty args never expand to an empty selection.

## Structure

Name resolution now lives entirely in `Config.SelectTunnels`, which answers "which tunnels do these args select?" in one place. `Client.Start` no longer filters tunnels itself. Side effect worth noting: dedup (`portr start frontend api` starting `api` once) and "no names selects all" became unit-testable instead of only observable by running the binary.

`portr http`, `portr tcp` and `portr stub` replace the whole tunnel set before validation, so config groups are meaningless on that path. `Config.ReplaceTunnels` makes swapping the tunnels and dropping the groups a single operation, so the pairing cannot be forgotten as more config fields are added.

## Also in here

- The unknown-name error now names the bad argument and lists what is available: `no tunnel or group matched frontnd; available: api, frontend (group), pg, web`. Previously it was a flat `please enter a valid service name` that also misfired when the config simply had no tunnels.
- `portr start` gained `ArgsUsage`, so `--help` documents its positional args.

Note: `Client.ReplaceTunnelsFromCli` (`internal/client/client/client.go:285`) is pre-existing dead code with no callers, and is now a near-duplicate of `Config.ReplaceTunnels` without the group reset. Left alone here, but it should be deleted.

## Testing

- `make testgo` — full suite green.
- 14 new tests in `internal/client/config/config_test.go` covering selection, group expansion, dedup, validation rules, YAML round-trip, and the error messages.
- Manual, server-free: `portr start frontend` → 2 tunnels, `frontend pg` → 3, `frontend api` → 2, bare `start` → 3, unknown name → the new error, `portr http 3000` with groups in config reaches the network stage without a validation error, `portr start --help` shows `[names or groups...]`.