### PR TITLE
Add portr doctor

### DIFF
--- a/cmd/portr/doctor.go
+++ b/cmd/portr/doctor.go
@@ -1,0 +1,485 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/amalshaji/portr/internal/client/config"
+	requestlogs "github.com/amalshaji/portr/internal/client/logs"
+	sshclient "github.com/amalshaji/portr/internal/client/ssh"
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/urfave/cli/v2"
+)
+
+type doctorStatus string
+
+const (
+	doctorPass    doctorStatus = "pass"
+	doctorWarn    doctorStatus = "warn"
+	doctorFail    doctorStatus = "fail"
+	doctorSkipped doctorStatus = "skipped"
+)
+
+// checksOK reports whether the run passed. Warnings and skips do not fail it.
+func checksOK(checks []doctorCheck) bool {
+	for _, check := range checks {
+		if check.Status == doctorFail {
+			return false
+		}
+	}
+	return true
+}
+
+func skippedCheck(name, reason string) doctorCheck {
+	return doctorCheck{Name: name, Status: doctorSkipped, Detail: "skipped (" + reason + ")"}
+}
+
+type doctorCheck struct {
+	Name   string       `json:"name"`
+	Status doctorStatus `json:"status"`
+	Detail string       `json:"detail,omitempty"`
+	Hint   string       `json:"hint,omitempty"`
+}
+
+type doctorReport struct {
+	OK            bool          `json:"ok"`
+	ClientVersion string        `json:"client_version"`
+	ConfigPath    string        `json:"config_path"`
+	ServerURL     string        `json:"server_url"`
+	SSHURL        string        `json:"ssh_url"`
+	ServerVersion string        `json:"server_version,omitempty"`
+	Checks        []doctorCheck `json:"checks"`
+}
+
+func doctorCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "doctor",
+		Usage: "Diagnose connection and configuration problems",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "json",
+				Usage: "Output the report as JSON",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			configPath := c.String("config")
+
+			cfg, err := config.Load(configPath)
+			if err != nil {
+				return err
+			}
+			if err := cfg.Validate(); err != nil {
+				return err
+			}
+
+			report := runDoctor(c.Context, cfg, configPath, version)
+
+			if c.Bool("json") {
+				if err := renderDoctorJSON(c.App.Writer, report); err != nil {
+					return err
+				}
+			} else if err := renderDoctorText(c.App.Writer, report); err != nil {
+				return err
+			}
+
+			if !report.OK {
+				return cli.Exit("", 1)
+			}
+			return nil
+		},
+	}
+}
+
+func runDoctor(ctx context.Context, cfg config.Config, configPath, clientVersion string) doctorReport {
+	report := doctorReport{
+		ClientVersion: clientVersion,
+		ConfigPath:    configPath,
+		ServerURL:     cfg.ServerUrl,
+		SSHURL:        cfg.SshUrl,
+	}
+
+	serverVersion, checks := runDoctorChecks(ctx, cfg, configPath)
+	report.ServerVersion = serverVersion
+	report.Checks = checks
+
+	report.OK = checksOK(checks)
+
+	// Details and hints can embed server errors; scrub before anyone shares this.
+	for i := range report.Checks {
+		report.Checks[i].Detail = redactSecret(report.Checks[i].Detail, cfg.SecretKey)
+		report.Checks[i].Hint = redactSecret(report.Checks[i].Hint, cfg.SecretKey)
+	}
+
+	return report
+}
+
+func runDoctorChecks(ctx context.Context, cfg config.Config, configPath string) (string, []doctorCheck) {
+	checks := []doctorCheck{
+		{Name: "config file", Status: doctorPass, Detail: fmt.Sprintf("parsed, %s configured", pluralize(len(cfg.Tunnels), "tunnel"))},
+		checkConfigPermissions(configPath),
+		checkRequestLogDatabase(requestlogs.DefaultDBPath()),
+	}
+
+	serverVersion, serverCheck := checkServerVersion(ctx, cfg)
+	checks = append(checks, serverCheck)
+
+	// Each of these depends on the one before it. Track why the chain broke so a
+	// downstream check reports that reason instead of repeating the same error.
+	blocked := ""
+	if serverCheck.Status == doctorFail {
+		blocked = "server unreachable"
+	}
+
+	var connectionID string
+	if blocked != "" {
+		checks = append(checks, skippedCheck("secret key", blocked))
+	} else {
+		var secretCheck doctorCheck
+		connectionID, secretCheck = checkSecretKey(ctx, cfg)
+		checks = append(checks, secretCheck)
+		if connectionID == "" {
+			blocked = "secret key not accepted"
+		}
+	}
+
+	endpointCheck := checkSSHEndpoint(cfg.SshUrl)
+	checks = append(checks, endpointCheck)
+	if blocked == "" && endpointCheck.Status == doctorFail {
+		blocked = "ssh endpoint unreachable"
+	}
+
+	if blocked != "" {
+		checks = append(checks, skippedCheck("ssh handshake", blocked))
+	} else {
+		checks = append(checks, checkSSHHandshake(ctx, cfg, connectionID))
+	}
+
+	for _, tunnel := range cfg.Tunnels {
+		if check, ok := checkLocalService(tunnel); ok {
+			checks = append(checks, check)
+		}
+	}
+
+	checks = append(checks, checkDashboardPort(cfg))
+	return serverVersion, checks
+}
+
+func checkConfigPermissions(path string) doctorCheck {
+	check := doctorCheck{Name: "config permissions"}
+
+	if runtime.GOOS == "windows" {
+		check.Status = doctorSkipped
+		check.Detail = "not applicable on windows"
+		return check
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = err.Error()
+		return check
+	}
+
+	mode := info.Mode().Perm()
+	if mode&0o077 != 0 {
+		check.Status = doctorWarn
+		check.Detail = fmt.Sprintf("mode %#o is readable by other users", mode)
+		check.Hint = fmt.Sprintf("chmod 600 %s", path)
+		return check
+	}
+
+	check.Status = doctorPass
+	check.Detail = fmt.Sprintf("mode %#o", mode)
+	return check
+}
+
+func checkRequestLogDatabase(dbPath string) doctorCheck {
+	check := doctorCheck{Name: "request log db"}
+
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		check.Status = doctorPass
+		check.Detail = fmt.Sprintf("%s not created yet (created on first tunnel)", dbPath)
+		return check
+	}
+
+	store, err := requestlogs.Open(dbPath)
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = err.Error()
+		check.Hint = fmt.Sprintf("delete %s to recreate it (this removes local request logs)", dbPath)
+		return check
+	}
+	_ = store.Close()
+
+	check.Status = doctorPass
+	check.Detail = dbPath
+	return check
+}
+
+func checkServerVersion(ctx context.Context, cfg config.Config) (string, doctorCheck) {
+	check := doctorCheck{Name: "server"}
+
+	if strings.HasPrefix(cfg.ServerUrl, "http://") || strings.HasPrefix(cfg.ServerUrl, "https://") {
+		check.Status = doctorWarn
+		check.Detail = fmt.Sprintf("server_url %q includes a scheme", cfg.ServerUrl)
+		check.Hint = "remove http:// or https:// from server_url; portr adds it"
+		return "", check
+	}
+
+	baseURL := cfg.GetAdminAddress()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/version", nil)
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = err.Error()
+		return "", check
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	response, err := client.Do(request)
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = err.Error()
+		check.Hint = "check server_url; if the server runs over http, set use_localhost: true"
+		return "", check
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf("%s returned %d", baseURL, response.StatusCode)
+		check.Hint = "server_url may point at a proxy or the wrong host"
+		return "", check
+	}
+
+	var payload struct {
+		Version string `json:"version"`
+	}
+	body, _ := io.ReadAll(response.Body)
+	_ = json.Unmarshal(body, &payload)
+
+	check.Status = doctorPass
+	if payload.Version == "" {
+		check.Detail = baseURL
+	} else {
+		check.Detail = fmt.Sprintf("%s (version %s)", baseURL, payload.Version)
+	}
+	return payload.Version, check
+}
+
+// checkSecretKey reserves a tcp-type connection. A tcp reservation claims no
+// subdomain and no port, so it cannot collide with a tunnel the user is about
+// to start, and the server reaps unclaimed reservations after five minutes.
+func checkSecretKey(ctx context.Context, cfg config.Config) (string, doctorCheck) {
+	check := doctorCheck{Name: "secret key"}
+
+	if strings.TrimSpace(cfg.SecretKey) == "" {
+		check.Status = doctorFail
+		check.Detail = "secret_key is empty"
+		check.Hint = "run: portr auth set --token <your token> --remote " + cfg.ServerUrl
+		return "", check
+	}
+
+	connectionID, err := sshclient.CreateNewConnectionWithContext(ctx, doctorClientConfig(cfg))
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = err.Error()
+		check.Hint = "run: portr auth set --token <your token> --remote " + cfg.ServerUrl
+		return "", check
+	}
+
+	check.Status = doctorPass
+	check.Detail = fmt.Sprintf("accepted by %s (reserved a short-lived diagnostic connection)", cfg.ServerUrl)
+	return connectionID, check
+}
+
+func checkSSHEndpoint(sshURL string) doctorCheck {
+	check := doctorCheck{Name: "ssh endpoint"}
+
+	if _, _, err := net.SplitHostPort(sshURL); err != nil {
+		check.Status = doctorFail
+		check.Detail = fmt.Sprintf("ssh_url %q is not host:port", sshURL)
+		check.Hint = "ssh_url must include the port, e.g. portr.example.com:2222"
+		return check
+	}
+
+	conn, err := net.DialTimeout("tcp", sshURL, 5*time.Second)
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = err.Error()
+		check.Hint = "check ssh_url and that outbound traffic to that port is not blocked"
+		return check
+	}
+	_ = conn.Close()
+
+	check.Status = doctorPass
+	check.Detail = "reachable at " + sshURL
+	return check
+}
+
+func checkSSHHandshake(ctx context.Context, cfg config.Config, connectionID string) doctorCheck {
+	check := doctorCheck{Name: "ssh handshake"}
+
+	clientConfig := doctorClientConfig(cfg)
+	clientConfig.ConnectionID = connectionID
+
+	fingerprint, err := sshclient.Probe(ctx, clientConfig)
+	if err != nil {
+		check.Status = doctorFail
+		check.Detail = err.Error()
+		check.Hint = "verify ssh_url points at the portr ssh port, not the http port"
+		return check
+	}
+
+	check.Status = doctorPass
+	check.Detail = "authenticated, host key " + fingerprint
+	if clientConfig.InsecureSkipHostKeyVerification {
+		check.Detail += " (host key verification disabled)"
+	}
+	return check
+}
+
+func checkLocalService(tunnel config.Tunnel) (doctorCheck, bool) {
+	// Stub tunnels are served in-process; there is no local port to probe.
+	if tunnel.Type == constants.Stub {
+		return doctorCheck{}, false
+	}
+
+	check := doctorCheck{Name: fmt.Sprintf("local service (%s)", tunnel.DisplayName())}
+	addr := tunnel.GetLocalAddr()
+
+	if tunnel.Port <= 0 {
+		check.Status = doctorWarn
+		check.Detail = "no local port configured"
+		check.Hint = fmt.Sprintf("set 'port:' for tunnel %s", tunnel.DisplayName())
+		return check, true
+	}
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		check.Status = doctorWarn
+		check.Detail = fmt.Sprintf("nothing is listening on %s", addr)
+		check.Hint = "requests will return 503 until it starts"
+		return check, true
+	}
+	_ = conn.Close()
+
+	check.Status = doctorPass
+	check.Detail = "listening on " + addr
+	return check, true
+}
+
+func checkDashboardPort(cfg config.Config) doctorCheck {
+	check := doctorCheck{Name: "dashboard port"}
+
+	if cfg.DisableDashboard {
+		check.Status = doctorSkipped
+		check.Detail = "disabled via config"
+		return check
+	}
+
+	// Mirrors the probe the dashboard itself does before binding.
+	client := &http.Client{Timeout: 2 * time.Second}
+	response, err := client.Get(fmt.Sprintf("http://localhost:%d/is-this-portr-server", cfg.DashboardPort))
+	if err != nil {
+		check.Status = doctorPass
+		check.Detail = fmt.Sprintf("port %d is free", cfg.DashboardPort)
+		return check
+	}
+	defer response.Body.Close()
+
+	body, _ := io.ReadAll(response.Body)
+	if response.StatusCode == http.StatusOK && string(body) == "yes" {
+		check.Status = doctorWarn
+		check.Detail = fmt.Sprintf("another portr instance already owns port %d", cfg.DashboardPort)
+		return check
+	}
+
+	check.Status = doctorFail
+	check.Detail = fmt.Sprintf("port %d is in use by another application", cfg.DashboardPort)
+	check.Hint = "set dashboard_port in the config"
+	return check
+}
+
+func pluralize(count int, noun string) string {
+	if count == 1 {
+		return fmt.Sprintf("%d %s", count, noun)
+	}
+	return fmt.Sprintf("%d %ss", count, noun)
+}
+
+func doctorClientConfig(cfg config.Config) config.ClientConfig {
+	return config.ClientConfig{
+		ServerUrl:                       cfg.ServerUrl,
+		SshUrl:                          cfg.SshUrl,
+		TunnelUrl:                       cfg.TunnelUrl,
+		SecretKey:                       cfg.SecretKey,
+		UseLocalHost:                    cfg.UseLocalHost,
+		Debug:                           cfg.Debug,
+		InsecureSkipHostKeyVerification: cfg.InsecureSkipHostKeyVerification == nil || *cfg.InsecureSkipHostKeyVerification,
+		// A tcp reservation claims no subdomain, so it never collides with a
+		// tunnel the user is about to start.
+		Tunnel: config.Tunnel{Type: constants.Tcp},
+	}
+}
+
+// redactSecret keeps the secret key out of output that is meant to be pasted
+// into bug reports. Short values are left alone so junk keys do not mangle text.
+func redactSecret(text, secret string) string {
+	if len(secret) < 6 {
+		return text
+	}
+	return strings.ReplaceAll(text, secret, "***")
+}
+
+func doctorStatusIcon(status doctorStatus) string {
+	switch status {
+	case doctorPass:
+		return "✅"
+	case doctorWarn:
+		return "⚠️ "
+	case doctorFail:
+		return "❌"
+	default:
+		return "⏭️ "
+	}
+}
+
+func renderDoctorText(w io.Writer, report doctorReport) error {
+	if _, err := fmt.Fprintf(w, "portr doctor (client %s)\nconfig: %s\n\n", report.ClientVersion, report.ConfigPath); err != nil {
+		return err
+	}
+
+	counts := map[doctorStatus]int{}
+	for _, check := range report.Checks {
+		counts[check.Status]++
+
+		if _, err := fmt.Fprintf(w, "%s %-20s %s\n", doctorStatusIcon(check.Status), check.Name, check.Detail); err != nil {
+			return err
+		}
+		if check.Hint != "" {
+			if _, err := fmt.Fprintf(w, "   → %s\n", check.Hint); err != nil {
+				return err
+			}
+		}
+	}
+
+	_, err := fmt.Fprintf(w, "\n%d checks: %d passed, %d warnings, %d failed, %d skipped\n",
+		len(report.Checks), counts[doctorPass], counts[doctorWarn], counts[doctorFail], counts[doctorSkipped])
+	return err
+}
+
+func renderDoctorJSON(w io.Writer, report doctorReport) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(report)
+}

--- a/cmd/portr/doctor_test.go
+++ b/cmd/portr/doctor_test.go
@@ -1,0 +1,507 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/urfave/cli/v2"
+)
+
+func openListener(t *testing.T) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener
+}
+
+func serverConfig(t *testing.T, server *httptest.Server) config.Config {
+	t.Helper()
+	return config.Config{
+		ServerUrl:    strings.TrimPrefix(server.URL, "http://"),
+		SecretKey:    "sk-doctor-test",
+		UseLocalHost: true,
+	}
+}
+
+func TestCheckConfigPermissionsFlagsGroupReadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permissions are not checked on windows")
+	}
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("tunnels: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	check := checkConfigPermissions(path)
+	if check.Status != doctorWarn {
+		t.Fatalf("expected a warning for 0644, got %s", check.Status)
+	}
+	if !strings.Contains(check.Hint, "chmod 600") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+
+	if err := os.Chmod(path, 0o600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if check := checkConfigPermissions(path); check.Status != doctorPass {
+		t.Fatalf("expected pass for 0600, got %s", check.Status)
+	}
+}
+
+func TestCheckServerVersionReportsVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/version" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = w.Write([]byte(`{"version":"1.2.0"}`))
+	}))
+	defer server.Close()
+
+	version, check := checkServerVersion(context.Background(), serverConfig(t, server))
+	if check.Status != doctorPass {
+		t.Fatalf("expected pass, got %s (%s)", check.Status, check.Detail)
+	}
+	if version != "1.2.0" {
+		t.Fatalf("expected version 1.2.0, got %q", version)
+	}
+	if !strings.Contains(check.Detail, "1.2.0") {
+		t.Fatalf("unexpected detail %q", check.Detail)
+	}
+}
+
+func TestCheckServerVersionFailsWhenUnreachable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	cfg := serverConfig(t, server)
+	server.Close()
+
+	_, check := checkServerVersion(context.Background(), cfg)
+	if check.Status != doctorFail {
+		t.Fatalf("expected fail, got %s", check.Status)
+	}
+	if !strings.Contains(check.Hint, "server_url") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+}
+
+func TestCheckServerVersionFailsOnNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	_, check := checkServerVersion(context.Background(), serverConfig(t, server))
+	if check.Status != doctorFail {
+		t.Fatalf("expected fail, got %s", check.Status)
+	}
+	if !strings.Contains(check.Detail, "404") {
+		t.Fatalf("unexpected detail %q", check.Detail)
+	}
+}
+
+func TestCheckServerVersionWarnsOnSchemeInServerURL(t *testing.T) {
+	// GetAdminAddress prepends a scheme, so a scheme here yields https://https://host.
+	cfg := config.Config{ServerUrl: "http://localhost:8000", UseLocalHost: true}
+
+	_, check := checkServerVersion(context.Background(), cfg)
+	if check.Status != doctorWarn {
+		t.Fatalf("expected warn, got %s", check.Status)
+	}
+	if !strings.Contains(check.Hint, "remove http://") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+}
+
+func TestCheckSecretKeyFailsWhenRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Invalid secret key"}`))
+	}))
+	defer server.Close()
+
+	connectionID, check := checkSecretKey(context.Background(), serverConfig(t, server))
+	if check.Status != doctorFail {
+		t.Fatalf("expected fail, got %s", check.Status)
+	}
+	if connectionID != "" {
+		t.Fatalf("expected no connection id, got %q", connectionID)
+	}
+	if !strings.Contains(check.Hint, "portr auth set") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+}
+
+func TestCheckSecretKeyReservesTCPConnection(t *testing.T) {
+	var seenType string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&payload)
+		seenType, _ = payload["connection_type"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"connection_id":"abc"}`))
+	}))
+	defer server.Close()
+
+	connectionID, check := checkSecretKey(context.Background(), serverConfig(t, server))
+	if check.Status != doctorPass {
+		t.Fatalf("expected pass, got %s (%s)", check.Status, check.Detail)
+	}
+	if connectionID != "abc" {
+		t.Fatalf("expected connection id abc, got %q", connectionID)
+	}
+	// A tcp reservation claims no subdomain, so doctor cannot collide with a
+	// tunnel the same user is about to start.
+	if seenType != string(constants.Tcp) {
+		t.Fatalf("expected a tcp reservation, got %q", seenType)
+	}
+}
+
+func TestCheckSecretKeyFailsWhenEmpty(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	cfg := serverConfig(t, server)
+	cfg.SecretKey = ""
+
+	_, check := checkSecretKey(context.Background(), cfg)
+	if check.Status != doctorFail {
+		t.Fatalf("expected fail, got %s", check.Status)
+	}
+	if called {
+		t.Fatal("expected no request for an empty secret key")
+	}
+}
+
+func TestCheckSSHEndpointHintsMissingPort(t *testing.T) {
+	check := checkSSHEndpoint("example.com")
+	if check.Status != doctorFail {
+		t.Fatalf("expected fail, got %s", check.Status)
+	}
+	if !strings.Contains(check.Hint, "must include the port") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+}
+
+func TestCheckSSHEndpointPassesForOpenListener(t *testing.T) {
+	listener := openListener(t)
+	if check := checkSSHEndpoint(listener.Addr().String()); check.Status != doctorPass {
+		t.Fatalf("expected pass, got %s (%s)", check.Status, check.Detail)
+	}
+}
+
+func TestCheckLocalServiceWarnsWhenClosed(t *testing.T) {
+	listener := openListener(t)
+	host, port, _ := net.SplitHostPort(listener.Addr().String())
+	tunnel := config.Tunnel{Name: "api", Type: constants.Http, Host: host}
+	fmt.Sscanf(port, "%d", &tunnel.Port)
+
+	check, ok := checkLocalService(tunnel)
+	if !ok || check.Status != doctorPass {
+		t.Fatalf("expected pass while listening, got %s", check.Status)
+	}
+
+	_ = listener.Close()
+	check, _ = checkLocalService(tunnel)
+	if check.Status != doctorWarn {
+		t.Fatalf("expected warn once closed, got %s", check.Status)
+	}
+	if !strings.Contains(check.Hint, "503") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+}
+
+func TestCheckLocalServiceHintsMissingPort(t *testing.T) {
+	check, ok := checkLocalService(config.Tunnel{Name: "api", Type: constants.Http, Host: "localhost"})
+	if !ok {
+		t.Fatal("expected a check for an http tunnel")
+	}
+	if !strings.Contains(check.Hint, "set 'port:' for tunnel api") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+}
+
+func TestCheckLocalServiceSkipsStubTunnels(t *testing.T) {
+	if _, ok := checkLocalService(config.Tunnel{Type: constants.Stub, Subdomain: "yaml"}); ok {
+		t.Fatal("stub tunnels have no local port to probe")
+	}
+}
+
+func TestCheckDashboardPortDetectsAnotherPortrInstance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("yes"))
+	}))
+	defer server.Close()
+
+	cfg := config.Config{DashboardPort: dashboardPortOf(t, server)}
+	if check := checkDashboardPort(cfg); check.Status != doctorWarn {
+		t.Fatalf("expected warn, got %s (%s)", check.Status, check.Detail)
+	}
+}
+
+func TestCheckDashboardPortDetectsForeignListener(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	cfg := config.Config{DashboardPort: dashboardPortOf(t, server)}
+	check := checkDashboardPort(cfg)
+	if check.Status != doctorFail {
+		t.Fatalf("expected fail, got %s", check.Status)
+	}
+	if !strings.Contains(check.Hint, "dashboard_port") {
+		t.Fatalf("unexpected hint %q", check.Hint)
+	}
+}
+
+func TestCheckDashboardPortSkipsWhenDisabled(t *testing.T) {
+	if check := checkDashboardPort(config.Config{DisableDashboard: true}); check.Status != doctorSkipped {
+		t.Fatalf("expected skipped, got %s", check.Status)
+	}
+}
+
+func dashboardPortOf(t *testing.T, server *httptest.Server) int {
+	t.Helper()
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	if err != nil {
+		t.Fatalf("split server url: %v", err)
+	}
+	var value int
+	fmt.Sscanf(port, "%d", &value)
+	return value
+}
+
+func TestRedactSecretReplacesSecret(t *testing.T) {
+	if got := redactSecret("auth failed for sk-abcdef", "sk-abcdef"); strings.Contains(got, "sk-abcdef") {
+		t.Fatalf("secret survived redaction: %q", got)
+	}
+	if got := redactSecret("nothing to redact", ""); got != "nothing to redact" {
+		t.Fatalf("unexpected result %q", got)
+	}
+	if got := redactSecret("short abc", "abc"); got != "short abc" {
+		t.Fatalf("short secrets should be left alone, got %q", got)
+	}
+}
+
+func TestChecksOKIgnoresWarningsAndSkips(t *testing.T) {
+	checks := []doctorCheck{{Status: doctorPass}, {Status: doctorWarn}, {Status: doctorSkipped}}
+	if !checksOK(checks) {
+		t.Fatal("warnings and skips must not fail the run")
+	}
+
+	if checksOK(append(checks, doctorCheck{Status: doctorFail})) {
+		t.Fatal("a failed check must fail the run")
+	}
+}
+
+func TestSkippedCheckNamesTheBlockingReason(t *testing.T) {
+	check := skippedCheck("ssh handshake", "server unreachable")
+	if check.Status != doctorSkipped {
+		t.Fatalf("expected skipped, got %s", check.Status)
+	}
+	if check.Detail != "skipped (server unreachable)" {
+		t.Fatalf("unexpected detail %q", check.Detail)
+	}
+}
+
+func TestRenderDoctorTextIncludesHintsAndSummary(t *testing.T) {
+	var out bytes.Buffer
+	report := doctorReport{
+		ClientVersion: "1.2.3",
+		ConfigPath:    "/tmp/config.yaml",
+		Checks: []doctorCheck{
+			{Name: "server", Status: doctorFail, Detail: "unreachable", Hint: "check server_url"},
+		},
+	}
+
+	if err := renderDoctorText(&out, report); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	text := out.String()
+	for _, want := range []string{"❌", "→ check server_url", "1 failed"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in output:\n%s", want, text)
+		}
+	}
+}
+
+func TestRenderDoctorJSONOmitsSecret(t *testing.T) {
+	var out bytes.Buffer
+	report := doctorReport{
+		OK:     false,
+		Checks: []doctorCheck{{Name: "secret key", Status: doctorFail, Detail: redactSecret("rejected sk-supersecret", "sk-supersecret")}},
+	}
+
+	if err := renderDoctorJSON(&out, report); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(out.String(), "sk-supersecret") {
+		t.Fatalf("secret leaked into json output:\n%s", out.String())
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(out.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode json: %v", err)
+	}
+	if _, ok := decoded["checks"]; !ok {
+		t.Fatal("expected a checks key")
+	}
+}
+
+func TestRunDoctorRedactsSecretsInChecks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/version") {
+			_, _ = w.Write([]byte(`{"version":"1.2.0"}`))
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		// A server that echoes the key back must not leak it into the report.
+		_, _ = w.Write([]byte(`{"message":"Invalid secret key sk-doctor-test-value"}`))
+	}))
+	defer server.Close()
+
+	cfg := serverConfig(t, server)
+	cfg.SecretKey = "sk-doctor-test-value"
+	cfg.DisableDashboard = true
+
+	report := runDoctor(context.Background(), cfg, "/tmp/config.yaml", "1.2.3")
+	for _, check := range report.Checks {
+		if strings.Contains(check.Detail, cfg.SecretKey) || strings.Contains(check.Hint, cfg.SecretKey) {
+			t.Fatalf("secret leaked into check %q: %+v", check.Name, check)
+		}
+	}
+}
+
+// runDoctorCommand runs the command with cli's exiter stubbed out, since
+// app.Run calls os.Exit for an ExitCoder and would kill the test process.
+func runDoctorCommand(t *testing.T, configBody string, args ...string) (string, int) {
+	t.Helper()
+
+	exitCode := 0
+	originalExiter := cli.OsExiter
+	cli.OsExiter = func(code int) { exitCode = code }
+	t.Cleanup(func() { cli.OsExiter = originalExiter })
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	var out bytes.Buffer
+	app := &cli.App{
+		Writer:   &out,
+		Flags:    []cli.Flag{&cli.StringFlag{Name: "config"}},
+		Commands: []*cli.Command{doctorCmd()},
+	}
+
+	full := append([]string{"portr", "--config", configPath, "doctor"}, args...)
+	_ = app.Run(full)
+	return out.String(), exitCode
+}
+
+func TestDoctorCommandExitsNonZeroOnFailure(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	serverURL := strings.TrimPrefix(server.URL, "http://")
+	server.Close()
+
+	body := fmt.Sprintf("server_url: %s\nssh_url: %s\nsecret_key: sk-doctor-test\nuse_localhost: true\ndisable_dashboard: true\ntunnels: []\n", serverURL, serverURL)
+	out, exitCode := runDoctorCommand(t, body)
+
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d\n%s", exitCode, out)
+	}
+	if !strings.Contains(out, "❌") {
+		t.Fatalf("expected a failed check in output:\n%s", out)
+	}
+}
+
+func TestDoctorCommandJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/version") {
+			_, _ = w.Write([]byte(`{"version":"1.2.0"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"connection_id":"abc"}`))
+	}))
+	defer server.Close()
+	serverURL := strings.TrimPrefix(server.URL, "http://")
+
+	body := fmt.Sprintf("server_url: %s\nssh_url: %s\nsecret_key: sk-doctor-test\nuse_localhost: true\ndisable_dashboard: true\ntunnels: []\n", serverURL, serverURL)
+	out, _ := runDoctorCommand(t, body, "--json")
+
+	var report doctorReport
+	if err := json.Unmarshal([]byte(out), &report); err != nil {
+		t.Fatalf("decode report: %v\n%s", err, out)
+	}
+	if len(report.Checks) == 0 {
+		t.Fatal("expected checks in the json report")
+	}
+	if report.ServerVersion != "1.2.0" {
+		t.Fatalf("expected the server version in the report, got %q", report.ServerVersion)
+	}
+}
+
+func TestDoctorCommandFailsWhenConfigMissing(t *testing.T) {
+	var out bytes.Buffer
+	app := &cli.App{
+		Writer:   &out,
+		Flags:    []cli.Flag{&cli.StringFlag{Name: "config"}},
+		Commands: []*cli.Command{doctorCmd()},
+	}
+
+	err := app.Run([]string{"portr", "--config", "/nonexistent/portr/config.yaml", "doctor"})
+	if err == nil {
+		t.Fatal("expected an error for a missing config")
+	}
+	if !strings.Contains(err.Error(), "/nonexistent/portr/config.yaml") {
+		t.Fatalf("expected the path in the error, got %v", err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("expected no report when the config cannot load, got %q", out.String())
+	}
+}
+
+func TestRunDoctorChecksSkipsDownstreamWithTheRealReason(t *testing.T) {
+	// A dead server must not make the handshake report "secret key not accepted".
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	cfg := serverConfig(t, server)
+	cfg.DisableDashboard = true
+	server.Close()
+
+	_, checks := runDoctorChecks(context.Background(), cfg, "/tmp/config.yaml")
+
+	byName := map[string]doctorCheck{}
+	for _, check := range checks {
+		byName[check.Name] = check
+	}
+
+	for _, name := range []string{"secret key", "ssh handshake"} {
+		check := byName[name]
+		if check.Status != doctorSkipped {
+			t.Fatalf("expected %q to be skipped, got %s", name, check.Status)
+		}
+		if !strings.Contains(check.Detail, "server unreachable") {
+			t.Fatalf("expected %q to name the real reason, got %q", name, check.Detail)
+		}
+	}
+}

--- a/cmd/portr/main.go
+++ b/cmd/portr/main.go
@@ -39,6 +39,7 @@ func main() {
 			authCmd(),
 			appServerCmd(),
 			adminCmd(),
+			doctorCmd(),
 		},
 	}
 

--- a/docs-v2/content/docs/client/doctor.mdx
+++ b/docs-v2/content/docs/client/doctor.mdx
@@ -1,0 +1,77 @@
+---
+title: Doctor
+description: Diagnose Portr client connection and configuration problems with a single command that checks each link in the chain.
+---
+
+
+`portr doctor` checks every step between your machine and the tunnel server and
+reports what is wrong, one line per check.
+
+```bash
+portr doctor
+```
+
+```text
+portr doctor (client 1.0.15)
+config: /Users/amal/.portr/config.yaml
+
+✅ config file          parsed, 2 tunnels configured
+⚠️  config permissions   mode 0644 is readable by other users
+   → chmod 600 /Users/amal/.portr/config.yaml
+✅ request log db       /Users/amal/.portr/db.sqlite
+✅ server               https://portr.example.com (version 1.0.15)
+❌ secret key           server rejected the secret key
+   → run: portr auth set --token <your token> --remote portr.example.com
+✅ ssh endpoint         reachable at portr.example.com:2222
+⏭️  ssh handshake        skipped (secret key not accepted)
+⚠️  local service (api)  nothing is listening on localhost:3000
+   → requests will return 503 until it starts
+✅ dashboard port       port 7777 is free
+
+9 checks: 5 passed, 2 warnings, 1 failed, 1 skipped
+```
+
+The command exits with status `1` when any check fails, so it can be used as a
+preflight step in scripts. Warnings and skipped checks do not affect the exit
+status.
+
+## What gets checked
+
+| Check | What it means |
+| --- | --- |
+| config file | The config parses and passes validation. If this fails, nothing else runs. |
+| config permissions | The config holds your secret key, so it should not be readable by other users. |
+| request log db | The local SQLite request log at `~/.portr/db.sqlite` opens. |
+| server | The tunnel server answers, and at what version. |
+| secret key | The server accepts your `secret_key`. |
+| ssh endpoint | The SSH port is reachable over TCP. Separate from the handshake so a firewall looks different from an auth problem. |
+| ssh handshake | SSH authentication succeeds, and which host key the server presented. |
+| local service | Something is listening on each configured tunnel's local port. A warning, not a failure — starting Portr before your app is fine. |
+| dashboard port | The inspector port is free, already owned by another Portr, or taken by an unrelated program. |
+
+Checks that depend on an earlier failure are reported as skipped rather than
+repeating the same error.
+
+## Machine-readable output
+
+```bash
+portr doctor --json
+```
+
+Returns the same report as JSON, with an `ok` field and the full list of checks.
+
+## What the output contains
+
+The report is meant to be pasted into a bug report. It includes your server and
+SSH URLs, the config file path, tunnel names and local ports, and the server's
+host key fingerprint.
+
+Your `secret_key` is never printed, and any server message that happens to
+contain it is redacted before the report is rendered.
+
+<Callout type="info">
+  The secret key and handshake checks reserve a short-lived TCP connection on
+  the server to authenticate with. It claims no subdomain and no port, so it
+  cannot collide with a tunnel you are about to start, and the server discards
+  unclaimed reservations after five minutes.
+</Callout>

--- a/docs-v2/content/docs/client/index.mdx
+++ b/docs-v2/content/docs/client/index.mdx
@@ -44,6 +44,9 @@ The Portr client is a command-line tool that allows you to create secure tunnels
   <Card title="Tunnel Templates" href="/docs/client/templates">
     Set up reusable tunnel configurations for common services.
   </Card>
+  <Card title="Doctor" href="/docs/client/doctor">
+    Diagnose connection and configuration problems in one command.
+  </Card>
 </Cards>
 
 ## Quick Commands

--- a/docs-v2/content/docs/client/meta.json
+++ b/docs-v2/content/docs/client/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "installation",
+    "doctor",
     "team-administration",
     "http-tunnel",
     "request-logs",

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -83,6 +83,17 @@ func (t *Tunnel) GetLocalAddr() string {
 	return t.Host + ":" + fmt.Sprint(t.Port)
 }
 
+// DisplayName is the human-readable label for a tunnel.
+func (t Tunnel) DisplayName() string {
+	if t.Name != "" {
+		return t.Name
+	}
+	if t.Type == constants.Stub && t.Subdomain != "" {
+		return t.Subdomain
+	}
+	return fmt.Sprint(t.Port)
+}
+
 func (t *Tunnel) ValidateStubTemplateSource() error {
 	if t.Type != constants.Stub {
 		return nil

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -637,3 +637,15 @@ func TestNoMatchingTunnelsErrorWithoutNamedTunnels(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestDisplayNameFallsBackToSubdomainForStub(t *testing.T) {
+	if got := (Tunnel{Type: constants.Stub, Subdomain: "yaml"}).DisplayName(); got != "yaml" {
+		t.Fatalf("unexpected display name %q", got)
+	}
+	if got := (Tunnel{Type: constants.Http, Port: 3000}).DisplayName(); got != "3000" {
+		t.Fatalf("unexpected display name %q", got)
+	}
+	if got := (Tunnel{Type: constants.Http, Port: 3000, Name: "api"}).DisplayName(); got != "api" {
+		t.Fatalf("unexpected display name %q", got)
+	}
+}

--- a/internal/client/ssh/probe.go
+++ b/internal/client/ssh/probe.go
@@ -1,0 +1,58 @@
+package ssh
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/amalshaji/portr/internal/client/config"
+	"golang.org/x/crypto/ssh"
+)
+
+// Probe completes an SSH handshake using cfg.ConnectionID and cfg.SecretKey and
+// closes the connection without requesting a port forward. It returns the
+// server host key fingerprint.
+//
+// Requesting a forward is what reserves a subdomain and marks the connection
+// active, so skipping it keeps a diagnostic run from colliding with a tunnel
+// the same user is about to start.
+func Probe(ctx context.Context, cfg config.ClientConfig) (string, error) {
+	verify := getHostKeyCallback(cfg.InsecureSkipHostKeyVerification)
+
+	var fingerprint string
+	callback := func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		fingerprint = fingerprintSHA256(key)
+		return verify(hostname, remote, key)
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            fmt.Sprintf("%s:%s", cfg.ConnectionID, cfg.SecretKey),
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: callback,
+	}
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	rawConn, err := dialer.DialContext(ctx, "tcp", cfg.SshUrl)
+	if err != nil {
+		return "", err
+	}
+
+	_ = rawConn.SetDeadline(time.Now().Add(10 * time.Second))
+	cc, channels, requests, err := ssh.NewClientConn(rawConn, cfg.SshUrl, sshConfig)
+	if err != nil {
+		_ = rawConn.Close()
+		return fingerprint, err
+	}
+	_ = rawConn.SetDeadline(time.Time{})
+
+	go ssh.DiscardRequests(requests)
+	go func() {
+		for channel := range channels {
+			_ = channel.Reject(ssh.Prohibited, "diagnostic probe")
+		}
+	}()
+
+	_ = cc.Close()
+	return fingerprint, nil
+}

--- a/internal/client/ssh/probe_test.go
+++ b/internal/client/ssh/probe_test.go
@@ -1,0 +1,147 @@
+package ssh
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	gssh "github.com/gliderlabs/ssh"
+	"golang.org/x/crypto/ssh"
+
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+)
+
+type probeServer struct {
+	addr        string
+	mu          sync.Mutex
+	seenUser    string
+	forwardSeen bool
+}
+
+func startProbeServer(t *testing.T, allowAuth bool) *probeServer {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	probe := &probeServer{addr: listener.Addr().String()}
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(key)
+	if err != nil {
+		t.Fatalf("signer: %v", err)
+	}
+
+	server := &gssh.Server{
+		Handler: func(s gssh.Session) { _ = s.Exit(0) },
+		PasswordHandler: func(ctx gssh.Context, password string) bool {
+			probe.mu.Lock()
+			probe.seenUser = ctx.User()
+			probe.mu.Unlock()
+			return allowAuth
+		},
+		RequestHandlers: map[string]gssh.RequestHandler{
+			"tcpip-forward": func(ctx gssh.Context, srv *gssh.Server, req *ssh.Request) (bool, []byte) {
+				probe.mu.Lock()
+				probe.forwardSeen = true
+				probe.mu.Unlock()
+				return false, nil
+			},
+		},
+	}
+	server.AddHostKey(signer)
+
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	return probe
+}
+
+func probeConfig(addr string) clientcfg.ClientConfig {
+	return clientcfg.ClientConfig{
+		SshUrl:                          addr,
+		ConnectionID:                    "conn-1",
+		SecretKey:                       "sk-1",
+		InsecureSkipHostKeyVerification: true,
+	}
+}
+
+func TestProbeSendsConnectionIDAndSecretAsUser(t *testing.T) {
+	server := startProbeServer(t, true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	fingerprint, err := Probe(ctx, probeConfig(server.addr))
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if !strings.HasPrefix(fingerprint, "SHA256:") {
+		t.Fatalf("expected a SHA256 fingerprint, got %q", fingerprint)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.seenUser != "conn-1:sk-1" {
+		t.Fatalf("expected connection id and secret as the ssh user, got %q", server.seenUser)
+	}
+}
+
+func TestProbeFailsWhenAuthRejected(t *testing.T) {
+	server := startProbeServer(t, false)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := Probe(ctx, probeConfig(server.addr)); err == nil {
+		t.Fatal("expected an authentication error")
+	} else if !strings.Contains(err.Error(), "unable to authenticate") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestProbeDoesNotRequestForward(t *testing.T) {
+	// Requesting a forward is what reserves a subdomain and marks a connection
+	// active. A diagnostic run must never do that.
+	server := startProbeServer(t, true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := Probe(ctx, probeConfig(server.addr)); err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.forwardSeen {
+		t.Fatal("probe must not request a port forward")
+	}
+}
+
+func TestProbeFailsWhenEndpointUnreachable(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := listener.Addr().String()
+	_ = listener.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := Probe(ctx, probeConfig(addr)); err == nil {
+		t.Fatal("expected a dial error")
+	}
+}


### PR DESCRIPTION
## Why

Closed issues are dominated by connection failures users could not self-diagnose: #91 handshake failed, #74 operation timed out, #64 not starting, #26 failed to initialize database, #38 / #220 dashboard not loading. Each is a different link in the same chain, and the symptom rarely says which link broke.

## What

`portr doctor` checks nine things in chain order and prints pass / warn / fail with a remediation hint:

config file → config permissions → request log db → server → secret key → ssh endpoint → ssh handshake → per-tunnel local port → dashboard port

```
✅ config file          parsed, 2 tunnels configured
⚠️  config permissions   mode 0644 is readable by other users
   → chmod 600 /Users/amal/.portr/config.yaml
✅ server               https://portr.example.com (version 1.0.15)
❌ secret key           server rejected the secret key
   → run: portr auth set --token <your token> --remote portr.example.com
⏭️  ssh handshake        skipped (secret key not accepted)
⚠️  local service (api)  nothing is listening on localhost:3000
   → requests will return 503 until it starts
```

`--json` for machine output. Exits 1 if any check fails; warnings and skips do not.

## Notes for review

**Everything after a config load failure keeps running.** A user pasting output into an issue needs the whole picture from one run, not N round trips with a maintainer. The four network checks form a dependency chain, so a single `blocked` reason is threaded through them — a dead server makes the handshake report `skipped (server unreachable)`, not a misleading "secret key not accepted".

**The handshake probe reserves a `tcp`-type connection, deliberately.** Authenticating cannot be done with zero server state: `sshd.go` splits the ssh user on `:` and looks the connection row up before accepting a password. But a tcp reservation claims no subdomain and no port, so running `doctor` immediately before `portr start` cannot collide — an `http` reservation would 409 against your own tunnel. The server reaps unclaimed reservations after 5 minutes. Cost to be aware of: one `reserved` row visible in admin for up to 5 minutes per run.

**The probe never requests a port forward**, which is what marks a connection active and registers a proxy backend. `TestProbeDoesNotRequestForward` asserts this.

**It does not use `/api/v1/admin/users`** to validate the key, despite that being the obvious endpoint — it requires admin role (so it would fail for ordinary team members with valid keys) and it *creates a user* as a side effect. `POST /api/v1/connections/` has the same secret-key auth and returns only a connection id.

## Secrets

Output is designed to be pasted into bug reports. The secret key is never printed, `/api/v1/config/download` is never called (its body contains the key), and every detail and hint is scrubbed of the key in case a server echoes it back in an error message.

## Found while writing this, not fixed here

- `hostkey.go` `loadKnownHostKey` guards `len(fields) < 2` then indexes `fields[2]` — a matching 2-field `known_hosts` line panics.
- `db.go` `New` calls `log.Fatal` on open failure. That is the raw shape of #26; doctor diagnoses it without fixing it.

## Testing

`go build ./...` and `go test ./cmd/... ./internal/...` pass. Every check is unit-tested against `httptest` servers or loopback listeners; the probe is tested against a real `gliderlabs/ssh` server.