### PR TITLE
Fix server image build by moving the client config schema

### DIFF
--- a/.github/workflows/portr-server.yml
+++ b/.github/workflows/portr-server.yml
@@ -48,8 +48,10 @@ jobs:
       - name: Build client
         run: bun run --cwd internal/client/dashboard/ui-v2 build
 
-      - name: Build Docker web assets
-        run: docker build --target web-builder .
+      # Builds the server the way releases do. The host `go build` below cannot
+      # catch a server package importing something .dockerignore excludes.
+      - name: Build Docker image
+        run: docker build .
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,8 @@
 ## Project Structure & Module Organization
 The repo root is flattened. Go entrypoints live in `cmd/portr` and `cmd/portrd`, with shared application code under `internal/`. Use `internal/server/admin` for admin server work, `internal/server/admin/web-v2` for the React + shadcn admin UI, and `internal/client/dashboard/ui-v2` for the client dashboard. Keep integration coverage in `tests/`, database changes in `migrations/`, and product docs in `docs-v2/`. Do not add new code under the legacy `tunnel/` path.
 
+`internal/client` and `cmd/portr` are excluded from the server image by `.dockerignore`, so nothing under `internal/server` or `cmd/portrd` may import them; the build only fails inside Docker. The client config schema is shared by both sides and lives in `internal/clientconfig` for that reason.
+
 ## Build, Test, and Development Commands
 Use `make buildgo` to compile repo-owned Go packages and `make testgo` before opening a PR. These targets exclude frontend `node_modules`, which can contain Go files after dependency installation. Build the CLI with `make buildcli`, which outputs `./portr`.
 

--- a/cmd/portr/admin.go
+++ b/cmd/portr/admin.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/portr/app_server.go
+++ b/cmd/portr/app_server.go
@@ -13,8 +13,8 @@ import (
 	"time"
 
 	"github.com/amalshaji/portr/internal/client/appserver"
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/portr/auth.go
+++ b/cmd/portr/auth.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/labstack/gommon/color"
 
 	"github.com/urfave/cli/v2"

--- a/cmd/portr/config.go
+++ b/cmd/portr/config.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/labstack/gommon/color"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/portr/doctor.go
+++ b/cmd/portr/doctor.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
 	requestlogs "github.com/amalshaji/portr/internal/client/logs"
 	sshclient "github.com/amalshaji/portr/internal/client/ssh"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/portr/doctor_test.go
+++ b/cmd/portr/doctor_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/portr/http.go
+++ b/cmd/portr/http.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/portr/main.go
+++ b/cmd/portr/main.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/amalshaji/portr/internal/client/config"
 	requestlogs "github.com/amalshaji/portr/internal/client/logs"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/utils"
 	"github.com/labstack/gommon/color"
 	"github.com/urfave/cli/v2"

--- a/cmd/portr/serve.go
+++ b/cmd/portr/serve.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/portr/start.go
+++ b/cmd/portr/start.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/amalshaji/portr/internal/client/client"
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/dashboard"
 	"github.com/amalshaji/portr/internal/client/db"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/portr/stub.go
+++ b/cmd/portr/stub.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/portr/tcp.go
+++ b/cmd/portr/tcp.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/urfave/cli/v2"
 )

--- a/cmd/portr/updates.go
+++ b/cmd/portr/updates.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/go-resty/resty/v2"
 )
 

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
 	sshclient "github.com/amalshaji/portr/internal/client/ssh"
 	"github.com/amalshaji/portr/internal/client/stubresponder"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/charmbracelet/log"
 	"github.com/oklog/ulid/v2"

--- a/internal/client/appserver/manager_test.go
+++ b/internal/client/appserver/manager_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
 	sshclient "github.com/amalshaji/portr/internal/client/ssh"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/charmbracelet/log"
 )

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -7,12 +7,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
 	"github.com/amalshaji/portr/internal/client/fileresponder"
 	sshclient "github.com/amalshaji/portr/internal/client/ssh"
 	"github.com/amalshaji/portr/internal/client/stubresponder"
 	"github.com/amalshaji/portr/internal/client/tui"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/log"

--- a/internal/client/client/static_tunnel_test.go
+++ b/internal/client/client/static_tunnel_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 )
 

--- a/internal/client/client/stub_tunnel_test.go
+++ b/internal/client/client/stub_tunnel_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 )
 

--- a/internal/client/client/version.go
+++ b/internal/client/client/version.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/go-resty/resty/v2"
 )

--- a/internal/client/client/version_test.go
+++ b/internal/client/client/version_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"testing"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 )
 

--- a/internal/client/dashboard/dashboard.go
+++ b/internal/client/dashboard/dashboard.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/dashboard/handler"
 	"github.com/amalshaji/portr/internal/client/dashboard/service"
 	"github.com/amalshaji/portr/internal/client/dashboard/ui-v2/dist"
 	"github.com/amalshaji/portr/internal/client/db"
 	"github.com/amalshaji/portr/internal/client/vite"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/charmbracelet/log"
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/filesystem"

--- a/internal/client/dashboard/handler/handler.go
+++ b/internal/client/dashboard/handler/handler.go
@@ -1,8 +1,8 @@
 package handler
 
 import (
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/dashboard/service"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/gofiber/fiber/v2"
 )
 

--- a/internal/client/dashboard/service/service.go
+++ b/internal/client/dashboard/service/service.go
@@ -1,8 +1,8 @@
 package service
 
 import (
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 )
 
 type Service struct {

--- a/internal/client/db/db.go
+++ b/internal/client/db/db.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/charmbracelet/log"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/glebarez/sqlite"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"

--- a/internal/client/logs/logs.go
+++ b/internal/client/logs/logs.go
@@ -13,8 +13,8 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/amalshaji/portr/internal/client/config"
 	clientdb "github.com/amalshaji/portr/internal/client/db"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"

--- a/internal/client/ssh/host_header_test.go
+++ b/internal/client/ssh/host_header_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
 	clientdb "github.com/amalshaji/portr/internal/client/db"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 )
 
 // hostSeenByBackend runs one request through the HTTP tunnel and returns the

--- a/internal/client/ssh/hostkey.go
+++ b/internal/client/ssh/hostkey.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/charmbracelet/log"
 	"golang.org/x/crypto/ssh"
 )

--- a/internal/client/ssh/local_server_error_test.go
+++ b/internal/client/ssh/local_server_error_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
 	clientdb "github.com/amalshaji/portr/internal/client/db"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 )
 
 func startClosingTCPServer(t *testing.T) string {

--- a/internal/client/ssh/logging_test.go
+++ b/internal/client/ssh/logging_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
 	clientdb "github.com/amalshaji/portr/internal/client/db"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/glebarez/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"

--- a/internal/client/ssh/probe.go
+++ b/internal/client/ssh/probe.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"golang.org/x/crypto/ssh"
 )
 

--- a/internal/client/ssh/probe_test.go
+++ b/internal/client/ssh/probe_test.go
@@ -13,7 +13,7 @@ import (
 	gssh "github.com/gliderlabs/ssh"
 	"golang.org/x/crypto/ssh"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 )
 
 type probeServer struct {

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
 	"github.com/amalshaji/portr/internal/client/db"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/utils"
 	"github.com/charmbracelet/log"
 	"github.com/go-resty/resty/v2"

--- a/internal/client/ssh/ssh_create_conn_test.go
+++ b/internal/client/ssh/ssh_create_conn_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/go-resty/resty/v2"
 )

--- a/internal/client/ssh/ssh_shutdown_test.go
+++ b/internal/client/ssh/ssh_shutdown_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	clientcfg "github.com/amalshaji/portr/internal/client/config"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 )
 

--- a/internal/client/tui/qr_test.go
+++ b/internal/client/tui/qr_test.go
@@ -6,7 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 )
 

--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"

--- a/internal/client/tui/tui_test.go
+++ b/internal/client/tui/tui_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 )
 

--- a/internal/clientconfig/config.go
+++ b/internal/clientconfig/config.go
@@ -1,4 +1,4 @@
-package config
+package clientconfig
 
 import (
 	"errors"

--- a/internal/clientconfig/config_test.go
+++ b/internal/clientconfig/config_test.go
@@ -1,4 +1,4 @@
-package config
+package clientconfig
 
 import (
 	"os"

--- a/internal/clientconfig/configfile.go
+++ b/internal/clientconfig/configfile.go
@@ -1,4 +1,4 @@
-package config
+package clientconfig
 
 import (
 	"bytes"

--- a/internal/clientconfig/remote.go
+++ b/internal/clientconfig/remote.go
@@ -1,4 +1,4 @@
-package config
+package clientconfig
 
 import (
 	"fmt"

--- a/internal/clientconfig/remote_test.go
+++ b/internal/clientconfig/remote_test.go
@@ -1,4 +1,4 @@
-package config
+package clientconfig
 
 import (
 	"fmt"

--- a/internal/clientconfig/template_test.go
+++ b/internal/clientconfig/template_test.go
@@ -1,4 +1,4 @@
-package config
+package clientconfig
 
 import (
 	"strings"

--- a/internal/server/admin/api/config/template.go
+++ b/internal/server/admin/api/config/template.go
@@ -3,7 +3,7 @@ package config
 import (
 	"strings"
 
-	clientConfig "github.com/amalshaji/portr/internal/client/config"
+	clientConfig "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/server/admin/middleware"
 	"github.com/amalshaji/portr/internal/server/admin/models"
 	"github.com/gofiber/fiber/v2"

--- a/tests/tunnel_data_flow_test.go
+++ b/tests/tunnel_data_flow_test.go
@@ -16,9 +16,9 @@ import (
 	"testing"
 	"time"
 
-	clientconfig "github.com/amalshaji/portr/internal/client/config"
 	clientdb "github.com/amalshaji/portr/internal/client/db"
 	clientssh "github.com/amalshaji/portr/internal/client/ssh"
+	clientconfig "github.com/amalshaji/portr/internal/clientconfig"
 	"github.com/amalshaji/portr/internal/constants"
 	serverconfig "github.com/amalshaji/portr/internal/server/config"
 	serverdb "github.com/amalshaji/portr/internal/server/db"


### PR DESCRIPTION
Fixes the red `main`. My mistake in #301.

## What broke

#301 had the admin server validate team templates against the client's own rules:

```go
// internal/server/admin/api/config/template.go
clientConfig "github.com/amalshaji/portr/internal/client/config"
```

`.dockerignore` excludes `internal/client` from the server image, so `portrd` cannot see that package:

```
internal/server/admin/api/config/template.go:6:2: no required module provides package
  github.com/amalshaji/portr/internal/client/config
```

`go build ./...` on a full checkout passes, which is why it got through review and CI.

## The fix

Reusing the client's `Config.Validate()` is still the right call — a second validator would drift from what the cli actually accepts, and the whole point is that a saved template is loadable. What was wrong is where the schema lived.

The config schema is genuinely shared: the server has always *generated* client YAML in `DownloadConfig`, and now validates it too. So the package moves out of the client-only tree to `internal/clientconfig`.

Callers alias it as `config`, so every one of the 38 client files is a one-line import change and no call sites move:

```diff
-	"github.com/amalshaji/portr/internal/client/config"
+	config "github.com/amalshaji/portr/internal/clientconfig"
```

`portrd` already linked resty, gommon/color and yaml transitively, so this adds nothing to the server binary.

## Closing the gap that let it through

CI ran `docker build --target web-builder .` — only the frontend stage. The Go build ran on the host, where `internal/client` exists, so `.dockerignore` was invisible to it. The workflow now builds the whole image, which is the check that actually reproduces a release.

Also noted the constraint in `AGENTS.md`, since nothing in the source tree hints that these paths are unreachable from the server.

## Verification

- `docker build .` passes locally — both the `builder` stage that was failing and the final image.
- `go build ./...`, `go vet ./...` and the full `go test ./...` pass.
- No references to the old path remain anywhere in the repo, Go or otherwise.
