### PR TITLE
Add QR code toggle to the terminal interface

### DIFF
--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -60,15 +60,17 @@ When TUI is disabled, the client will:
 - Show tunnel status updates and health check results
 - Exit gracefully on errors
 
-### Show a QR Code for the Tunnel URL
+### QR Code for the Tunnel URL
 
-Set `enable_qr_code: true` to add a QR code toggle to the terminal interface. Press `r` to show or hide it, then scan the code to open the tunnel on a phone:
+The terminal interface can show a QR code for the tunnel URL, so you can open it on a phone without typing it. Press `r` to show or hide it. This is on by default; nothing is rendered until you press the key.
+
+Set `enable_qr_code: false` to remove the toggle and its footer hint:
 
 ```yaml
 server_url: example.com
 ssh_url: example.com:2222
 secret_key: { your-secret-key }
-enable_qr_code: true
+enable_qr_code: false
 tunnels:
   - name: portr
     subdomain: portr
@@ -256,7 +258,7 @@ These options apply to the entire client configuration:
 - **secret_key**: Your authentication secret key
 - **groups**: Named sets of tunnel names; `portr start <group>` starts every tunnel in the set
 - **disable_tui**: Disable the interactive terminal interface (default: false)
-- **enable_qr_code**: Add a QR code toggle (press `r`) to the terminal interface for the tunnel URL (default: false). Ignored when `disable_tui` is true.
+- **enable_qr_code**: Offer a QR code toggle (press `r`) in the terminal interface for the tunnel URL (default: true). The code is only rendered once the key is pressed. Ignored when `disable_tui` is true.
 - **dashboard_port**: Local port for the inspector dashboard (default: 7777)
 - **disable_dashboard**: Disable the local inspector dashboard completely (default: false)
 - **disable_update_check**: Disable automatic update checks and notifications (default: false)

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -60,6 +60,27 @@ When TUI is disabled, the client will:
 - Show tunnel status updates and health check results
 - Exit gracefully on errors
 
+### Show a QR Code for the Tunnel URL
+
+Set `enable_qr_code: true` to add a QR code toggle to the terminal interface. Press `r` to show or hide it, then scan the code to open the tunnel on a phone:
+
+```yaml
+server_url: example.com
+ssh_url: example.com:2222
+secret_key: { your-secret-key }
+enable_qr_code: true
+tunnels:
+  - name: portr
+    subdomain: portr
+    port: 4321
+```
+
+The panel renders only when exactly one HTTP or stub tunnel is running, since there is no way to pick between several. TCP tunnels have no browsable URL and are ignored. The panel takes vertical space from the request table while visible, and is replaced by a note if the terminal is too narrow to render a scannable code.
+
+<Callout type="info">
+  This option has no effect when `disable_tui: true`, because there is no terminal interface to render the code into.
+</Callout>
+
 ### Configure or Disable the Local Dashboard
 
 You can change the inspector port or disable it permanently in the client config:
@@ -235,6 +256,7 @@ These options apply to the entire client configuration:
 - **secret_key**: Your authentication secret key
 - **groups**: Named sets of tunnel names; `portr start <group>` starts every tunnel in the set
 - **disable_tui**: Disable the interactive terminal interface (default: false)
+- **enable_qr_code**: Add a QR code toggle (press `r`) to the terminal interface for the tunnel URL (default: false). Ignored when `disable_tui` is true.
 - **dashboard_port**: Local port for the inspector dashboard (default: 7777)
 - **disable_dashboard**: Disable the local inspector dashboard completely (default: false)
 - **disable_update_check**: Disable automatic update checks and notifications (default: false)

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/matoous/go-nanoid/v2 v2.0.0
 	github.com/mattn/go-sqlite3 v1.14.22
+	github.com/mdp/qrterminal/v3 v3.2.1
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/pressly/goose/v3 v3.24.3
-	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.1
 	github.com/valyala/fasttemplate v1.2.2
 	golang.org/x/crypto v0.51.0
@@ -46,7 +46,6 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/elastic/go-windows v1.0.2 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -67,7 +66,7 @@ require (
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
@@ -77,7 +76,6 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
@@ -92,6 +90,7 @@ require (
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
+	golang.org/x/term v0.43.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	gorm.io/driver/mysql v1.5.6 // indirect
 	howett.net/plist v1.0.1 // indirect
@@ -99,4 +98,5 @@ require (
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect
 	modernc.org/sqlite v1.38.0 // indirect
+	rsc.io/qr v0.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -114,9 +114,8 @@ github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i
 github.com/matoous/go-nanoid v1.5.0/go.mod h1:zyD2a71IubI24efhpvkJz+ZwfwagzgSO6UNiFsZKN7U=
 github.com/matoous/go-nanoid/v2 v2.0.0 h1:d19kur2QuLeHmJBkvYkFdhFBzLoo1XVm2GgTpL+9Tj0=
 github.com/matoous/go-nanoid/v2 v2.0.0/go.mod h1:FtS4aGPVfEkxKxhdWPAspZpZSh1cOjtM7Ej/So3hR0g=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
-github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
-github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
@@ -125,6 +124,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mdp/qrterminal/v3 v3.2.1 h1:6+yQjiiOsSuXT5n9/m60E54vdgFsw0zhADHhHLrFet4=
+github.com/mdp/qrterminal/v3 v3.2.1/go.mod h1:jOTmXvnBsMy5xqLniO0R++Jmjs2sTm9dFSuQ5kpz/SU=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
 github.com/mfridman/interpolate v0.0.2/go.mod h1:p+7uk6oE07mpE/Ik1b8EckO0O4ZXiGAfshKBWLUM9Xg=
 github.com/microsoft/go-mssqldb v1.9.2 h1:nY8TmFMQOHpm2qVWo6y4I2mAmVdZqlGiMGAYt64Ibbs=
@@ -216,7 +217,6 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -297,3 +297,5 @@ modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+rsc.io/qr v0.2.0 h1:6vBLea5/NRMVTz8V66gipeLycZMl/+UlFmk8DvqQ6WY=
+rsc.io/qr v0.2.0/go.mod h1:IF+uZjkb9fqyeF/4tlBoynqmQxUoPfWEKh921coOuXs=

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -44,7 +44,7 @@ func NewClient(config *config.Config, db *db.Db) *Client {
 	}
 
 	if !config.DisableTUI {
-		p = tui.New(config.Debug, config.GetDashboardAddress(), config.GetDashboardDisableLabel(), config.EnableQRCode)
+		p = tui.New(config.Debug, config.GetDashboardAddress(), config.GetDashboardDisableLabel(), *config.EnableQRCode)
 		c.tui = p
 		c.tuiStart = make(chan struct{})
 		c.tuiDone = make(chan struct{})

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -42,7 +42,7 @@ func NewClient(config *config.Config, db *db.Db) *Client {
 	}
 
 	if !config.DisableTUI {
-		p = tui.New(config.Debug, config.GetDashboardAddress(), config.GetDashboardDisableLabel())
+		p = tui.New(config.Debug, config.GetDashboardAddress(), config.GetDashboardDisableLabel(), config.EnableQRCode)
 		c.tui = p
 		c.tuiStart = make(chan struct{})
 		c.tuiDone = make(chan struct{})

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -224,7 +224,7 @@ type Config struct {
 	HealthCheckInterval             int                 `yaml:"health_check_interval"`
 	HealthCheckMaxRetries           int                 `yaml:"health_check_max_retries"`
 	DisableTUI                      bool                `yaml:"disable_tui"`
-	EnableQRCode                    bool                `yaml:"enable_qr_code"`
+	EnableQRCode                    *bool               `yaml:"enable_qr_code"`
 	DisableUpdateCheck              bool                `yaml:"disable_update_check"`
 	InsecureSkipHostKeyVerification *bool               `yaml:"insecure_skip_host_key_verification"`
 }
@@ -257,6 +257,11 @@ func (c *Config) SetDefaults() {
 	if c.EnableRequestLogging == nil {
 		defaultValue := true
 		c.EnableRequestLogging = &defaultValue
+	}
+
+	if c.EnableQRCode == nil {
+		defaultValue := true
+		c.EnableQRCode = &defaultValue
 	}
 
 	if len(c.RedactHeaders) == 0 {

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -160,6 +160,7 @@ type Config struct {
 	HealthCheckInterval             int                 `yaml:"health_check_interval"`
 	HealthCheckMaxRetries           int                 `yaml:"health_check_max_retries"`
 	DisableTUI                      bool                `yaml:"disable_tui"`
+	EnableQRCode                    bool                `yaml:"enable_qr_code"`
 	DisableUpdateCheck              bool                `yaml:"disable_update_check"`
 	InsecureSkipHostKeyVerification *bool               `yaml:"insecure_skip_host_key_verification"`
 }

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -754,3 +754,18 @@ func TestDisplayNameFallsBackToSubdomainForStatic(t *testing.T) {
 		t.Fatalf("unexpected display name %q", got)
 	}
 }
+
+func TestSetDefaultsEnablesQRCodeUnlessDisabled(t *testing.T) {
+	var cfg Config
+	cfg.SetDefaults()
+	if cfg.EnableQRCode == nil || !*cfg.EnableQRCode {
+		t.Fatal("expected the qr code to be enabled by default")
+	}
+
+	disabled := false
+	cfg = Config{EnableQRCode: &disabled}
+	cfg.SetDefaults()
+	if cfg.EnableQRCode == nil || *cfg.EnableQRCode {
+		t.Fatal("expected an explicit false to be respected")
+	}
+}

--- a/internal/client/tui/qr.go
+++ b/internal/client/tui/qr.go
@@ -1,0 +1,53 @@
+package tui
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mdp/qrterminal/v3"
+)
+
+// buildQRPanel renders the QR panel for the current terminal size, or an empty
+// string when the panel is hidden.
+func (m *model) buildQRPanel() string {
+	if !m.qrEnabled || !m.showQR {
+		return ""
+	}
+
+	url, ok := m.singleBrowsableTunnelURL()
+	if !ok {
+		return subtitleStyle.Render("QR code unavailable: needs exactly one http tunnel")
+	}
+
+	var buf bytes.Buffer
+	qrterminal.GenerateHalfBlock(url, qrterminal.L, &buf)
+	code := strings.TrimRight(buf.String(), "\n")
+
+	// A QR wider than the terminal soft-wraps into something unscannable.
+	if lipgloss.Width(code) > m.width {
+		return subtitleStyle.Render("QR code unavailable: terminal too narrow")
+	}
+
+	return subtitleStyle.Render("Scan to open "+url) + "\n" + code
+}
+
+// singleBrowsableTunnelURL returns the public URL when exactly one tunnel has
+// one. TCP tunnels are excluded because their address is not browsable.
+func (m *model) singleBrowsableTunnelURL() (string, bool) {
+	url := ""
+	for _, tunnel := range m.tunnels {
+		if tunnel.config == nil || tunnel.clientConfig == nil {
+			continue
+		}
+		if tunnel.config.Type != constants.Http && tunnel.config.Type != constants.Stub {
+			continue
+		}
+		if url != "" {
+			return "", false
+		}
+		url = tunnel.clientConfig.GetTunnelAddr()
+	}
+	return url, url != ""
+}

--- a/internal/client/tui/qr_test.go
+++ b/internal/client/tui/qr_test.go
@@ -1,0 +1,163 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+const qrBlock = "█"
+
+func qrModel(t *testing.T, enabled bool, tunnels ...config.Tunnel) model {
+	t.Helper()
+
+	m := model{
+		tunnels:   map[string]*tunnelStatus{},
+		qrEnabled: enabled,
+		width:     200,
+		height:    60,
+	}
+	for _, tunnel := range tunnels {
+		key := tunnelKey(&tunnel)
+		m.tunnels[key] = &tunnelStatus{
+			config:       &tunnel,
+			clientConfig: testClientConfig(tunnel),
+			active:       1,
+			poolSize:     1,
+		}
+	}
+	return m
+}
+
+func pressR(t *testing.T, m model) model {
+	t.Helper()
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	return updated.(model)
+}
+
+func TestViewOmitsQRHintWhenDisabled(t *testing.T) {
+	view := qrModel(t, false, testTunnel()).View()
+	if strings.Contains(view, "QR") {
+		t.Fatalf("expected no QR hint when disabled, got %q", view)
+	}
+}
+
+func TestViewShowsQRHintWhenEnabled(t *testing.T) {
+	view := qrModel(t, true, testTunnel()).View()
+	if !strings.Contains(view, "r: QR code") {
+		t.Fatalf("expected QR hint, got %q", view)
+	}
+}
+
+func TestQRKeyIgnoredWhenDisabled(t *testing.T) {
+	m := pressR(t, qrModel(t, false, testTunnel()))
+	if m.showQR {
+		t.Fatal("expected the key to be ignored when the feature is off")
+	}
+	if strings.Contains(m.View(), qrBlock) {
+		t.Fatal("expected no QR panel when the feature is off")
+	}
+}
+
+func TestQRKeyTogglesPanelForSingleHTTPTunnel(t *testing.T) {
+	m := pressR(t, qrModel(t, true, testTunnel()))
+
+	view := m.View()
+	if !strings.Contains(view, "Scan to open https://audio-stream.go.portr.dev") {
+		t.Fatalf("expected QR caption, got %q", view)
+	}
+	if !strings.Contains(view, qrBlock) {
+		t.Fatalf("expected a rendered QR code, got %q", view)
+	}
+
+	view = pressR(t, m).View()
+	if strings.Contains(view, "Scan to open") || strings.Contains(view, qrBlock) {
+		t.Fatalf("expected the panel to toggle off, got %q", view)
+	}
+}
+
+func TestQRUnavailableWithMultipleTunnels(t *testing.T) {
+	second := testTunnel()
+	second.Name = "second"
+	second.Subdomain = "second"
+	second.Port = 9000
+
+	view := pressR(t, qrModel(t, true, testTunnel(), second)).View()
+	if !strings.Contains(view, "QR code unavailable") {
+		t.Fatalf("expected unavailable note, got %q", view)
+	}
+	if strings.Contains(view, qrBlock) {
+		t.Fatalf("expected no QR code for multiple tunnels, got %q", view)
+	}
+}
+
+func TestQRUnavailableForTcpOnlyTunnel(t *testing.T) {
+	tcp := config.Tunnel{
+		Name:     "postgres",
+		Type:     constants.Tcp,
+		Host:     "localhost",
+		Port:     5432,
+		PoolSize: 1,
+	}
+
+	view := pressR(t, qrModel(t, true, tcp)).View()
+	if !strings.Contains(view, "QR code unavailable") {
+		t.Fatalf("expected unavailable note for tcp, got %q", view)
+	}
+}
+
+func TestQRPanelShrinksRequestTable(t *testing.T) {
+	m := qrModel(t, true, testTunnel())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 60})
+	m = updated.(model)
+	before := m.table.Height()
+
+	m = pressR(t, m)
+	after := m.table.Height()
+
+	panelHeight := strings.Count(m.qrPanel, "\n") + 1
+	if after >= before {
+		t.Fatalf("expected the table to shrink, before=%d after=%d", before, after)
+	}
+	if before-after < panelHeight {
+		t.Fatalf("table shrank by %d, expected at least the panel height %d", before-after, panelHeight)
+	}
+}
+
+func TestQRPanelAppearsAfterTunnelConnects(t *testing.T) {
+	// With no tunnels the view short-circuits before the panel renders, but the
+	// toggle must still be remembered.
+	m := pressR(t, qrModel(t, true))
+	if !m.showQR {
+		t.Fatal("expected the toggle to be remembered before any tunnel connects")
+	}
+	if strings.Contains(m.View(), qrBlock) {
+		t.Fatalf("expected no QR code with no tunnels, got %q", m.View())
+	}
+
+	tunnel := testTunnel()
+	updated, _ := m.Update(AddTunnelMsg{
+		Config:       &tunnel,
+		ClientConfig: testClientConfig(tunnel),
+		Healthy:      true,
+	})
+	m = updated.(model)
+
+	if !strings.Contains(m.View(), qrBlock) {
+		t.Fatalf("expected the QR panel once a tunnel connected, got %q", m.View())
+	}
+}
+
+func TestQRUnavailableWhenTerminalTooNarrow(t *testing.T) {
+	m := qrModel(t, true, testTunnel())
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 20, Height: 60})
+	m = pressR(t, updated.(model))
+
+	if !strings.Contains(m.View(), "terminal too narrow") {
+		t.Fatalf("expected the narrow-terminal note, got %q", m.View())
+	}
+}

--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -105,8 +105,82 @@ type model struct {
 	lastUpdate             time.Time
 	selected               string
 	width                  int
+	height                 int
 	dashboardURL           string
 	dashboardDisabledLabel string
+	qrEnabled              bool
+	showQR                 bool
+	qrPanel                string
+}
+
+// applyLayout resizes the tables for the given terminal size. The QR panel is
+// rebuilt here because it competes with the request table for vertical space.
+func (m *model) applyLayout(width, height int) {
+	m.width = width
+	m.height = height
+	m.qrPanel = m.buildQRPanel()
+
+	// Calculate dynamic widths based on terminal size
+	totalWidth := max(width-6, 30) // Account for borders and terminal edges
+
+	// Adjust table heights based on terminal height
+	availableHeight := height - 15 // Account for headers and other UI elements
+	if m.qrPanel != "" {
+		availableHeight -= lipgloss.Height(m.qrPanel) + 1
+	}
+	availableHeight = max(availableHeight, 8)
+
+	if m.debug {
+		// Prioritize request logs when debug is enabled.
+		mainTableHeight := max((availableHeight*2)/3, 8)
+		debugTableHeight := max(availableHeight-mainTableHeight-1, 4)
+		m.table.SetHeight(mainTableHeight)
+		m.debugTable.SetHeight(debugTableHeight)
+	} else {
+		// Use nearly all available space for request logs when debug table is hidden.
+		m.table.SetHeight(availableHeight)
+	}
+
+	// Adjust URL column width to fill remaining space
+	timeWidth := 12
+	tunnelWidth := 15
+	methodWidth := 8
+	statusWidth := 8
+	mainCellPadding := 2 * 5 // table default style adds left/right padding to each cell
+	urlWidth := totalWidth - (timeWidth + tunnelWidth + methodWidth + statusWidth + mainCellPadding + 1)
+
+	urlWidth = max(urlWidth, 10)
+
+	// Update main table columns
+	cols := []table.Column{
+		{Title: "Time", Width: timeWidth},
+		{Title: "Tunnel", Width: tunnelWidth},
+		{Title: "Method", Width: methodWidth},
+		{Title: "Status", Width: statusWidth},
+		{Title: "URL", Width: urlWidth},
+	}
+	m.table.SetColumns(cols)
+
+	// Update debug table columns if debug is enabled
+	if m.debug {
+		debugCellPadding := 2 * 4 // four columns with left/right padding
+		debugContentWidth := totalWidth - (timeWidth + methodWidth + debugCellPadding + 1)
+		debugContentWidth = max(debugContentWidth, 24)
+
+		messageWidth := max(debugContentWidth/2, 12)
+		errorWidth := max(debugContentWidth-messageWidth, 12)
+
+		debugCols := []table.Column{
+			{Title: "Time", Width: timeWidth},
+			{Title: "Level", Width: methodWidth},
+			{Title: "Message", Width: messageWidth},
+			{Title: "Error", Width: errorWidth},
+		}
+		m.debugTable.SetColumns(debugCols)
+	}
+
+	m.table.SetWidth(totalWidth)
+	m.debugTable.SetWidth(totalWidth)
 }
 
 func tunnelKey(tunnelConfig *config.Tunnel) string {
@@ -119,7 +193,7 @@ func tunnelKey(tunnelConfig *config.Tunnel) string {
 	return fmt.Sprintf("%d", tunnelConfig.Port)
 }
 
-func New(debug bool, dashboardURL string, dashboardDisabledLabel string) *tea.Program {
+func New(debug bool, dashboardURL string, dashboardDisabledLabel string, enableQRCode bool) *tea.Program {
 	// Initial default widths
 	const (
 		timeWidth   = 12
@@ -178,6 +252,7 @@ func New(debug bool, dashboardURL string, dashboardDisabledLabel string) *tea.Pr
 			width:                  80,
 			dashboardURL:           dashboardURL,
 			dashboardDisabledLabel: dashboardDisabledLabel,
+			qrEnabled:              enableQRCode,
 		},
 		tea.WithAltScreen(),
 	)
@@ -211,6 +286,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c":
 			m.quitting = true
 			return m, tea.Quit
+		case "r":
+			if m.qrEnabled {
+				m.showQR = !m.showQR
+				m.applyLayout(m.width, m.height)
+			}
+			// Swallow the key either way so the table never scrolls on it.
+			return m, nil
 		}
 
 	case ErrorMsg:
@@ -245,6 +327,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.selected == "" {
 			m.selected = key
 		}
+		if m.showQR {
+			// The panel may have been unavailable before this tunnel connected.
+			m.applyLayout(m.width, m.height)
+		}
 
 	case UpdateHealthMsg:
 		if tunnel, exists := m.tunnels[msg.Port]; exists {
@@ -261,66 +347,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
-
-		// Calculate dynamic widths based on terminal size
-		totalWidth := max(msg.Width-6, 30) // Account for borders and terminal edges
-
-		// Adjust table heights based on terminal height
-		availableHeight := msg.Height - 15 // Account for headers and other UI elements
-		availableHeight = max(availableHeight, 8)
-
-		if m.debug {
-			// Prioritize request logs when debug is enabled.
-			mainTableHeight := max((availableHeight*2)/3, 8)
-			debugTableHeight := max(availableHeight-mainTableHeight-1, 4)
-			m.table.SetHeight(mainTableHeight)
-			m.debugTable.SetHeight(debugTableHeight)
-		} else {
-			// Use nearly all available space for request logs when debug table is hidden.
-			m.table.SetHeight(availableHeight)
-		}
-
-		// Adjust URL column width to fill remaining space
-		timeWidth := 12
-		tunnelWidth := 15
-		methodWidth := 8
-		statusWidth := 8
-		mainCellPadding := 2 * 5 // table default style adds left/right padding to each cell
-		urlWidth := totalWidth - (timeWidth + tunnelWidth + methodWidth + statusWidth + mainCellPadding + 1)
-
-		urlWidth = max(urlWidth, 10)
-
-		// Update main table columns
-		cols := []table.Column{
-			{Title: "Time", Width: timeWidth},
-			{Title: "Tunnel", Width: tunnelWidth},
-			{Title: "Method", Width: methodWidth},
-			{Title: "Status", Width: statusWidth},
-			{Title: "URL", Width: urlWidth},
-		}
-		m.table.SetColumns(cols)
-
-		// Update debug table columns if debug is enabled
-		if m.debug {
-			debugCellPadding := 2 * 4 // four columns with left/right padding
-			debugContentWidth := totalWidth - (timeWidth + methodWidth + debugCellPadding + 1)
-			debugContentWidth = max(debugContentWidth, 24)
-
-			messageWidth := max(debugContentWidth/2, 12)
-			errorWidth := max(debugContentWidth-messageWidth, 12)
-
-			debugCols := []table.Column{
-				{Title: "Time", Width: timeWidth},
-				{Title: "Level", Width: methodWidth},
-				{Title: "Message", Width: messageWidth},
-				{Title: "Error", Width: errorWidth},
-			}
-			m.debugTable.SetColumns(debugCols)
-		}
-
-		m.table.SetWidth(totalWidth)
-		m.debugTable.SetWidth(totalWidth)
+		m.applyLayout(msg.Width, msg.Height)
 		return m, nil
 
 	case tickMsg:
@@ -456,6 +483,12 @@ func (m model) View() string {
 	}
 	s += "\n"
 
+	// The QR panel sits above the table because a short terminal clips the
+	// bottom of the alt screen, and the table is the right thing to lose.
+	if m.qrPanel != "" {
+		s += m.qrPanel + "\n\n"
+	}
+
 	// Add waiting message if no logs
 	if len(m.table.Rows()) == 0 {
 		// Create empty table with just headers
@@ -474,7 +507,11 @@ func (m model) View() string {
 	}
 
 	// Help and status
-	s += "\n" + subtitleStyle.Render("Ctrl+C: Quit") + "\n"
+	help := "Ctrl+C: Quit"
+	if m.qrEnabled {
+		help += " • r: QR code"
+	}
+	s += "\n" + subtitleStyle.Render(help) + "\n"
 	s += subtitleStyle.Render(fmt.Sprintf("Last updated: %s", m.lastUpdate.Format("15:04:05"))) + "\n"
 
 	return s


### PR DESCRIPTION
## Why

Scanning the tunnel URL is the fastest way to open it on a phone, which is one of the most common reasons to start a tunnel at all. Pinggy and Loophole both ship terminal QR codes and users cite it.

## What

`enable_qr_code: true` in the client config adds the feature; pressing `r` in the TUI toggles the panel.

```
myapp (localhost:3000 → https://myapp.portr.dev) [myapp] 🟢 Healthy (2/2)

Scan to open https://myapp.portr.dev
▄▄▄▄▄▄▄ ▄ ▄▄  ▄▄▄▄▄▄▄
█ ▄▄▄ █ ▀█▄▀▄ █ ▄▄▄ █
...

Ctrl+C: Quit • r: QR code
```

## Notes for review

**A toggle, not always-on.** The code is ~17 rows tall; rendering it unconditionally would crowd the request table on every run.

**`r`, not `q`.** `q` and `ctrl+c` are quit, and `bubbles/table`'s default keymap already consumes `up k down j b pgup f pgdown space u ctrl+u d ctrl+d home g end G` via the catch-all forward. `r` is free in both layers, and the case returns early so the table never scrolls on it.

**The window-size block moves into `applyLayout`.** Table height now depends on whether the panel is visible, not just on terminal size, so it has to be recomputable on a keypress. This is the only structural change in the diff.

**The panel renders above the table.** `availableHeight` is floored at `max(..., 8)` (pre-existing), so a short terminal overflows the alt screen and clips the *bottom*. If the user asked for the QR, the table is the right thing to lose. `TestQRPanelShrinksRequestTable` guards the height math — without it the panel silently pushes the footer off-screen.

**Only when exactly one browsable tunnel exists.** Picking between several would mean keying off whichever `AddTunnelMsg` landed first, which is nondeterministic across runs with no way to change it. "Unavailable" is honest; cycling can be added later behind the same key without changing the config surface. TCP tunnels have no browsable URL and are excluded.

A width guard replaces the code with a note rather than letting it soft-wrap into something unscannable.

## Notes

- New dependency: `github.com/mdp/qrterminal/v3`. Chosen over `skip2/go-qrcode`, which is archived upstream.
- `enable_qr_code` has no effect with `disable_tui: true`; headless QR printing is out of scope.

## Testing

`go build ./...` and `go test ./cmd/... ./internal/...` pass. Tests cover the hint, the toggle, the multi-tunnel and TCP-only unavailable cases, the narrow-terminal guard, the table height regression, and the panel appearing once a tunnel connects.