### PR TITLE
Add portr serve for static directories

### DIFF
--- a/cmd/portr/main.go
+++ b/cmd/portr/main.go
@@ -33,6 +33,7 @@ func main() {
 			configCmd(),
 			httpCmd(),
 			stubCmd(),
+			serveCmd(),
 			tcpCmd(),
 			logsCmd(),
 			replayCmd(),

--- a/cmd/portr/serve.go
+++ b/cmd/portr/serve.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+	"github.com/urfave/cli/v2"
+)
+
+func serveCmd() *cli.Command {
+	return &cli.Command{
+		Name:      "serve",
+		Usage:     "Serve a local directory over a public url",
+		ArgsUsage: "<directory>",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "subdomain",
+				Aliases: []string{"s"},
+				Usage:   "Subdomain to serve the directory from",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			dir := strings.TrimSpace(c.Args().First())
+			if dir == "" {
+				return fmt.Errorf("please specify a directory to serve")
+			}
+
+			return startTunnels(c, &config.Tunnel{
+				Dir:       dir,
+				Subdomain: c.String("subdomain"),
+				Type:      constants.Static,
+			})
+		},
+	}
+}

--- a/cmd/portr/start.go
+++ b/cmd/portr/start.go
@@ -26,6 +26,9 @@ func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 		if err := tunnelFromCli.ResolveStubTemplate("."); err != nil {
 			return err
 		}
+		if err := tunnelFromCli.ResolveServeDir("."); err != nil {
+			return err
+		}
 		if err := tunnelFromCli.Validate(); err != nil {
 			return err
 		}

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -243,6 +243,13 @@ curl -X POST http://127.0.0.1:7778/api/v1/tunnels \
   }'
 ```
 
+<Callout type="info">
+  `type` accepts `http`, `tcp`, and `stub`. [Static tunnels](/docs/client/static-tunnel)
+  are available from the CLI and the config file only, because a `dir` sent over
+  this API would resolve against the app-server process's working directory
+  rather than the caller's.
+</Callout>
+
 ## Request fields
 
 | Field | Type | Required | Description |

--- a/docs-v2/content/docs/client/index.mdx
+++ b/docs-v2/content/docs/client/index.mdx
@@ -33,6 +33,9 @@ The Portr client is a command-line tool that allows you to create secure tunnels
   <Card title="Stub Tunnels" href="/docs/client/stub-tunnel">
     Serve templated responses without a separate local web server.
   </Card>
+  <Card title="Static Tunnels" href="/docs/client/static-tunnel">
+    Serve a local directory on a public URL with no local web server.
+  </Card>
   <Card title="WebSocket Tunnels" href="/docs/client/websocket-tunnel">
     Enable real-time WebSocket connections through tunnels.
   </Card>

--- a/docs-v2/content/docs/client/meta.json
+++ b/docs-v2/content/docs/client/meta.json
@@ -10,6 +10,7 @@
     "app-server",
     "tcp-tunnel",
     "stub-tunnel",
+    "static-tunnel",
     "websocket-tunnel",
     "templates"
   ]

--- a/docs-v2/content/docs/client/static-tunnel.mdx
+++ b/docs-v2/content/docs/client/static-tunnel.mdx
@@ -1,0 +1,84 @@
+---
+title: Static Tunnel
+description: Serve a local directory on a public URL with the Portr CLI, without running a separate local web server.
+---
+
+
+Static tunnels serve files straight from a directory on your machine. Portr runs
+the file server inside its own process, so there is no separate local web server
+to start.
+
+```bash
+portr serve ./dist
+```
+
+That prints a public URL serving the contents of `./dist`. Pin it to a subdomain
+with `--subdomain`:
+
+```bash
+portr serve ./dist --subdomain docs
+```
+
+<Callout type="info">
+  Static tunnels use the existing HTTP tunnel protocol, so they work with
+  existing Portr servers and do not require a server migration.
+</Callout>
+
+## Common Use Cases
+
+- Sharing a production build with a teammate or client before deploying it
+- Opening a static site on a phone or tablet for testing
+- Handing over a folder of screenshots, PDFs, or reports
+
+## Directory Listings
+
+Requesting a directory serves its `index.html` when one exists. When it does
+not, Portr renders a listing of the directory contents.
+
+<Callout type="warn">
+  Everything under the directory you pass is publicly reachable, including files
+  a listing makes easy to discover. Serve a build output directory, not a source
+  tree or a home directory.
+</Callout>
+
+## Symlinks
+
+Symlinks inside the served directory are followed as long as they stay inside
+it. A symlink pointing anywhere outside returns `404`, so a stray link cannot
+expose the rest of your filesystem.
+
+## Rebuilds
+
+Portr reads files on each request, so a build tool that rewrites files in place
+(Vite, Hugo, esbuild, `tsc`) is picked up immediately with no restart.
+
+If you delete and recreate the directory itself — `rm -rf dist && npm run build`
+— restart `portr serve`. Portr holds a handle to the original directory, and
+after it is removed every request returns `404`.
+
+## Single-page Apps
+
+Deep links into a single-page app return `404` today, because there is no file
+at that path. Only the entry route is served. Use `portr http` in front of your
+dev server if you need client-side routing.
+
+## Config File
+
+Static tunnels can live in the client config alongside other tunnels:
+
+```yaml
+tunnels:
+  - name: site
+    type: static
+    subdomain: site
+    dir: ./dist
+```
+
+`dir` in the config file is resolved relative to the config file. On the command
+line it is resolved relative to your current directory. A subdomain is generated
+when you do not set one.
+
+<Callout type="info">
+  Static tunnels are available from the CLI and the config file. The
+  [app server](/docs/client/app-server) API does not accept `type: static`.
+</Callout>

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -288,8 +288,9 @@ Each tunnel template supports the following options:
 - **name**: A unique identifier for the tunnel
 - **subdomain**: The subdomain to use for the tunnel
 - **port**: The local port to tunnel
-- **type**: The tunnel type (`http` or `tcp`)
+- **type**: The tunnel type (`http`, `tcp`, `stub`, or `static`)
 - **host**: The local host to bind to (default: localhost)
+- **dir**: Static only. Directory to serve, resolved relative to the config file
 - **pool_size**: HTTP only. Number of SSH workers to run per HTTP tunnel (default: 2). Increases resilience and throughput.
 
 HTTP tunnels use streaming reverse proxying by default. Request and response bodies are forwarded as they arrive, while inspector captures are stored asynchronously and capped at 1 MiB per body.

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -539,11 +539,13 @@ func (m *Manager) dispatchCallbacks(callbackURLs []string, event TunnelEvent) {
 }
 
 func validateTunnelRequest(tunnel clientcfg.Tunnel, callbackURL string, callbackURLs []string) error {
-	if tunnel.Type != constants.Stub && (tunnel.Port <= 0 || tunnel.Port > 65535) {
-		return fmt.Errorf("port must be between 1 and 65535")
-	}
+	// Check the type first so an unsupported type reports that, rather than a
+	// misleading port error.
 	if tunnel.Type != constants.Http && tunnel.Type != constants.Tcp && tunnel.Type != constants.Stub {
 		return fmt.Errorf("type must be http, tcp, or stub")
+	}
+	if tunnel.Type != constants.Stub && (tunnel.Port <= 0 || tunnel.Port > 65535) {
+		return fmt.Errorf("port must be between 1 and 65535")
 	}
 	if err := tunnel.Validate(); err != nil {
 		return err

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
+	"github.com/amalshaji/portr/internal/client/fileresponder"
 	sshclient "github.com/amalshaji/portr/internal/client/ssh"
 	"github.com/amalshaji/portr/internal/client/stubresponder"
 	"github.com/amalshaji/portr/internal/client/tui"
@@ -30,6 +31,7 @@ type Client struct {
 	tuiDone         chan struct{}
 	tuiStopOnce     sync.Once
 	stubResponder   *stubresponder.Responder
+	fileResponder   *fileresponder.Responder
 }
 
 func NewClient(config *config.Config, db *db.Db) *Client {
@@ -152,6 +154,11 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 		return err
 	}
 
+	clientConfigs, err = c.prepareStaticTunnels(clientConfigs)
+	if err != nil {
+		return err
+	}
+
 	poolingSupported := true
 	for _, clientConfig := range clientConfigs {
 		if desiredWorkers(clientConfig, true) > 1 {
@@ -161,19 +168,15 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 	}
 
 	for _, clientConfig := range clientConfigs {
-		tunnelName := clientConfig.Tunnel.Name
-		if tunnelName == "" {
-			if clientConfig.Tunnel.Type == constants.Stub {
-				tunnelName = clientConfig.Tunnel.Subdomain
-			} else {
-				tunnelName = fmt.Sprintf("%d", clientConfig.Tunnel.Port)
-			}
-		}
+		tunnelName := clientConfig.Tunnel.DisplayName()
 
 		if c.config.DisableTUI {
-			if clientConfig.Tunnel.Type == constants.Stub {
+			switch clientConfig.Tunnel.Type {
+			case constants.Stub:
 				fmt.Printf("🚀 Starting stub tunnel: %s (%s)\n", tunnelName, clientConfig.GetTunnelAddr())
-			} else {
+			case constants.Static:
+				fmt.Printf("🚀 Starting static tunnel: %s (%s → %s)\n", tunnelName, clientConfig.Tunnel.Dir, clientConfig.GetTunnelAddr())
+			default:
 				fmt.Printf("🚀 Starting tunnel: %s (%s:%d)\n", tunnelName, clientConfig.Tunnel.Host, clientConfig.Tunnel.Port)
 			}
 		}
@@ -243,6 +246,45 @@ func (c *Client) prepareStubTunnels(clientConfigs []config.ClientConfig) ([]conf
 	return clientConfigs, nil
 }
 
+func (c *Client) prepareStaticTunnels(clientConfigs []config.ClientConfig) ([]config.ClientConfig, error) {
+	hasStatic := false
+	for _, clientConfig := range clientConfigs {
+		if clientConfig.Tunnel.Type == constants.Static {
+			hasStatic = true
+			break
+		}
+	}
+	if !hasStatic {
+		return clientConfigs, nil
+	}
+
+	if c.fileResponder == nil {
+		c.fileResponder = fileresponder.New()
+		if err := c.fileResponder.Start(); err != nil {
+			return nil, err
+		}
+	}
+
+	for i := range clientConfigs {
+		if clientConfigs[i].Tunnel.Type != constants.Static {
+			continue
+		}
+
+		if err := c.fileResponder.Register(fileresponder.Route{
+			Subdomain: clientConfigs[i].Tunnel.Subdomain,
+			Dir:       clientConfigs[i].Tunnel.Dir,
+		}); err != nil {
+			return nil, err
+		}
+
+		clientConfigs[i].Tunnel.Host = "127.0.0.1"
+		clientConfigs[i].Tunnel.Port = c.fileResponder.Port()
+		clientConfigs[i].Tunnel.PoolSize = 1
+	}
+
+	return clientConfigs, nil
+}
+
 func (c *Client) Add(sshc *sshclient.SshClient) {
 	c.sshcs = append(c.sshcs, sshc)
 }
@@ -272,6 +314,11 @@ func (c *Client) Shutdown(ctx context.Context) {
 		}()
 	}
 	shutdowns.Wait()
+
+	if c.fileResponder != nil {
+		_ = c.fileResponder.Shutdown(ctx)
+		c.fileResponder = nil
+	}
 
 	if c.stubResponder != nil {
 		_ = c.stubResponder.Shutdown(ctx)

--- a/internal/client/client/static_tunnel_test.go
+++ b/internal/client/client/static_tunnel_test.go
@@ -1,0 +1,93 @@
+package client
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	"github.com/amalshaji/portr/internal/constants"
+)
+
+func staticDir(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+	return dir
+}
+
+func TestPrepareStaticTunnelsUsesOneLocalResponder(t *testing.T) {
+	c := &Client{
+		config: &clientcfg.Config{
+			DisableTUI: true,
+		},
+	}
+	t.Cleanup(func() {
+		c.Shutdown(t.Context())
+	})
+
+	prepared, err := c.prepareStaticTunnels([]clientcfg.ClientConfig{
+		{
+			Tunnel: clientcfg.Tunnel{
+				Type:      constants.Static,
+				Subdomain: "a",
+				Dir:       staticDir(t, "A"),
+			},
+		},
+		{
+			Tunnel: clientcfg.Tunnel{
+				Type:      constants.Static,
+				Subdomain: "b",
+				Dir:       staticDir(t, "B"),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("prepare static tunnels: %v", err)
+	}
+
+	if len(prepared) != 2 {
+		t.Fatalf("expected 2 prepared configs, got %d", len(prepared))
+	}
+	firstPort := prepared[0].Tunnel.Port
+	if firstPort == 0 {
+		t.Fatal("expected first static tunnel to receive responder port")
+	}
+	for _, cfg := range prepared {
+		if cfg.Tunnel.Type != constants.Static {
+			t.Fatalf("expected public tunnel type to remain static, got %s", cfg.Tunnel.Type)
+		}
+		if cfg.Tunnel.Host != "127.0.0.1" {
+			t.Fatalf("expected local responder host, got %q", cfg.Tunnel.Host)
+		}
+		if cfg.Tunnel.Port != firstPort {
+			t.Fatalf("expected shared responder port %d, got %d", firstPort, cfg.Tunnel.Port)
+		}
+	}
+
+	// Every static tunnel shares one port, so Host is the only discriminator.
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/", firstPort), nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = "b.example.test"
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request file responder: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	if string(body) != "B" {
+		t.Fatalf("unexpected response body: %q", string(body))
+	}
+}

--- a/internal/client/client/version_test.go
+++ b/internal/client/client/version_test.go
@@ -94,4 +94,15 @@ func TestDesiredWorkers(t *testing.T) {
 	if got := desiredWorkers(stubCfg, true); got != 1 {
 		t.Fatalf("expected stub tunnels to use a single worker, got %d", got)
 	}
+
+	staticCfg := clientcfg.ClientConfig{
+		Tunnel: clientcfg.Tunnel{
+			Type:     constants.Static,
+			PoolSize: 4,
+		},
+	}
+
+	if got := desiredWorkers(staticCfg, true); got != 1 {
+		t.Fatalf("expected static tunnels to use a single worker, got %d", got)
+	}
 }

--- a/internal/client/config/config.go
+++ b/internal/client/config/config.go
@@ -25,6 +25,7 @@ type Tunnel struct {
 	Subdomain            string                   `yaml:"subdomain"`
 	Port                 int                      `yaml:"port"`
 	Host                 string                   `yaml:"host"`
+	Dir                  string                   `yaml:"dir"`
 	Type                 constants.ConnectionType `yaml:"type"`
 	ResponseFormat       string                   `yaml:"response_format"`
 	ResponseTemplate     string                   `yaml:"response_tmpl"`
@@ -38,18 +39,20 @@ func (t *Tunnel) SetDefaults() {
 		t.Type = constants.Http
 	}
 
-	if t.Type == constants.Http && t.Subdomain == "" {
+	if (t.Type == constants.Http || t.Type == constants.Static) && t.Subdomain == "" {
 		t.Subdomain = utils.GenerateTunnelSubdomain()
 	}
-	if t.Type == constants.Http || t.Type == constants.Stub {
+	if t.Type.IsHTTPLike() {
 		t.Subdomain = utils.NormalizeSubdomain(t.Subdomain)
 	}
 
-	if t.Host == "" && t.Type != constants.Stub {
+	// Stub and static tunnels are served by an in-process responder, so their
+	// local address is assigned when that responder starts.
+	if t.Host == "" && t.Type != constants.Stub && t.Type != constants.Static {
 		t.Host = "localhost"
 	}
 
-	if t.Type == constants.Stub {
+	if t.Type == constants.Stub || t.Type == constants.Static {
 		t.PoolSize = 1
 	} else if t.PoolSize <= 0 {
 		t.PoolSize = 2
@@ -61,7 +64,7 @@ func (t *Tunnel) Validate() error {
 		return fmt.Errorf("subdomain is required for stub tunnels")
 	}
 
-	if t.Type == constants.Http || t.Type == constants.Stub {
+	if t.Type.IsHTTPLike() {
 		if err := utils.ValidateSubdomain(t.Subdomain); err != nil {
 			return err
 		}
@@ -76,11 +79,72 @@ func (t *Tunnel) Validate() error {
 		}
 	}
 
+	if t.Type == constants.Static {
+		if strings.TrimSpace(t.Dir) == "" {
+			return fmt.Errorf("dir is required for static tunnels")
+		}
+		info, err := os.Stat(t.Dir)
+		if err != nil {
+			return fmt.Errorf("failed to read dir %q: %w", t.Dir, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("dir %q is not a directory", t.Dir)
+		}
+	}
+
 	return nil
 }
 
 func (t *Tunnel) GetLocalAddr() string {
 	return t.Host + ":" + fmt.Sprint(t.Port)
+}
+
+// ResolveServeDir makes a static tunnel's directory absolute, relative to
+// baseDir. It deliberately does not touch the filesystem: Load runs on every
+// CLI invocation, so a stale static entry must not break unrelated commands.
+// Validate is where the directory is checked to exist.
+func (t *Tunnel) ResolveServeDir(baseDir string) error {
+	if t.Type != constants.Static {
+		return nil
+	}
+
+	dir := strings.TrimSpace(t.Dir)
+	if dir == "" {
+		return fmt.Errorf("dir is required for static tunnels")
+	}
+	if !filepath.IsAbs(dir) {
+		if baseDir == "" {
+			baseDir = "."
+		}
+		dir = filepath.Join(baseDir, dir)
+	}
+
+	resolved, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("failed to resolve dir %q: %w", t.Dir, err)
+	}
+	t.Dir = resolved
+	return nil
+}
+
+// StatusKey identifies a tunnel in TUI messages. Stub and static tunnels share
+// one local responder port, so they key on subdomain instead.
+func (t Tunnel) StatusKey() string {
+	if t.Type == constants.Stub || t.Type == constants.Static {
+		return string(t.Type) + ":" + t.Subdomain
+	}
+	return fmt.Sprint(t.Port)
+}
+
+// DisplayName is the human-readable label for a tunnel.
+func (t Tunnel) DisplayName() string {
+	if t.Name != "" {
+		return t.Name
+	}
+	if (t.Type == constants.Stub || t.Type == constants.Static) && t.Subdomain != "" {
+		return t.Subdomain
+	}
+	return fmt.Sprint(t.Port)
 }
 
 func (t *Tunnel) ValidateStubTemplateSource() error {
@@ -365,7 +429,7 @@ func (c *ClientConfig) GetTcpTunnelAddr() string {
 }
 
 func (c *ClientConfig) GetTunnelAddr() string {
-	if c.Tunnel.Type == constants.Http || c.Tunnel.Type == constants.Stub {
+	if c.Tunnel.Type.IsHTTPLike() {
 		return c.GetHttpTunnelAddr()
 	}
 	return c.GetTcpTunnelAddr()
@@ -398,6 +462,9 @@ func Load(configFile string) (Config, error) {
 	baseDir := filepath.Dir(configFile)
 	for i := range config.Tunnels {
 		if err := config.Tunnels[i].ResolveStubTemplate(baseDir); err != nil {
+			return Config{}, err
+		}
+		if err := config.Tunnels[i].ResolveServeDir(baseDir); err != nil {
 			return Config{}, err
 		}
 	}

--- a/internal/client/config/config_test.go
+++ b/internal/client/config/config_test.go
@@ -637,3 +637,120 @@ func TestNoMatchingTunnelsErrorWithoutNamedTunnels(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestSetDefaultsGeneratesSubdomainForStaticTunnel(t *testing.T) {
+	tunnel := Tunnel{Type: constants.Static, Dir: "./dist"}
+	tunnel.SetDefaults()
+
+	if tunnel.Subdomain == "" {
+		t.Fatal("expected a generated subdomain for static tunnels")
+	}
+	if tunnel.PoolSize != 1 {
+		t.Fatalf("expected pool size 1, got %d", tunnel.PoolSize)
+	}
+	if tunnel.Host != "" {
+		t.Fatalf("expected the responder to assign the host, got %q", tunnel.Host)
+	}
+}
+
+func TestLoadResolvesServeDirRelativeToConfig(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "dist"), 0o755); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("tunnels:\n  - name: site\n    type: static\n    subdomain: site\n    dir: dist\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+
+	expected, err := filepath.Abs(filepath.Join(dir, "dist"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	if cfg.Tunnels[0].Dir != expected {
+		t.Fatalf("expected %q, got %q", expected, cfg.Tunnels[0].Dir)
+	}
+}
+
+func TestLoadDoesNotStatServeDir(t *testing.T) {
+	// Load runs on every CLI invocation, so a stale static entry must not break
+	// unrelated commands. Validate is where the directory has to exist.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("tunnels:\n  - name: site\n    type: static\n    subdomain: site\n    dir: gone\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("expected load to succeed for a missing dir, got %v", err)
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected validate to reject the missing dir")
+	}
+}
+
+func TestValidateRejectsStaticTunnelWithoutDir(t *testing.T) {
+	tunnel := Tunnel{Type: constants.Static, Subdomain: "site"}
+	tunnel.SetDefaults()
+
+	err := tunnel.Validate()
+	if err == nil || !strings.Contains(err.Error(), "dir is required for static tunnels") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateRejectsStaticTunnelWithFileAsDir(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "not-a-dir.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tunnel := Tunnel{Type: constants.Static, Subdomain: "site", Dir: file}
+	tunnel.SetDefaults()
+
+	err := tunnel.Validate()
+	if err == nil || !strings.Contains(err.Error(), "is not a directory") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetTunnelAddrUsesHttpAddrForStatic(t *testing.T) {
+	cfg := ClientConfig{
+		TunnelUrl: "go.portr.dev",
+		Tunnel:    Tunnel{Type: constants.Static, Subdomain: "site"},
+	}
+
+	if got := cfg.GetTunnelAddr(); got != "https://site.go.portr.dev" {
+		t.Fatalf("unexpected tunnel address %q", got)
+	}
+}
+
+func TestStatusKeyDistinguishesStubAndStatic(t *testing.T) {
+	stub := Tunnel{Type: constants.Stub, Subdomain: "x"}
+	static := Tunnel{Type: constants.Static, Subdomain: "x"}
+
+	if stub.StatusKey() == static.StatusKey() {
+		t.Fatalf("expected distinct status keys, both were %q", stub.StatusKey())
+	}
+	if static.StatusKey() != "static:x" {
+		t.Fatalf("unexpected static status key %q", static.StatusKey())
+	}
+}
+
+func TestDisplayNameFallsBackToSubdomainForStatic(t *testing.T) {
+	tunnel := Tunnel{Type: constants.Static, Subdomain: "site"}
+	if got := tunnel.DisplayName(); got != "site" {
+		t.Fatalf("unexpected display name %q", got)
+	}
+
+	named := Tunnel{Type: constants.Static, Subdomain: "site", Name: "docs"}
+	if got := named.DisplayName(); got != "docs" {
+		t.Fatalf("unexpected display name %q", got)
+	}
+}

--- a/internal/client/fileresponder/responder.go
+++ b/internal/client/fileresponder/responder.go
@@ -1,0 +1,81 @@
+package fileresponder
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+
+	"github.com/amalshaji/portr/internal/client/localserver"
+)
+
+type Route struct {
+	Subdomain string
+	Dir       string
+}
+
+// Responder serves static directories over the shared local server.
+type Responder struct {
+	*localserver.Server
+}
+
+func New() *Responder {
+	return &Responder{Server: localserver.New("static responder")}
+}
+
+func (r *Responder) Register(rt Route) error {
+	if rt.Dir == "" {
+		return fmt.Errorf("dir is required")
+	}
+
+	handler, err := newDirHandler(rt.Dir)
+	if err != nil {
+		return err
+	}
+	if err := r.Server.Register(rt.Subdomain, handler); err != nil {
+		_ = handler.Close()
+		return err
+	}
+	return nil
+}
+
+// dirHandler serves one directory. It holds the open root so the server can
+// close it when the route goes away.
+type dirHandler struct {
+	root *os.Root
+	http.Handler
+}
+
+func (d *dirHandler) Close() error {
+	return d.root.Close()
+}
+
+func newDirHandler(dir string) (*dirHandler, error) {
+	// os.Root keeps symlinks from escaping the served directory, which http.Dir
+	// explicitly does not do. The directory is published to the internet.
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serve dir %q: %w", dir, err)
+	}
+	return &dirHandler{
+		root:    root,
+		Handler: http.FileServerFS(containedFS{root.FS()}),
+	}, nil
+}
+
+// containedFS reports every unreadable path as missing. os.Root rejects
+// symlinks that escape the served directory with a "path escapes from parent"
+// error, which http.FileServerFS would otherwise surface as a 500 — telling a
+// public client that the path exists and points somewhere it should not.
+type containedFS struct {
+	fsys fs.FS
+}
+
+func (c containedFS) Open(name string) (fs.File, error) {
+	file, err := c.fsys.Open(name)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	return file, err
+}

--- a/internal/client/fileresponder/responder_test.go
+++ b/internal/client/fileresponder/responder_test.go
@@ -1,0 +1,226 @@
+package fileresponder
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func testResponder(t *testing.T, routes ...Route) *Responder {
+	t.Helper()
+
+	responder := New()
+	for _, route := range routes {
+		if err := responder.Register(route); err != nil {
+			t.Fatalf("register %q: %v", route.Subdomain, err)
+		}
+	}
+	t.Cleanup(func() { _ = responder.Shutdown(context.Background()) })
+	return responder
+}
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func get(t *testing.T, responder *Responder, host, path string) *http.Response {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, path, nil)
+	request.Host = host
+	recorder := httptest.NewRecorder()
+	responder.ServeHTTP(recorder, request)
+	return recorder.Result()
+}
+
+func bodyOf(t *testing.T, response *http.Response) string {
+	t.Helper()
+	defer response.Body.Close()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return string(body)
+}
+
+func TestResponderServesIndexFromDirectory(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "index.html", "<h1>portr</h1>")
+	responder := testResponder(t, Route{Subdomain: "site", Dir: dir})
+
+	response := get(t, responder, "site.example.test", "/")
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.StatusCode)
+	}
+	if body := bodyOf(t, response); body != "<h1>portr</h1>" {
+		t.Fatalf("unexpected body %q", body)
+	}
+}
+
+func TestResponderServesNestedFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "assets/app.js", "console.log(1)")
+	responder := testResponder(t, Route{Subdomain: "site", Dir: dir})
+
+	response := get(t, responder, "site.example.test", "/assets/app.js")
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.StatusCode)
+	}
+	if body := bodyOf(t, response); body != "console.log(1)" {
+		t.Fatalf("unexpected body %q", body)
+	}
+}
+
+func TestResponderListsDirectoryWithoutIndex(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.txt", "a")
+	responder := testResponder(t, Route{Subdomain: "site", Dir: dir})
+
+	response := get(t, responder, "site.example.test", "/")
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.StatusCode)
+	}
+	if body := bodyOf(t, response); !strings.Contains(body, "a.txt") {
+		t.Fatalf("expected a directory listing, got %q", body)
+	}
+}
+
+func TestResponderRejectsParentTraversal(t *testing.T) {
+	parent := t.TempDir()
+	if err := os.WriteFile(filepath.Join(parent, "secret.txt"), []byte("classified"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	dir := filepath.Join(parent, "public")
+	writeFile(t, dir, "index.html", "ok")
+	responder := testResponder(t, Route{Subdomain: "site", Dir: dir})
+
+	response := get(t, responder, "site.example.test", "/../secret.txt")
+	if body := bodyOf(t, response); strings.Contains(body, "classified") {
+		t.Fatalf("traversal escaped the served directory: %q", body)
+	}
+}
+
+func TestResponderRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on windows")
+	}
+
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	if err := os.WriteFile(secret, []byte("classified"), 0o644); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	dir := t.TempDir()
+	writeFile(t, dir, "index.html", "ok")
+	if err := os.Symlink(secret, filepath.Join(dir, "escape")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	responder := testResponder(t, Route{Subdomain: "site", Dir: dir})
+
+	// This is the assertion that justifies os.OpenRoot over http.Dir, which
+	// follows symlinks out of the served tree.
+	response := get(t, responder, "site.example.test", "/escape")
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for an escaping symlink, got %d: %q", response.StatusCode, bodyOf(t, response))
+	}
+}
+
+func TestResponderRoutesMultipleSubdomainsByHost(t *testing.T) {
+	dirA := t.TempDir()
+	writeFile(t, dirA, "index.html", "A")
+	dirB := t.TempDir()
+	writeFile(t, dirB, "index.html", "B")
+
+	responder := testResponder(t,
+		Route{Subdomain: "a", Dir: dirA},
+		Route{Subdomain: "b", Dir: dirB},
+	)
+
+	if body := bodyOf(t, get(t, responder, "a.example.test", "/")); body != "A" {
+		t.Fatalf("expected A, got %q", body)
+	}
+	if body := bodyOf(t, get(t, responder, "b.example.test", "/")); body != "B" {
+		t.Fatalf("expected B, got %q", body)
+	}
+}
+
+func TestResponderReturnsOKForHealthCheck(t *testing.T) {
+	responder := testResponder(t)
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Portr-Ping-Request", "true")
+	recorder := httptest.NewRecorder()
+	responder.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a ping, got %d", recorder.Code)
+	}
+}
+
+func TestResponderNotFoundForUnknownHost(t *testing.T) {
+	dirA := t.TempDir()
+	writeFile(t, dirA, "index.html", "A")
+	dirB := t.TempDir()
+	writeFile(t, dirB, "index.html", "B")
+
+	// Two routes, so the single-route fallback cannot mask the miss.
+	responder := testResponder(t,
+		Route{Subdomain: "a", Dir: dirA},
+		Route{Subdomain: "b", Dir: dirB},
+	)
+
+	response := get(t, responder, "nope.example.test", "/")
+	if response.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404 for an unknown host, got %d", response.StatusCode)
+	}
+}
+
+func TestRegisterRejectsDuplicateSubdomain(t *testing.T) {
+	dir := t.TempDir()
+	responder := testResponder(t, Route{Subdomain: "site", Dir: dir})
+
+	err := responder.Register(Route{Subdomain: "site", Dir: dir})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected a duplicate error, got %v", err)
+	}
+}
+
+func TestRegisterRejectsNonDirectory(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "not-a-dir.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	responder := New()
+	t.Cleanup(func() { _ = responder.Shutdown(context.Background()) })
+
+	if err := responder.Register(Route{Subdomain: "site", Dir: file}); err == nil {
+		t.Fatal("expected an error when the dir is a regular file")
+	}
+}
+
+func TestRegisterRejectsMissingFields(t *testing.T) {
+	responder := New()
+	t.Cleanup(func() { _ = responder.Shutdown(context.Background()) })
+
+	if err := responder.Register(Route{Dir: t.TempDir()}); err == nil {
+		t.Fatal("expected an error for a missing subdomain")
+	}
+	if err := responder.Register(Route{Subdomain: "site"}); err == nil {
+		t.Fatal("expected an error for a missing dir")
+	}
+}

--- a/internal/client/localserver/server.go
+++ b/internal/client/localserver/server.go
@@ -1,0 +1,183 @@
+package localserver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Server is a loopback HTTP server that dispatches to a handler per subdomain.
+//
+// Tunnels served from inside the client process (stub responses, static
+// directories) all share this shape: one ephemeral local port that the tunnel
+// worker forwards to, with the Host header as the only discriminator between
+// the tunnels registered on it.
+//
+// A registered handler that implements io.Closer is closed when it is
+// unregistered or when the server shuts down.
+type Server struct {
+	name     string
+	server   *http.Server
+	listener net.Listener
+	mu       sync.RWMutex
+	handlers map[string]http.Handler
+}
+
+// New returns a server that is not yet listening. name is used in start errors.
+func New(name string) *Server {
+	s := &Server{
+		name:     name,
+		handlers: make(map[string]http.Handler),
+	}
+	s.server = &http.Server{
+		Handler:           s,
+		ReadHeaderTimeout: 15 * time.Second,
+	}
+	return s
+}
+
+func (s *Server) Start() error {
+	if s.listener != nil {
+		return nil
+	}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return fmt.Errorf("start %s: %w", s.name, err)
+	}
+	s.listener = listener
+
+	go func() {
+		if err := s.server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			// The tunnel worker health checks surface unreachable local endpoints;
+			// there is no caller to return this asynchronous server error to.
+		}
+	}()
+
+	return nil
+}
+
+func (s *Server) Addr() string {
+	if s.listener == nil {
+		return ""
+	}
+	return s.listener.Addr().String()
+}
+
+func (s *Server) Port() int {
+	if s.listener == nil {
+		return 0
+	}
+	if addr, ok := s.listener.Addr().(*net.TCPAddr); ok {
+		return addr.Port
+	}
+	return 0
+}
+
+func (s *Server) Register(subdomain string, handler http.Handler) error {
+	subdomain = strings.ToLower(strings.TrimSpace(subdomain))
+	if subdomain == "" {
+		return fmt.Errorf("subdomain is required")
+	}
+	if handler == nil {
+		return fmt.Errorf("handler is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.handlers[subdomain]; exists {
+		return fmt.Errorf("%s route for subdomain %q already exists", s.name, subdomain)
+	}
+	s.handlers[subdomain] = handler
+	return nil
+}
+
+func (s *Server) Unregister(subdomain string) {
+	subdomain = strings.ToLower(strings.TrimSpace(subdomain))
+	if subdomain == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if handler, ok := s.handlers[subdomain]; ok {
+		closeHandler(handler)
+		delete(s.handlers, subdomain)
+	}
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	for subdomain, handler := range s.handlers {
+		closeHandler(handler)
+		delete(s.handlers, subdomain)
+	}
+	s.mu.Unlock()
+
+	if s.server == nil {
+		return nil
+	}
+	return s.server.Shutdown(ctx)
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("X-Portr-Ping-Request") == "true" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	handler, ok := s.handlerForHost(req.Host)
+	if !ok {
+		http.NotFound(w, req)
+		return
+	}
+	handler.ServeHTTP(w, req)
+}
+
+// handlerForHost resolves the handler for a request. Every tunnel on this
+// server shares one local port, so the Host header is the only discriminator.
+func (s *Server) handlerForHost(host string) (http.Handler, bool) {
+	hostname := strings.ToLower(strings.TrimSpace(stripPort(host)))
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if handler, ok := s.handlers[hostname]; ok {
+		return handler, true
+	}
+	for subdomain, handler := range s.handlers {
+		if strings.HasPrefix(hostname, subdomain+".") {
+			return handler, true
+		}
+	}
+	// A direct request to the loopback address has no subdomain to match.
+	if len(s.handlers) == 1 {
+		for _, handler := range s.handlers {
+			return handler, true
+		}
+	}
+	return nil, false
+}
+
+func closeHandler(handler http.Handler) {
+	if closer, ok := handler.(io.Closer); ok {
+		_ = closer.Close()
+	}
+}
+
+func stripPort(host string) string {
+	if hostname, _, err := net.SplitHostPort(host); err == nil {
+		return hostname
+	}
+	if strings.Count(host, ":") == 1 {
+		if idx := strings.LastIndex(host, ":"); idx > -1 {
+			return host[:idx]
+		}
+	}
+	return host
+}

--- a/internal/client/localserver/server_test.go
+++ b/internal/client/localserver/server_test.go
@@ -1,0 +1,151 @@
+package localserver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func textHandler(body string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	})
+}
+
+type closableHandler struct {
+	http.Handler
+	closed bool
+}
+
+func (c *closableHandler) Close() error {
+	c.closed = true
+	return nil
+}
+
+func get(t *testing.T, server *Server, host string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Host = host
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, request)
+	return recorder
+}
+
+func TestServerRoutesBySubdomain(t *testing.T) {
+	server := New("test server")
+	if err := server.Register("a", textHandler("A")); err != nil {
+		t.Fatalf("register a: %v", err)
+	}
+	if err := server.Register("b", textHandler("B")); err != nil {
+		t.Fatalf("register b: %v", err)
+	}
+
+	if body := get(t, server, "a.example.test").Body.String(); body != "A" {
+		t.Fatalf("expected A, got %q", body)
+	}
+	if body := get(t, server, "b.example.test:8001").Body.String(); body != "B" {
+		t.Fatalf("expected B for a host with a port, got %q", body)
+	}
+	if code := get(t, server, "nope.example.test").Code; code != http.StatusNotFound {
+		t.Fatalf("expected 404 for an unknown host, got %d", code)
+	}
+}
+
+func TestServerFallsBackToSoleHandler(t *testing.T) {
+	// A direct request to the loopback address carries no subdomain.
+	server := New("test server")
+	if err := server.Register("only", textHandler("ONLY")); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	if body := get(t, server, "127.0.0.1:54321").Body.String(); body != "ONLY" {
+		t.Fatalf("expected the sole handler to answer, got %q", body)
+	}
+}
+
+func TestServerAnswersHealthCheckWithoutRoute(t *testing.T) {
+	server := New("test server")
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.Header.Set("X-Portr-Ping-Request", "true")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200 for a ping, got %d", recorder.Code)
+	}
+}
+
+func TestServerRejectsDuplicateAndEmptySubdomain(t *testing.T) {
+	server := New("test server")
+	if err := server.Register("dup", textHandler("x")); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	err := server.Register("dup", textHandler("y"))
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("expected a duplicate error, got %v", err)
+	}
+	if err := server.Register("  ", textHandler("z")); err == nil {
+		t.Fatalf("expected an error for an empty subdomain")
+	}
+	if err := server.Register("nil-handler", nil); err == nil {
+		t.Fatalf("expected an error for a nil handler")
+	}
+}
+
+func TestServerClosesHandlersOnUnregisterAndShutdown(t *testing.T) {
+	server := New("test server")
+
+	first := &closableHandler{Handler: textHandler("A")}
+	second := &closableHandler{Handler: textHandler("B")}
+	if err := server.Register("a", first); err != nil {
+		t.Fatalf("register a: %v", err)
+	}
+	if err := server.Register("b", second); err != nil {
+		t.Fatalf("register b: %v", err)
+	}
+
+	server.Unregister("a")
+	if !first.closed {
+		t.Fatal("expected unregister to close the handler")
+	}
+	if second.closed {
+		t.Fatal("unregister must not touch other handlers")
+	}
+
+	if err := server.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	if !second.closed {
+		t.Fatal("expected shutdown to close remaining handlers")
+	}
+}
+
+func TestServerStartIsIdempotentAndReportsPort(t *testing.T) {
+	server := New("test server")
+	t.Cleanup(func() { _ = server.Shutdown(context.Background()) })
+
+	if server.Port() != 0 || server.Addr() != "" {
+		t.Fatal("expected no port before start")
+	}
+	if err := server.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	port := server.Port()
+	if port == 0 {
+		t.Fatal("expected an assigned port after start")
+	}
+	if err := server.Start(); err != nil {
+		t.Fatalf("second start: %v", err)
+	}
+	if server.Port() != port {
+		t.Fatal("expected start to be idempotent")
+	}
+	if !strings.HasPrefix(server.Addr(), "127.0.0.1:") {
+		t.Fatalf("expected a loopback address, got %q", server.Addr())
+	}
+}

--- a/internal/client/ssh/lifecycle.go
+++ b/internal/client/ssh/lifecycle.go
@@ -8,9 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/tui"
-	"github.com/amalshaji/portr/internal/constants"
 	"github.com/charmbracelet/log"
 )
 
@@ -42,7 +40,7 @@ func (s *SshClient) Shutdown(ctx context.Context) error {
 	}
 	cfg := s.ConfigSnapshot()
 	if s.tui != nil {
-		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(cfg.Tunnel), Delta: -1})
+		s.tui.Send(tui.UpdateConnCountMsg{Port: cfg.Tunnel.StatusKey(), Delta: -1})
 	}
 	s.emitEvent(EventStopped, nil)
 	log.Info("Stopped tunnel connection", "address", cfg.GetTunnelAddr())
@@ -61,17 +59,7 @@ func reconnectBackoff(attempt int) time.Duration {
 }
 
 func (s *SshClient) startError(err error) error {
-	return fmt.Errorf("failed to start tunnel '%s': %w", tunnelDisplayName(s.config.Tunnel), err)
-}
-
-func tunnelDisplayName(tunnel config.Tunnel) string {
-	if tunnel.Name != "" {
-		return tunnel.Name
-	}
-	if tunnel.Type == constants.Stub && tunnel.Subdomain != "" {
-		return tunnel.Subdomain
-	}
-	return fmt.Sprintf("%d", tunnel.Port)
+	return fmt.Errorf("failed to start tunnel '%s': %w", s.config.Tunnel.DisplayName(), err)
 }
 
 func (s *SshClient) Start(ctx context.Context) error {
@@ -141,7 +129,7 @@ func (s *SshClient) Start(ctx context.Context) error {
 				s.logDebug(fmt.Sprintf("Failed to reconnect to ssh tunnel (attempt %d)", attempt), err)
 			}
 			if attempt >= maxRetries {
-				return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", tunnelDisplayName(s.config.Tunnel), attempt, err)
+				return fmt.Errorf("failed to reconnect tunnel '%s' after %d attempts: %w", s.config.Tunnel.DisplayName(), attempt, err)
 			}
 			if !waitForReconnect(lifecycleCtx, reconnectBackoff(attempt)) {
 				return nil
@@ -199,7 +187,7 @@ func (s *SshClient) monitorTransport(ctx context.Context, transport *tunnelTrans
 				return err
 			}
 			if s.tui != nil {
-				s.tui.Send(tui.UpdateHealthMsg{Port: tunnelStatusKey(s.config.Tunnel), Healthy: true})
+				s.tui.Send(tui.UpdateHealthMsg{Port: s.config.Tunnel.StatusKey(), Healthy: true})
 			}
 		}
 	}
@@ -216,14 +204,14 @@ func (s *SshClient) announceTransportReady(initial bool) {
 		s.emitEvent(EventStarted, nil)
 	} else {
 		if s.tui != nil {
-			s.tui.Send(tui.UpdateHealthMsg{Port: tunnelStatusKey(cfg.Tunnel), Healthy: true})
+			s.tui.Send(tui.UpdateHealthMsg{Port: cfg.Tunnel.StatusKey(), Healthy: true})
 		} else if !cfg.DisableTerminalLogs {
 			fmt.Printf("🔄 Tunnel reconnected: %s\n", cfg.GetTunnelAddr())
 		}
 		s.emitEvent(EventReconnected, nil)
 	}
 	if s.tui != nil {
-		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(cfg.Tunnel), Delta: 1})
+		s.tui.Send(tui.UpdateConnCountMsg{Port: cfg.Tunnel.StatusKey(), Delta: 1})
 	}
 }
 
@@ -233,8 +221,8 @@ func (s *SshClient) announceTransportLost(err error) {
 		s.logDebug("Tunnel transport failed", err)
 	}
 	if s.tui != nil {
-		s.tui.Send(tui.UpdateConnCountMsg{Port: tunnelStatusKey(cfg.Tunnel), Delta: -1})
-		s.tui.Send(tui.UpdateHealthMsg{Port: tunnelStatusKey(cfg.Tunnel), Healthy: false})
+		s.tui.Send(tui.UpdateConnCountMsg{Port: cfg.Tunnel.StatusKey(), Delta: -1})
+		s.tui.Send(tui.UpdateHealthMsg{Port: cfg.Tunnel.StatusKey(), Healthy: false})
 	} else if !cfg.DisableTerminalLogs {
 		fmt.Printf("❌ Tunnel unhealthy: %s (attempting reconnect)\n", cfg.GetTunnelAddr())
 	}

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
-	"github.com/amalshaji/portr/internal/constants"
 	"github.com/amalshaji/portr/internal/utils"
 	"github.com/charmbracelet/log"
 	"github.com/go-resty/resty/v2"
@@ -173,13 +172,8 @@ func CreateNewConnectionWithContext(ctx context.Context, cfg config.ClientConfig
 		ConnectionId string `json:"connection_id"`
 	}
 
-	connectionType := cfg.Tunnel.Type
-	if connectionType == constants.Stub {
-		connectionType = constants.Http
-	}
-
 	payload := map[string]any{
-		"connection_type": string(connectionType),
+		"connection_type": string(cfg.Tunnel.Type.WireType()),
 		"secret_key":      cfg.SecretKey,
 		"subdomain":       nil,
 	}
@@ -187,7 +181,7 @@ func CreateNewConnectionWithContext(ctx context.Context, cfg config.ClientConfig
 		SetError(&reqErr).
 		SetResult(&response)
 
-	if cfg.Tunnel.Type == constants.Http || cfg.Tunnel.Type == constants.Stub {
+	if cfg.Tunnel.Type.IsHTTPLike() {
 		payload["subdomain"] = cfg.Tunnel.Subdomain
 	}
 
@@ -214,13 +208,6 @@ func (s *SshClient) createNewConnection(ctx context.Context) (string, error) {
 		return s.config.ConnectionID, nil
 	}
 	return CreateNewConnectionWithContext(ctx, s.config)
-}
-
-func tunnelStatusKey(tunnel config.Tunnel) string {
-	if tunnel.Type == constants.Stub {
-		return "stub:" + tunnel.Subdomain
-	}
-	return fmt.Sprintf("%d", tunnel.Port)
 }
 
 func (s *SshClient) httpTunnel(src net.Conn, localEndpoint string) {
@@ -509,14 +496,7 @@ func (s *SshClient) logHttpRequestSized(
 		return
 	}
 
-	tunnelName := s.config.Tunnel.Name
-	if tunnelName == "" {
-		if s.config.Tunnel.Type == constants.Stub && s.config.Tunnel.Subdomain != "" {
-			tunnelName = s.config.Tunnel.Subdomain
-		} else {
-			tunnelName = fmt.Sprintf("%d", s.config.Tunnel.Port)
-		}
-	}
+	tunnelName := s.config.Tunnel.DisplayName()
 
 	if s.tui != nil {
 		s.tui.Send(tui.AddLogMsg{

--- a/internal/client/ssh/ssh_create_conn_test.go
+++ b/internal/client/ssh/ssh_create_conn_test.go
@@ -254,3 +254,55 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
+
+func TestCreateNewConnection_StaticUsesHTTPPayload(t *testing.T) {
+	// The server's connection API only accepts http and tcp, and its ssh
+	// handler rejects anything else outright, so this translation must hold.
+	newRestyClient = func() *resty.Client {
+		return resty.NewWithClient(&http.Client{
+			Transport: roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+				var payload map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+					t.Fatalf("decode request body: %v", err)
+				}
+
+				if payload["connection_type"] != "http" {
+					t.Fatalf("expected static tunnel to register as http, got %v", payload["connection_type"])
+				}
+				if payload["subdomain"] != "site" {
+					t.Fatalf("expected site subdomain, got %v", payload["subdomain"])
+				}
+				if _, ok := payload["dir"]; ok {
+					t.Fatalf("did not expect dir in server payload")
+				}
+
+				body, _ := json.Marshal(map[string]string{"connection_id": "static123"})
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       io.NopCloser(strings.NewReader(string(body))),
+				}, nil
+			}),
+		})
+	}
+	defer func() { newRestyClient = resty.New }()
+
+	cfg := clientcfg.ClientConfig{
+		ServerUrl:    "localhost:8001",
+		SecretKey:    "sk",
+		UseLocalHost: true,
+		Tunnel: clientcfg.Tunnel{
+			Type:      constants.Static,
+			Subdomain: "site",
+			Dir:       "/tmp/dist",
+		},
+	}
+
+	id, err := CreateNewConnection(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if id != "static123" {
+		t.Fatalf("expected static connection id, got %q", id)
+	}
+}

--- a/internal/client/ssh/transport.go
+++ b/internal/client/ssh/transport.go
@@ -153,11 +153,7 @@ func (s *SshClient) clearTransport(transport *tunnelTransport) {
 }
 
 func (s *SshClient) tunnelType() constants.ConnectionType {
-	tunnelType := s.config.Tunnel.Type
-	if tunnelType == constants.Stub {
-		return constants.Http
-	}
-	return tunnelType
+	return s.config.Tunnel.Type.WireType()
 }
 
 func (s *SshClient) serveTransport(ctx context.Context, transport *tunnelTransport) error {

--- a/internal/client/stubresponder/responder.go
+++ b/internal/client/stubresponder/responder.go
@@ -1,19 +1,17 @@
 package stubresponder
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"mime"
-	"net"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
-	"sync"
-	"time"
+
+	"github.com/amalshaji/portr/internal/client/localserver"
 )
 
 var (
@@ -28,67 +26,16 @@ type Route struct {
 	ResponseTemplate string
 }
 
+// Responder serves templated stub responses over the shared local server.
 type Responder struct {
-	server   *http.Server
-	listener net.Listener
-	mu       sync.RWMutex
-	routes   map[string]Route
+	*localserver.Server
 }
 
 func New() *Responder {
-	responder := &Responder{
-		routes: make(map[string]Route),
-	}
-	responder.server = &http.Server{
-		Handler:           responder,
-		ReadHeaderTimeout: 15 * time.Second,
-	}
-	return responder
-}
-
-func (r *Responder) Start() error {
-	if r.listener != nil {
-		return nil
-	}
-
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return fmt.Errorf("start stub responder: %w", err)
-	}
-	r.listener = listener
-
-	go func() {
-		if err := r.server.Serve(listener); err != nil && err != http.ErrServerClosed {
-			// The tunnel worker health checks surface unreachable local endpoints;
-			// there is no caller to return this asynchronous server error to.
-		}
-	}()
-
-	return nil
-}
-
-func (r *Responder) Addr() string {
-	if r.listener == nil {
-		return ""
-	}
-	return r.listener.Addr().String()
-}
-
-func (r *Responder) Port() int {
-	if r.listener == nil {
-		return 0
-	}
-	if addr, ok := r.listener.Addr().(*net.TCPAddr); ok {
-		return addr.Port
-	}
-	return 0
+	return &Responder{Server: localserver.New("stub responder")}
 }
 
 func (r *Responder) Register(route Route) error {
-	subdomain := strings.ToLower(strings.TrimSpace(route.Subdomain))
-	if subdomain == "" {
-		return fmt.Errorf("subdomain is required")
-	}
 	if strings.TrimSpace(route.ResponseFormat) == "" {
 		return fmt.Errorf("response format is required")
 	}
@@ -96,90 +43,22 @@ func (r *Responder) Register(route Route) error {
 		return fmt.Errorf("response template is required")
 	}
 
-	route.Subdomain = subdomain
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, exists := r.routes[subdomain]; exists {
-		return fmt.Errorf("stub route for subdomain %q already exists", subdomain)
-	}
-	r.routes[subdomain] = route
-	return nil
+	return r.Server.Register(route.Subdomain, newStubHandler(route))
 }
 
-func (r *Responder) Unregister(subdomain string) {
-	subdomain = strings.ToLower(strings.TrimSpace(subdomain))
-	if subdomain == "" {
-		return
-	}
+func newStubHandler(route Route) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		bodyValues, err := requestBodyValues(req)
+		if err != nil {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	delete(r.routes, subdomain)
-}
-
-func (r *Responder) Shutdown(ctx context.Context) error {
-	if r.server == nil {
-		return nil
-	}
-	return r.server.Shutdown(ctx)
-}
-
-func (r *Responder) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if req.Header.Get("X-Portr-Ping-Request") == "true" {
+		rendered := renderTemplate(route.ResponseTemplate, req.URL.Query(), bodyValues, isJSONResponse(route.ResponseFormat))
+		w.Header().Set("Content-Type", route.ResponseFormat)
 		w.WriteHeader(http.StatusOK)
-		return
-	}
-
-	route, ok := r.routeForHost(req.Host)
-	if !ok {
-		http.NotFound(w, req)
-		return
-	}
-
-	bodyValues, err := requestBodyValues(req)
-	if err != nil {
-		http.Error(w, "Bad Request", http.StatusBadRequest)
-		return
-	}
-
-	rendered := renderTemplate(route.ResponseTemplate, req.URL.Query(), bodyValues, isJSONResponse(route.ResponseFormat))
-	w.Header().Set("Content-Type", route.ResponseFormat)
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(rendered))
-}
-
-func (r *Responder) routeForHost(host string) (Route, bool) {
-	hostname := strings.ToLower(strings.TrimSpace(stripPort(host)))
-
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
-	if route, ok := r.routes[hostname]; ok {
-		return route, true
-	}
-	for subdomain, route := range r.routes {
-		if strings.HasPrefix(hostname, subdomain+".") {
-			return route, true
-		}
-	}
-	if len(r.routes) == 1 {
-		for _, route := range r.routes {
-			return route, true
-		}
-	}
-	return Route{}, false
-}
-
-func stripPort(host string) string {
-	if hostname, _, err := net.SplitHostPort(host); err == nil {
-		return hostname
-	}
-	if strings.Count(host, ":") == 1 {
-		if idx := strings.LastIndex(host, ":"); idx > -1 {
-			return host[:idx]
-		}
-	}
-	return host
+		_, _ = w.Write([]byte(rendered))
+	})
 }
 
 func requestBodyValues(req *http.Request) (map[string]string, error) {

--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -113,10 +113,7 @@ func tunnelKey(tunnelConfig *config.Tunnel) string {
 	if tunnelConfig == nil {
 		return ""
 	}
-	if tunnelConfig.Type == constants.Stub {
-		return "stub:" + tunnelConfig.Subdomain
-	}
-	return fmt.Sprintf("%d", tunnelConfig.Port)
+	return tunnelConfig.StatusKey()
 }
 
 func New(debug bool, dashboardURL string, dashboardDisabledLabel string) *tea.Program {
@@ -421,23 +418,19 @@ func (m model) View() string {
 			statusText = "🟢 Healthy (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
 		}
 
-		tunnelName := tunnel.config.Name
-		if tunnelName == "" {
-			if tunnel.config.Type == constants.Stub {
-				tunnelName = tunnel.config.Subdomain
-			} else {
-				tunnelName = fmt.Sprintf("%d", tunnel.config.Port)
-			}
-		}
+		tunnelName := tunnel.config.DisplayName()
 		tunnelAddr := ""
 		if tunnel.clientConfig != nil {
 			tunnelAddr = tunnel.clientConfig.GetTunnelAddr()
 		}
 
 		var tunnelInfo string
-		if tunnel.config.Type == constants.Stub {
-			tunnelInfo = fmt.Sprintf("%s (stub → %s) [%s] %s",
+		if tunnel.config.Type == constants.Stub || tunnel.config.Type == constants.Static {
+			// The served directory is absolute and would push the public URL off
+			// the end of this width-clamped line; it is printed at startup instead.
+			tunnelInfo = fmt.Sprintf("%s (%s → %s) [%s] %s",
 				tunnelName,
+				tunnel.config.Type,
 				tunnelAddr,
 				tunnel.config.Subdomain,
 				statusText,

--- a/internal/client/tui/tui_test.go
+++ b/internal/client/tui/tui_test.go
@@ -106,3 +106,43 @@ func testClientConfig(tunnel config.Tunnel) *config.ClientConfig {
 		UseLocalHost: false,
 	}
 }
+
+func TestViewRendersStaticTunnelWithoutLocalPort(t *testing.T) {
+	tunnel := config.Tunnel{
+		Name:      "site",
+		Type:      constants.Static,
+		Subdomain: "site",
+		Dir:       "/tmp/dist",
+		PoolSize:  1,
+	}
+	m := model{
+		tunnels: map[string]*tunnelStatus{
+			tunnelKey(&tunnel): {
+				config:       &tunnel,
+				clientConfig: testClientConfig(tunnel),
+				active:       1,
+				poolSize:     1,
+			},
+		},
+		width: 200,
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "site (static → https://site.go.portr.dev)") {
+		t.Fatalf("expected static tunnel line, got %q", view)
+	}
+	if strings.Contains(view, "127.0.0.1:") || strings.Contains(view, "/tmp/dist") {
+		t.Fatalf("expected no local address or directory in the status line, got %q", view)
+	}
+}
+
+func TestTunnelKeyDistinguishesStaticTunnelsSharingLocalPort(t *testing.T) {
+	// Every static tunnel is served from one responder port, so a port-based
+	// key would collapse them into a single row with a wrong health count.
+	first := config.Tunnel{Type: constants.Static, Subdomain: "a", Port: 54321}
+	second := config.Tunnel{Type: constants.Static, Subdomain: "b", Port: 54321}
+
+	if tunnelKey(&first) == tunnelKey(&second) {
+		t.Fatalf("expected distinct keys, both were %q", tunnelKey(&first))
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -19,6 +19,8 @@ func (c *ConnectionType) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		*c = Tcp
 	case "stub":
 		*c = Stub
+	case "static":
+		*c = Static
 	default:
 		*c = Http
 	}
@@ -26,10 +28,26 @@ func (c *ConnectionType) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	return nil
 }
 
+// WireType returns the connection type sent to the server. Stub and static
+// tunnels are client-side concepts served over the HTTP tunnel protocol; the
+// server only ever accepts http and tcp.
+func (c ConnectionType) WireType() ConnectionType {
+	if c == Stub || c == Static {
+		return Http
+	}
+	return c
+}
+
+// IsHTTPLike reports whether the tunnel is addressed by subdomain over HTTP.
+func (c ConnectionType) IsHTTPLike() bool {
+	return c == Http || c == Stub || c == Static
+}
+
 const (
-	Http ConnectionType = "http"
-	Tcp  ConnectionType = "tcp"
-	Stub ConnectionType = "stub"
+	Http   ConnectionType = "http"
+	Tcp    ConnectionType = "tcp"
+	Stub   ConnectionType = "stub"
+	Static ConnectionType = "static"
 )
 
 const ClientUiViteDistDir = "./internal/client/dashboard/ui-v2/dist/static/.vite/manifest.json"


### PR DESCRIPTION
## Why

Serving a folder publicly today means `python -m http.server` in one terminal and `portr http` in another. `portr serve ./dist` does both. frp, zrok and LocalXpose all have built-in file serving.

```bash
portr serve ./dist                    # subdomain generated
portr serve ./dist --subdomain docs
```

```yaml
tunnels:
  - name: site
    type: static
    subdomain: site
    dir: ./dist
```

## Notes for review

**The server is unchanged.** `static` is a client-side type translated to `http` before anything goes over the wire, exactly like `stub`. `TestCreateNewConnection_StaticUsesHTTPPayload` guards that, since `sshd.go`'s switch rejects anything else at runtime rather than compile time.

**The loopback responder is extracted rather than duplicated.** `internal/client/localserver` now owns the shape both stub and static tunnels need: one ephemeral port, a handler per subdomain, Host as the only discriminator, health-check short-circuit. `stubresponder` and `fileresponder` embed it and supply only their handler. That deletes ~120 lines from `stubresponder` and leaves one implementation of the lifecycle instead of two copies to keep in sync. A handler implementing `io.Closer` is closed on unregister, which is how the static handler releases its directory. `appserver` is untouched — it only ever used the public API.

**`os.OpenRoot`, not `http.Dir`.** `http.Dir`'s own docs warn it follows symlinks out of the served tree, and this directory is published to the internet. Escaping paths return **404, not the 500** `os.Root`'s error would otherwise produce — a 500 tells a client the path exists and points somewhere it should not. `TestResponderRejectsSymlinkEscape` fails with `http.Dir`.

**`ResolveServeDir` does path math only; the existence check lives in `Validate`.** This is the one design call worth pushing back on if you disagree. `Config.Load` runs on *every* CLI invocation, and build directories get deleted constantly — if `Load` stat'd, one stale `type: static` entry in your config would break `portr http 3000`. `TestLoadDoesNotStatServeDir` pins it so nobody "fixes" it back.

**Multi-route is required, not optional.** Every static tunnel shares one responder port, so `StatusKey` keys on subdomain — a port-based key would collapse two static tunnels into one TUI row with a wrong health count.

`WireType` / `IsHTTPLike` replace the ad-hoc Stub→Http translations, and `StatusKey` / `DisplayName` collapse copies that had already drifted apart.

## Scope

- **Directory listing is on** (the `http.FileServerFS` default, matches the `python -m http.server` mental model). Disclosure caveat is documented; `--no-listing` is a small follow-up.
- **SPA fallback is out of scope** and is the #1 follow-up. Doing it right is GET/HEAD only, `Accept: text/html` only, only when `index.html` exists, and must *not* rewrite missing `.js`/`.css` into HTML-with-200. Deep links 404 today.
- **The app-server API keeps rejecting `static`**: a relative `dir` sent over HTTP would resolve against the daemon's working directory, not the caller's. Documented as a boundary. Its validation order is swapped so it now reports the type error instead of a misleading port error.
- `os.Root` holds an open handle, so in-place rebuilds (Vite, Hugo, esbuild) are served live, but `rm -rf` + recreate needs a restart. Documented.

## Merge order

Depends on nothing, but **#298 also adds `Tunnel.DisplayName`**. If that merges first, drop this branch's copy on rebase — this one is the superset (it handles `static`). The clash is a compile error, not a silent merge.

## Testing

`go build ./...` and `go test ./cmd/... ./internal/...` pass, including the pre-existing stubresponder tests unchanged, which is the evidence the extraction is behaviour-preserving. Manually verified index/nested/listing/traversal/symlink-escape/live-rebuild, both error paths, and that a stale static entry does not break `portr http`.