### PR TITLE
Add host_header option for http tunnels

### DIFF
--- a/cmd/portr/http.go
+++ b/cmd/portr/http.go
@@ -19,6 +19,10 @@ func httpCmd() *cli.Command {
 				Aliases: []string{"s"},
 				Usage:   "Subdomain to tunnel to",
 			},
+			&cli.StringFlag{
+				Name:  "host-header",
+				Usage: "Host header to send to the local server ('rewrite' to use the local address)",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			portStr := c.Args().First()
@@ -29,9 +33,10 @@ func httpCmd() *cli.Command {
 			}
 
 			return startTunnels(c, &config.Tunnel{
-				Port:      port,
-				Subdomain: c.String("subdomain"),
-				Type:      constants.Http,
+				Port:       port,
+				Subdomain:  c.String("subdomain"),
+				Type:       constants.Http,
+				HostHeader: c.String("host-header"),
 			})
 		},
 	}

--- a/docs-v2/content/docs/client/http-tunnel.mdx
+++ b/docs-v2/content/docs/client/http-tunnel.mdx
@@ -20,6 +20,36 @@ portr http 9000 --subdomain amal-test
   This also starts the portr inspector on [http://localhost:7777](http://localhost:7777) by default, where you can inspect and replay HTTP requests. Change `dashboard_port` in the client config to move it to another local port, or set `disable_dashboard: true` to skip starting it entirely.
 </Callout>
 
+## Rewriting the Host header
+
+By default, Portr forwards the public host (`amal-test.portr.dev`) to your local server. Frameworks with host allowlists — Rails host authorization, Django `ALLOWED_HOSTS`, Vite `server.allowedHosts` — reject those requests.
+
+```bash
+portr http 9000 --host-header rewrite
+```
+
+`rewrite` replaces the Host header with the local address (`localhost:9000`). Any other value is sent literally, which is useful for vhost-based local setups:
+
+```bash
+portr http 9000 --host-header myapp.local
+```
+
+Or per tunnel in the config file:
+
+```yaml
+tunnels:
+  - name: rails
+    subdomain: rails
+    port: 3000
+    host_header: rewrite
+```
+
+<Callout type="warn">
+  `rewrite` changes the hostname your app believes it is served from, so absolute URLs and redirects it generates will point at the local address. If that matters, leave `host_header` unset and add the public host to your framework's allowlist instead.
+</Callout>
+
+`host_header` is only valid on `type: http` tunnels. The inspector always records the original public host, not the rewritten one.
+
 ## How it works
 
 When you run the HTTP tunnel command:

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -291,6 +291,7 @@ Each tunnel template supports the following options:
 - **type**: The tunnel type (`http` or `tcp`)
 - **host**: The local host to bind to (default: localhost)
 - **pool_size**: HTTP only. Number of SSH workers to run per HTTP tunnel (default: 2). Increases resilience and throughput.
+- **host_header**: HTTP only. Host header sent to the local server. Use `rewrite` for the local address, or any literal hostname (default: pass the public host through)
 
 HTTP tunnels use streaming reverse proxying by default. Request and response bodies are forwarded as they arrive, while inspector captures are stored asynchronously and capped at 1 MiB per body.
 The former `enable_http_reverse_proxy` option is no longer required; existing configurations containing it still load, but the option is ignored.

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -30,8 +30,12 @@ type Tunnel struct {
 	ResponseTemplate     string                   `yaml:"response_tmpl"`
 	ResponseTemplateFile string                   `yaml:"response_tmpl_file"`
 	RemotePort           int
-	PoolSize             int `yaml:"pool_size"`
+	PoolSize             int    `yaml:"pool_size"`
+	HostHeader           string `yaml:"host_header"`
 }
+
+// HostHeaderRewrite sets the outbound Host header to the local address.
+const HostHeaderRewrite = "rewrite"
 
 func (t *Tunnel) SetDefaults() {
 	if t.Type == "" {
@@ -57,6 +61,10 @@ func (t *Tunnel) SetDefaults() {
 }
 
 func (t *Tunnel) Validate() error {
+	if strings.TrimSpace(t.HostHeader) != "" && t.Type != constants.Http {
+		return fmt.Errorf("host_header is only supported for http tunnels")
+	}
+
 	if t.Type == constants.Stub && strings.TrimSpace(t.Subdomain) == "" {
 		return fmt.Errorf("subdomain is required for stub tunnels")
 	}
@@ -81,6 +89,20 @@ func (t *Tunnel) Validate() error {
 
 func (t *Tunnel) GetLocalAddr() string {
 	return t.Host + ":" + fmt.Sprint(t.Port)
+}
+
+// ResolvedHostHeader returns the Host header to send to the local service, or
+// an empty string when the public Host should be passed through unchanged.
+func (t *Tunnel) ResolvedHostHeader(localAddr string) string {
+	value := strings.TrimSpace(t.HostHeader)
+	switch {
+	case value == "":
+		return ""
+	case strings.EqualFold(value, HostHeaderRewrite):
+		return localAddr
+	default:
+		return value
+	}
 }
 
 func (t *Tunnel) ValidateStubTemplateSource() error {

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -637,3 +637,56 @@ func TestNoMatchingTunnelsErrorWithoutNamedTunnels(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestResolvedHostHeaderRewriteUsesLocalAddr(t *testing.T) {
+	for _, value := range []string{"rewrite", "  Rewrite  ", "REWRITE"} {
+		tunnel := Tunnel{HostHeader: value}
+		if got := tunnel.ResolvedHostHeader("localhost:3000"); got != "localhost:3000" {
+			t.Fatalf("host_header %q resolved to %q", value, got)
+		}
+	}
+}
+
+func TestResolvedHostHeaderReturnsLiteralValue(t *testing.T) {
+	tunnel := Tunnel{HostHeader: "myapp.local"}
+	if got := tunnel.ResolvedHostHeader("localhost:3000"); got != "myapp.local" {
+		t.Fatalf("expected literal host header, got %q", got)
+	}
+}
+
+func TestResolvedHostHeaderEmptyPassesThrough(t *testing.T) {
+	tunnel := Tunnel{}
+	if got := tunnel.ResolvedHostHeader("localhost:3000"); got != "" {
+		t.Fatalf("expected pass-through, got %q", got)
+	}
+}
+
+func TestValidateRejectsHostHeaderOnNonHTTPTunnel(t *testing.T) {
+	tcp := Tunnel{Type: constants.Tcp, Port: 5432, HostHeader: "rewrite"}
+	tcp.SetDefaults()
+	err := tcp.Validate()
+	if err == nil || !strings.Contains(err.Error(), "host_header is only supported for http tunnels") {
+		t.Fatalf("expected tcp rejection, got %v", err)
+	}
+
+	// Stub tunnels reach the same reverse proxy but route by Host, so a rewrite
+	// would silently serve the wrong stub when more than one is registered.
+	stub := Tunnel{
+		Type:             constants.Stub,
+		Subdomain:        "stubby",
+		ResponseFormat:   "application/json",
+		ResponseTemplate: "{}",
+		HostHeader:       "rewrite",
+	}
+	stub.SetDefaults()
+	err = stub.Validate()
+	if err == nil || !strings.Contains(err.Error(), "host_header is only supported for http tunnels") {
+		t.Fatalf("expected stub rejection, got %v", err)
+	}
+
+	http := Tunnel{Type: constants.Http, Subdomain: "web", Port: 3000, HostHeader: "rewrite"}
+	http.SetDefaults()
+	if err := http.Validate(); err != nil {
+		t.Fatalf("http tunnel should accept host_header: %v", err)
+	}
+}

--- a/internal/client/ssh/host_header_test.go
+++ b/internal/client/ssh/host_header_test.go
@@ -1,0 +1,242 @@
+package ssh
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientdb "github.com/amalshaji/portr/internal/client/db"
+)
+
+// hostSeenByBackend runs one request through the HTTP tunnel and returns the
+// Host header the local server received.
+func hostSeenByBackend(t *testing.T, hostHeader string) string {
+	t.Helper()
+
+	received := make(chan string, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		received <- r.Host
+	}))
+	defer backend.Close()
+
+	client := &SshClient{config: clientcfg.ClientConfig{Tunnel: clientcfg.Tunnel{
+		Name: "test", Subdomain: "test", Port: 3000, HostHeader: hostHeader,
+	}}}
+	runRawRequest(t, client, strings.TrimPrefix(backend.URL, "http://"),
+		"GET / HTTP/1.1\r\nHost: test.example\r\nConnection: close\r\n\r\n")
+
+	select {
+	case host := <-received:
+		return host
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend did not receive a request")
+		return ""
+	}
+}
+
+func runRawRequest(t *testing.T, client *SshClient, localEndpoint, rawRequest string) string {
+	t.Helper()
+
+	remoteConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		client.httpTunnel(remoteConn, localEndpoint)
+		close(done)
+	}()
+	if _, err := clientConn.Write([]byte(rawRequest)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+	response, err := io.ReadAll(clientConn)
+	if err != nil && !strings.Contains(strings.ToLower(err.Error()), "closed") {
+		t.Fatalf("read response: %v", err)
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("tunnel handler did not finish")
+	}
+	return string(response)
+}
+
+func TestHTTPTunnelPassesPublicHostByDefault(t *testing.T) {
+	if host := hostSeenByBackend(t, ""); host != "test.example" {
+		t.Fatalf("expected the public host to pass through, got %q", host)
+	}
+}
+
+func TestHTTPTunnelRewritesHostToLocalAddress(t *testing.T) {
+	received := make(chan string, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		received <- r.Host
+	}))
+	defer backend.Close()
+	localEndpoint := strings.TrimPrefix(backend.URL, "http://")
+
+	client := &SshClient{config: clientcfg.ClientConfig{Tunnel: clientcfg.Tunnel{
+		Name: "test", Subdomain: "test", Port: 3000, HostHeader: clientcfg.HostHeaderRewrite,
+	}}}
+	runRawRequest(t, client, localEndpoint,
+		"GET / HTTP/1.1\r\nHost: test.example\r\nConnection: close\r\n\r\n")
+
+	select {
+	case host := <-received:
+		if host != localEndpoint {
+			t.Fatalf("expected local endpoint %q, got %q", localEndpoint, host)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend did not receive a request")
+	}
+}
+
+func TestHTTPTunnelSendsLiteralHostHeader(t *testing.T) {
+	if host := hostSeenByBackend(t, "myapp.local"); host != "myapp.local" {
+		t.Fatalf("expected literal host header, got %q", host)
+	}
+}
+
+func TestHTTPTunnelLogsPublicHostWhenRewriting(t *testing.T) {
+	received := make(chan string, 1)
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- r.Host
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer backend.Close()
+	localEndpoint := strings.TrimPrefix(backend.URL, "http://")
+
+	client := &SshClient{
+		config: clientcfg.ClientConfig{
+			EnableRequestLogging: true,
+			Tunnel: clientcfg.Tunnel{
+				Name: "test", Subdomain: "test", Port: 3000, HostHeader: clientcfg.HostHeaderRewrite,
+			},
+		},
+		db: newTestRequestStore(t),
+	}
+	runRawRequest(t, client, localEndpoint,
+		"GET / HTTP/1.1\r\nHost: test.example\r\nConnection: close\r\n\r\n")
+
+	select {
+	case host := <-received:
+		if host != localEndpoint {
+			t.Fatalf("expected the backend to see %q, got %q", localEndpoint, host)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend did not receive a request")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown tunnel client: %v", err)
+	}
+
+	var logged clientdb.Request
+	if err := client.db.Conn.First(&logged).Error; err != nil {
+		t.Fatalf("load persisted request: %v", err)
+	}
+	if logged.Host != "test.example" {
+		t.Fatalf("inspector must log the public host, got %q", logged.Host)
+	}
+}
+
+// startWebSocketEchoServer accepts one connection, records the handshake Host,
+// and replies with a 101 so the tunnel treats it as an upgraded session.
+func startWebSocketEchoServer(t *testing.T, received chan<- string) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		request, err := http.ReadRequest(bufio.NewReader(conn))
+		if err != nil {
+			return
+		}
+		received <- request.Host
+		_, _ = io.WriteString(conn, strings.Join([]string{
+			"HTTP/1.1 101 Switching Protocols",
+			"Upgrade: websocket",
+			"Connection: Upgrade",
+			"Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=",
+			"",
+			"",
+		}, "\r\n"))
+		// Hold the connection open briefly so the tunnel can relay the 101.
+		time.Sleep(100 * time.Millisecond)
+	}()
+
+	return listener.Addr().String()
+}
+
+func TestWebSocketTunnelRewritesHostHeader(t *testing.T) {
+	received := make(chan string, 1)
+	localEndpoint := startWebSocketEchoServer(t, received)
+
+	client := &SshClient{
+		config: clientcfg.ClientConfig{
+			EnableRequestLogging: true,
+			Tunnel: clientcfg.Tunnel{
+				Name: "test", Subdomain: "test", Port: 3000, HostHeader: clientcfg.HostHeaderRewrite,
+			},
+		},
+		db: newTestRequestStore(t),
+	}
+
+	request := strings.Join([]string{
+		"GET /ws HTTP/1.1",
+		"Host: test.example",
+		"Connection: Upgrade",
+		"Upgrade: websocket",
+		"Sec-WebSocket-Version: 13",
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+		"",
+		"",
+	}, "\r\n")
+	runRawRequest(t, client, localEndpoint, request)
+
+	select {
+	case host := <-received:
+		if host != localEndpoint {
+			t.Fatalf("expected the local server to see %q, got %q", localEndpoint, host)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("local server did not receive a handshake")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown tunnel client: %v", err)
+	}
+
+	// The handshake request object is shared with the capture goroutine, so an
+	// in-place rewrite here would corrupt the logged host.
+	var session clientdb.WebSocketSession
+	if err := client.db.Conn.First(&session).Error; err != nil {
+		t.Fatalf("load persisted websocket session: %v", err)
+	}
+	if session.Host != "test.example" {
+		t.Fatalf("inspector must log the public host, got %q", session.Host)
+	}
+}

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -269,9 +269,14 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 	proxy := httputil.NewSingleHostReverseProxy(target)
 	proxy.Transport = transport
 
+	hostHeader := s.config.Tunnel.ResolvedHostHeader(localEndpoint)
+
 	defaultDirector := proxy.Director
 	proxy.Director = func(request *http.Request) {
 		host := request.Host
+		if hostHeader != "" {
+			host = hostHeader
+		}
 		defaultDirector(request)
 		request.Host = host
 	}

--- a/internal/client/ssh/websocket.go
+++ b/internal/client/ssh/websocket.go
@@ -426,7 +426,16 @@ func (s *SshClient) handleWebSocketRequest(
 		defer request.Body.Close()
 	}
 
-	if err := request.Write(dstWriter); err != nil {
+	// The capture goroutine reads request.Host after this point, so the host
+	// rewrite goes on a shallow copy that still shares the captured body.
+	outbound := request
+	if hostHeader := s.config.Tunnel.ResolvedHostHeader(localEndpoint); hostHeader != "" {
+		clone := *request
+		clone.Host = hostHeader
+		outbound = &clone
+	}
+
+	if err := outbound.Write(dstWriter); err != nil {
 		_ = writeLocalServerUnavailable(srcWriter, localEndpoint)
 		_ = srcWriter.Flush()
 		return err


### PR DESCRIPTION
## Why

Portr forwards the public host (`amal-test.portr.dev`) to the local server. Frameworks with host allowlists — Rails host authorization, Django `ALLOWED_HOSTS`, Vite `server.allowedHosts` — reject every tunneled request as a result. `--host-header` is one of ngrok's most-used flags for exactly this.

## What

- `host_header: rewrite` sends the local address (`localhost:3000`) as Host
- `host_header: <anything else>` is sent literally, for vhost-based local setups
- unset keeps today's pass-through behaviour
- CLI: `portr http 3000 --host-header rewrite`

## Notes for review

**The `Validate()` guard is load-bearing, not hygiene.** `transport.go` maps `Stub → Http`, so stub tunnels reach the same reverse proxy with `localEndpoint` pointing at the stub responder — which routes by `req.Host`. Rewriting Host there would fall through to the single-route fallback: fine with one stub tunnel, silently serving the *wrong* stub with two. Hence `host_header` is rejected on non-http types, with a regression test for the stub case specifically.

**The websocket branch needs a copy, not a mutation.** Unlike the reverse-proxy path, `handleWebSocketRequest` shares its request object with the async capture goroutine. An in-place Host rewrite there is a data race that corrupts the logged host. It uses a shallow copy placed *after* the body wrapper is installed, so it still shares the captured body. `TestWebSocketTunnelRewritesHostHeader` fails if anyone "simplifies" this back to a mutation.

## Deliberate non-goals

- **No `X-Forwarded-Host`.** Rack prefers it over `HTTP_HOST` and `HostAuthorization` checks `request.host`, so adding it would send Rails straight back to blocking the host we just rewrote away. Django with `USE_X_FORWARDED_HOST` inverts the same way.
- **No `Location`/redirect rewriting.** It patches one header and misses HTML, JS, `Set-Cookie Domain=`, and CORS. Documented as a caveat instead: `rewrite` changes what the app believes its own hostname is.
- The app-server API does not get `host_header`; field additions to `config.Tunnel` do not flow there automatically.

## Testing

`go build ./...` and `go test ./cmd/... ./internal/...` pass. New tests cover pass-through, rewrite, literal value, the non-http rejection, and that the inspector keeps logging the **public** host on both the HTTP and websocket paths.