### PR TITLE
feat(client): add basic auth for http tunnels

### DIFF
--- a/cmd/portr/basic_auth_flag_test.go
+++ b/cmd/portr/basic_auth_flag_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+// TestBasicAuthFlagIsRegisteredOnHTTPLikeCommands guards the three commands that
+// serve traffic through the client's HTTP reverse proxy. tcp is excluded on
+// purpose: Tunnel.Validate rejects basic_auth there.
+func TestBasicAuthFlagIsRegisteredOnHTTPLikeCommands(t *testing.T) {
+	commands := map[string]*cli.Command{
+		"http":  httpCmd(),
+		"serve": serveCmd(),
+		"stub":  stubCmd(),
+	}
+
+	for name, command := range commands {
+		t.Run(name, func(t *testing.T) {
+			flag := findStringFlag(command, "basic-auth")
+			if flag == nil {
+				t.Fatalf("%s is missing the --basic-auth flag", name)
+			}
+			// Without the env var the credential lands in the process table
+			// and in shell history.
+			if !slices.Contains(flag.EnvVars, "PORTR_BASIC_AUTH") {
+				t.Fatalf("%s must accept PORTR_BASIC_AUTH, got %v", name, flag.EnvVars)
+			}
+		})
+	}
+}
+
+func TestBasicAuthFlagIsNotOfferedForTcpTunnels(t *testing.T) {
+	if findStringFlag(tcpCmd(), "basic-auth") != nil {
+		t.Fatal("tcp tunnels cannot enforce basic auth, so the flag must not be offered")
+	}
+}
+
+func findStringFlag(command *cli.Command, name string) *cli.StringFlag {
+	for _, flag := range command.Flags {
+		stringFlag, ok := flag.(*cli.StringFlag)
+		if ok && stringFlag.Name == name {
+			return stringFlag
+		}
+	}
+	return nil
+}

--- a/cmd/portr/http.go
+++ b/cmd/portr/http.go
@@ -23,6 +23,11 @@ func httpCmd() *cli.Command {
 				Name:  "host-header",
 				Usage: "Host header to send to the local server ('rewrite' to use the local address)",
 			},
+			&cli.StringFlag{
+				Name:    "basic-auth",
+				Usage:   "Protect the tunnel with HTTP basic auth, as user:password",
+				EnvVars: []string{"PORTR_BASIC_AUTH"},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			portStr := c.Args().First()
@@ -37,6 +42,7 @@ func httpCmd() *cli.Command {
 				Subdomain:  c.String("subdomain"),
 				Type:       constants.Http,
 				HostHeader: c.String("host-header"),
+				BasicAuth:  c.String("basic-auth"),
 			})
 		},
 	}

--- a/cmd/portr/serve.go
+++ b/cmd/portr/serve.go
@@ -20,6 +20,11 @@ func serveCmd() *cli.Command {
 				Aliases: []string{"s"},
 				Usage:   "Subdomain to serve the directory from",
 			},
+			&cli.StringFlag{
+				Name:    "basic-auth",
+				Usage:   "Protect the tunnel with HTTP basic auth, as user:password",
+				EnvVars: []string{"PORTR_BASIC_AUTH"},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			dir := strings.TrimSpace(c.Args().First())
@@ -31,6 +36,7 @@ func serveCmd() *cli.Command {
 				Dir:       dir,
 				Subdomain: c.String("subdomain"),
 				Type:      constants.Static,
+				BasicAuth: c.String("basic-auth"),
 			})
 		},
 	}

--- a/cmd/portr/stub.go
+++ b/cmd/portr/stub.go
@@ -30,6 +30,11 @@ func stubCmd() *cli.Command {
 				Name:  "response-tmpl-file",
 				Usage: "Path to a response template file",
 			},
+			&cli.StringFlag{
+				Name:    "basic-auth",
+				Usage:   "Protect the tunnel with HTTP basic auth, as user:password",
+				EnvVars: []string{"PORTR_BASIC_AUTH"},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			return startTunnels(c, &config.Tunnel{
@@ -38,6 +43,7 @@ func stubCmd() *cli.Command {
 				ResponseFormat:       c.String("response-format"),
 				ResponseTemplate:     c.String("response-tmpl"),
 				ResponseTemplateFile: c.String("response-tmpl-file"),
+				BasicAuth:            c.String("basic-auth"),
 			})
 		},
 	}

--- a/docs-v2/content/docs/client/app-server.mdx
+++ b/docs-v2/content/docs/client/app-server.mdx
@@ -263,6 +263,7 @@ curl -X POST http://127.0.0.1:7778/api/v1/tunnels \
 | `response_format` | string | Stub only | Response `Content-Type`, such as `application/json` or `application/yml`. |
 | `response_tmpl` | string | Stub only | Inline stub response template. Use exactly one of `response_tmpl` or `response_tmpl_file`. |
 | `response_tmpl_file` | string | Stub only | Stub response template file path, resolved from the app-server process working directory. |
+| `basic_auth` | string | No | `user:password` credential required to reach the tunnel URL. HTTP and stub tunnels only. |
 | `callback_url` | string | No | Single webhook URL for lifecycle events. |
 | `callback_urls` | string[] | No | Additional webhook URLs for lifecycle events. Duplicate URLs are ignored. |
 

--- a/docs-v2/content/docs/client/http-tunnel.mdx
+++ b/docs-v2/content/docs/client/http-tunnel.mdx
@@ -50,6 +50,46 @@ tunnels:
 
 `host_header` is only valid on `type: http` tunnels. The inspector always records the original public host, not the rewritten one.
 
+## Password-protecting a tunnel
+
+A tunnel URL is public as soon as it starts. `basic_auth` puts HTTP basic auth in front of it, so visitors get their browser's credential prompt and only authenticated requests reach your local server.
+
+```bash
+portr http 9000 --basic-auth admin:s3cret
+```
+
+The value is `user:password`, split on the first colon — your password may contain colons, the username may not. Because a credential on the command line is visible in the process table and lands in your shell history, you can pass it through the environment instead:
+
+```bash
+PORTR_BASIC_AUTH=admin:s3cret portr http 9000
+```
+
+Or per tunnel in the config file:
+
+```yaml
+tunnels:
+  - name: staging
+    subdomain: staging
+    port: 9000
+    basic_auth: admin:s3cret
+```
+
+`basic_auth` works on `http`, `stub` and `static` tunnels. It is rejected on `tcp` tunnels, which carry no HTTP requests to challenge, and on [team templates](/docs/client/templates#team-templates), which are shared verbatim in plain text and cannot keep a credential secret.
+
+Rejected requests are recorded in the inspector as `401`, with the attempted credential redacted, so you can see what is hitting the tunnel.
+
+<Callout type="warn">
+  Basic auth is base64-encoded, not encrypted. Over the default `https://` tunnel URL it is protected by TLS, but if you run with `use_localhost: true` the tunnel URL is plain `http://` and the credentials travel in the clear.
+</Callout>
+
+A few behaviours worth knowing:
+
+- **Your app still sees the header.** Portr validates `Authorization` and forwards it unchanged, so a local app checking the same credential keeps working. An app expecting a *different* `Authorization` value cannot work behind `basic_auth` — a browser only sends one.
+- **WebSocket handshakes are gated too.** Browsers replay cached credentials on the upgrade, but non-browser clients must send the header themselves (`wscat -H "Authorization: Basic ..."`). A failed upgrade shows up as `401` with no credential prompt.
+- **CORS preflights are gated.** Browsers do not send `Authorization` on an `OPTIONS` preflight, so cross-origin JavaScript cannot reach a `basic_auth` tunnel.
+- **There is no logout.** Browsers cache basic credentials per origin for the session, so changing `basic_auth` does not evict a credential a browser already has.
+- **Replaying a request returns `401`.** The inspector redacts `Authorization` when it stores a request, so a replay re-sends the redacted placeholder. Set the header explicitly in the replay dialog, or with `portr replay --header "Authorization: Basic ..."`.
+
 ## How it works
 
 When you run the HTTP tunnel command:

--- a/docs-v2/content/docs/client/static-tunnel.mdx
+++ b/docs-v2/content/docs/client/static-tunnel.mdx
@@ -30,6 +30,12 @@ portr serve ./dist --subdomain docs
 - Opening a static site on a phone or tablet for testing
 - Handing over a folder of screenshots, PDFs, or reports
 
+## Password Protection
+
+A static tunnel is public as soon as it starts. Pass `--basic-auth user:password`
+to require credentials before anyone can browse the directory. See
+[password-protecting a tunnel](/docs/client/http-tunnel#password-protecting-a-tunnel).
+
 ## Directory Listings
 
 Requesting a directory serves its `index.html` when one exists. When it does

--- a/docs-v2/content/docs/client/stub-tunnel.mdx
+++ b/docs-v2/content/docs/client/stub-tunnel.mdx
@@ -112,6 +112,10 @@ tunnels:
 
 Template file paths in config are resolved relative to the config file.
 
+Add `basic_auth: user:password` (or pass `--basic-auth`) to require credentials
+before the stub responds. See
+[password-protecting a tunnel](/docs/client/http-tunnel#password-protecting-a-tunnel).
+
 ## Examples
 
 Example templates are available in:

--- a/docs-v2/content/docs/client/templates.mdx
+++ b/docs-v2/content/docs/client/templates.mdx
@@ -268,6 +268,8 @@ Only `tunnels` and `groups` can be set in a team template. `server_url`, `ssh_ur
 
 Anything that names a path on one machine is rejected too, since a template is shared verbatim: static tunnels (`type: static`, which serves a local `dir`) and `response_tmpl_file`. Use an inline `response_tmpl` for stub tunnels.
 
+`basic_auth` is rejected for the same reason: a template is stored and distributed in plain text, so it cannot keep a credential secret. Set it in your local config or pass `--basic-auth` when starting the tunnel.
+
 New members get the template on a fresh setup:
 
 ```bash
@@ -356,6 +358,7 @@ Each tunnel template supports the following options:
 - **dir**: Static only. Directory to serve, resolved relative to the config file
 - **pool_size**: HTTP only. Number of SSH workers to run per HTTP tunnel (default: 2). Increases resilience and throughput.
 - **host_header**: HTTP only. Host header sent to the local server. Use `rewrite` for the local address, or any literal hostname (default: pass the public host through)
+- **basic_auth**: HTTP, stub and static only. `user:password` credential required to reach the tunnel URL. See [password-protecting a tunnel](/docs/client/http-tunnel#password-protecting-a-tunnel)
 
 HTTP tunnels use streaming reverse proxying by default. Request and response bodies are forwarded as they arrive, while inspector captures are stored asynchronously and capped at 1 MiB per body.
 The former `enable_http_reverse_proxy` option is no longer required; existing configurations containing it still load, but the option is ignored.

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -88,6 +88,7 @@ func (m *Manager) StartTunnel(ctx context.Context, request StartTunnelRequest) (
 		ResponseFormat:       request.ResponseFormat,
 		ResponseTemplate:     request.ResponseTemplate,
 		ResponseTemplateFile: request.ResponseTemplateFile,
+		BasicAuth:            request.BasicAuth,
 	}
 	tunnel.SetDefaults()
 	if err := tunnel.ResolveStubTemplate("."); err != nil {

--- a/internal/client/appserver/manager_test.go
+++ b/internal/client/appserver/manager_test.go
@@ -38,6 +38,19 @@ func TestValidateTunnelRequestRejectsInvalidPort(t *testing.T) {
 	}
 }
 
+func TestValidateTunnelRequestRejectsMalformedBasicAuth(t *testing.T) {
+	tunnel := clientcfg.Tunnel{
+		Type:      constants.Http,
+		Port:      3000,
+		BasicAuth: "admin:",
+	}
+	tunnel.SetDefaults()
+
+	if err := validateTunnelRequest(tunnel, "", nil); err == nil {
+		t.Fatal("expected an empty password to be rejected")
+	}
+}
+
 func TestValidateTunnelRequestRejectsInvalidCallbackURL(t *testing.T) {
 	tunnel := clientcfg.Tunnel{
 		Type: constants.Tcp,

--- a/internal/client/appserver/types.go
+++ b/internal/client/appserver/types.go
@@ -21,6 +21,7 @@ type StartTunnelRequest struct {
 	ResponseFormat       string                   `json:"response_format"`
 	ResponseTemplate     string                   `json:"response_tmpl"`
 	ResponseTemplateFile string                   `json:"response_tmpl_file"`
+	BasicAuth            string                   `json:"basic_auth"`
 	CallbackURL          string                   `json:"callback_url"`
 	CallbackURLs         []string                 `json:"callback_urls"`
 }

--- a/internal/client/ssh/basic_auth_test.go
+++ b/internal/client/ssh/basic_auth_test.go
@@ -266,39 +266,60 @@ func TestWebSocketUpgradeAllowedWithCredentials(t *testing.T) {
 }
 
 func TestRejectedRequestIsLoggedWithRedactedCredential(t *testing.T) {
-	backend := newGatedBackend(t)
-
-	client := &SshClient{
-		config: clientcfg.ClientConfig{
-			EnableRequestLogging: true,
-			RedactHeaders:        clientcfg.DefaultRedactHeaders,
-			Tunnel: clientcfg.Tunnel{
-				Name: "test", Subdomain: "test", Port: 3000, BasicAuth: "admin:s3cret",
-			},
-		},
-		db: newTestRequestStore(t),
+	// The custom list omits Authorization on purpose: redact_headers must not
+	// be able to expose the credential the auth gate itself relies on.
+	tests := []struct {
+		name          string
+		redactHeaders []string
+	}{
+		{"default redact list", clientcfg.DefaultRedactHeaders},
+		{"custom redact list without Authorization", []string{"Cookie"}},
 	}
 
-	// runRawRequest rather than runGatedRequest: Shutdown must flush the
-	// capture recorder after the tunnel handler has finished.
-	runRawRequest(t, client, backend.endpoint, httpRequest(basicAuthHeader("admin:guess")))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := newGatedBackend(t)
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if err := client.Shutdown(shutdownCtx); err != nil {
-		t.Fatalf("shutdown tunnel client: %v", err)
-	}
+			client := &SshClient{
+				config: clientcfg.ClientConfig{
+					EnableRequestLogging: true,
+					RedactHeaders:        tt.redactHeaders,
+					Tunnel: clientcfg.Tunnel{
+						Name: "test", Subdomain: "test", Port: 3000, BasicAuth: "admin:s3cret",
+					},
+				},
+				db: newTestRequestStore(t),
+			}
 
-	// Without this the inspector stays empty and a working gate looks like a
-	// broken tunnel.
-	var logged clientdb.Request
-	if err := client.db.Conn.First(&logged).Error; err != nil {
-		t.Fatalf("load persisted request: %v", err)
-	}
-	if logged.ResponseStatusCode != http.StatusUnauthorized {
-		t.Fatalf("expected the rejection to be logged as 401, got %d", logged.ResponseStatusCode)
-	}
-	if strings.Contains(string(logged.Headers), "guess") {
-		t.Fatalf("the attempted credential must be redacted, got %s", logged.Headers)
+			// runRawRequest rather than runGatedRequest: Shutdown must flush the
+			// capture recorder after the tunnel handler has finished.
+			runRawRequest(t, client, backend.endpoint, httpRequest(basicAuthHeader("admin:guess")))
+
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+			if err := client.Shutdown(shutdownCtx); err != nil {
+				t.Fatalf("shutdown tunnel client: %v", err)
+			}
+
+			// Without this the inspector stays empty and a working gate looks like a
+			// broken tunnel.
+			var logged clientdb.Request
+			if err := client.db.Conn.First(&logged).Error; err != nil {
+				t.Fatalf("load persisted request: %v", err)
+			}
+			if logged.ResponseStatusCode != http.StatusUnauthorized {
+				t.Fatalf("expected the rejection to be logged as 401, got %d", logged.ResponseStatusCode)
+			}
+			// Checking for the base64 token rather than the plaintext password:
+			// a verbatim header contains "Basic YWRtaW46Z3Vlc3M=", never "guess",
+			// so a plaintext check passes even when redaction is broken.
+			if !strings.Contains(string(logged.Headers), `"Authorization":["[redacted]"]`) {
+				t.Fatalf("the Authorization header must be stored as [redacted], got %s", logged.Headers)
+			}
+			encoded := base64.StdEncoding.EncodeToString([]byte("admin:guess"))
+			if strings.Contains(string(logged.Headers), encoded) {
+				t.Fatalf("the attempted credential must be redacted, got %s", logged.Headers)
+			}
+		})
 	}
 }

--- a/internal/client/ssh/basic_auth_test.go
+++ b/internal/client/ssh/basic_auth_test.go
@@ -1,0 +1,304 @@
+package ssh
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	clientdb "github.com/amalshaji/portr/internal/client/db"
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
+)
+
+const testBasicAuthChallenge = `Basic realm="Restricted", charset="UTF-8"`
+
+func basicAuthHeader(credential string) string {
+	return "Authorization: Basic " + base64.StdEncoding.EncodeToString([]byte(credential)) + "\r\n"
+}
+
+// runGatedRequest sends one raw request through the HTTP tunnel and parses the
+// response head. Unlike runRawRequest it does not wait for EOF: a rejected
+// websocket upgrade carries Connection: Upgrade, so the gate answers it without
+// closing, and reading to EOF would block until the deadline.
+func runGatedRequest(t *testing.T, client *SshClient, localEndpoint, rawRequest string) *http.Response {
+	t.Helper()
+
+	remoteConn, clientConn := net.Pipe()
+	done := make(chan struct{})
+	go func() {
+		client.httpTunnel(remoteConn, localEndpoint)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("tunnel handler did not finish")
+		}
+	})
+
+	if _, err := clientConn.Write([]byte(rawRequest)); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	if err := clientConn.SetReadDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	response, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	t.Cleanup(func() { _ = response.Body.Close() })
+	return response
+}
+
+// gatedBackend is a local server that records what reached it, so a test can
+// assert that a rejected request never got past the gate.
+type gatedBackend struct {
+	endpoint      string
+	hits          *atomic.Int64
+	authorization chan string
+}
+
+func newGatedBackend(t *testing.T) gatedBackend {
+	t.Helper()
+
+	hits := &atomic.Int64{}
+	authorization := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		select {
+		case authorization <- r.Header.Get("Authorization"):
+		default:
+		}
+		_, _ = io.WriteString(w, "ok")
+	}))
+	t.Cleanup(server.Close)
+
+	return gatedBackend{
+		endpoint:      strings.TrimPrefix(server.URL, "http://"),
+		hits:          hits,
+		authorization: authorization,
+	}
+}
+
+func basicAuthClient(credential string) *SshClient {
+	return &SshClient{config: clientcfg.ClientConfig{Tunnel: clientcfg.Tunnel{
+		Name: "test", Subdomain: "test", Port: 3000, BasicAuth: credential,
+	}}}
+}
+
+func httpRequest(extraHeaders string) string {
+	return "GET / HTTP/1.1\r\nHost: test.example\r\n" + extraHeaders + "Connection: close\r\n\r\n"
+}
+
+func websocketUpgradeRequest(extraHeaders string) string {
+	return "GET /ws HTTP/1.1\r\n" +
+		"Host: test.example\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Sec-WebSocket-Version: 13\r\n" +
+		"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+		extraHeaders + "\r\n"
+}
+
+func TestHTTPTunnelRejectsMissingCredentials(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	response := runGatedRequest(t, basicAuthClient("admin:s3cret"), backend.endpoint, httpRequest(""))
+
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected a 401, got %d", response.StatusCode)
+	}
+	// Without this header browsers never show their credential prompt.
+	if challenge := response.Header.Get("WWW-Authenticate"); challenge != testBasicAuthChallenge {
+		t.Fatalf("expected challenge %q, got %q", testBasicAuthChallenge, challenge)
+	}
+	// A 401 is the feature working, not a portr failure: replayFailure turns an
+	// unrecognised error reason into a 502.
+	if response.Header.Get("X-Portr-Error") != "" {
+		t.Fatal("a 401 must not be marked as a portr error")
+	}
+	if hits := backend.hits.Load(); hits != 0 {
+		t.Fatalf("the local server must not be reached, got %d hits", hits)
+	}
+}
+
+func TestHTTPTunnelRejectsWrongCredentials(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	response := runGatedRequest(t, basicAuthClient("admin:s3cret"), backend.endpoint,
+		httpRequest(basicAuthHeader("admin:wrong")))
+
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected a 401, got %d", response.StatusCode)
+	}
+	if hits := backend.hits.Load(); hits != 0 {
+		t.Fatalf("the local server must not be reached, got %d hits", hits)
+	}
+}
+
+func TestHTTPTunnelForwardsAuthorizationOnCorrectCredentials(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	response := runGatedRequest(t, basicAuthClient("admin:s3cret"), backend.endpoint,
+		httpRequest(basicAuthHeader("admin:s3cret")))
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected the request to pass the gate, got %d", response.StatusCode)
+	}
+
+	// Portr validates Authorization but forwards it unchanged, so a local app
+	// checking the same credential keeps working.
+	select {
+	case got := <-backend.authorization:
+		want := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:s3cret"))
+		if got != want {
+			t.Fatalf("expected Authorization to be forwarded as %q, got %q", want, got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("backend did not receive a request")
+	}
+}
+
+func TestHTTPTunnelPassesThroughWithoutBasicAuth(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	response := runGatedRequest(t, basicAuthClient(""), backend.endpoint, httpRequest(""))
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("an unprotected tunnel must pass the request through, got %d", response.StatusCode)
+	}
+	if hits := backend.hits.Load(); hits != 1 {
+		t.Fatalf("expected exactly one backend hit, got %d", hits)
+	}
+}
+
+func TestBasicAuthPasswordMayContainColon(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	response := runGatedRequest(t, basicAuthClient("admin:pa:ss"), backend.endpoint,
+		httpRequest(basicAuthHeader("admin:pa:ss")))
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected the colon-bearing password to be accepted, got %d", response.StatusCode)
+	}
+}
+
+func TestMalformedBasicAuthLocksTheTunnel(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	// Validate rejects a colon-less credential, so this is only reachable by a
+	// caller that skipped validation. The gate hashes the credential whole, and
+	// every request reproduces it as user + ":" + password, so a value with no
+	// colon can never be matched -- including by the request that would match
+	// if the two halves were compared separately.
+	for _, attempt := range []string{"nocolon", "nocolon:", ":nocolon"} {
+		t.Run(attempt, func(t *testing.T) {
+			response := runGatedRequest(t, basicAuthClient("nocolon"), backend.endpoint,
+				httpRequest(basicAuthHeader(attempt)))
+
+			if response.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("expected %q to be rejected, got %d", attempt, response.StatusCode)
+			}
+		})
+	}
+
+	if hits := backend.hits.Load(); hits != 0 {
+		t.Fatalf("the local server must not be reached, got %d hits", hits)
+	}
+}
+
+func TestPingRequestBypassesBasicAuth(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	// The portr server answers pings itself once it has a backend, but gating
+	// them here would still break reconciliation against older servers.
+	response := runGatedRequest(t, basicAuthClient("admin:s3cret"), backend.endpoint,
+		httpRequest("X-Portr-Ping-Request: true\r\n"))
+
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("expected the ping to bypass the gate, got %d", response.StatusCode)
+	}
+}
+
+func TestWebSocketUpgradeRejectedWithoutCredentials(t *testing.T) {
+	received := make(chan string, 1)
+	localEndpoint := startWebSocketEchoServer(t, received)
+
+	// Gating upgrades matters: otherwise an Upgrade header bypasses the gate.
+	response := runGatedRequest(t, basicAuthClient("admin:s3cret"), localEndpoint,
+		websocketUpgradeRequest(""))
+
+	if response.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected a 401, got %d", response.StatusCode)
+	}
+	select {
+	case host := <-received:
+		t.Fatalf("the local websocket server must not be reached, saw a handshake for %q", host)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestWebSocketUpgradeAllowedWithCredentials(t *testing.T) {
+	received := make(chan string, 1)
+	localEndpoint := startWebSocketEchoServer(t, received)
+
+	response := runGatedRequest(t, basicAuthClient("admin:s3cret"), localEndpoint,
+		websocketUpgradeRequest(basicAuthHeader("admin:s3cret")))
+
+	if response.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected the upgrade to be relayed, got %d", response.StatusCode)
+	}
+	select {
+	case <-received:
+	case <-time.After(2 * time.Second):
+		t.Fatal("local websocket server did not receive a handshake")
+	}
+}
+
+func TestRejectedRequestIsLoggedWithRedactedCredential(t *testing.T) {
+	backend := newGatedBackend(t)
+
+	client := &SshClient{
+		config: clientcfg.ClientConfig{
+			EnableRequestLogging: true,
+			RedactHeaders:        clientcfg.DefaultRedactHeaders,
+			Tunnel: clientcfg.Tunnel{
+				Name: "test", Subdomain: "test", Port: 3000, BasicAuth: "admin:s3cret",
+			},
+		},
+		db: newTestRequestStore(t),
+	}
+
+	// runRawRequest rather than runGatedRequest: Shutdown must flush the
+	// capture recorder after the tunnel handler has finished.
+	runRawRequest(t, client, backend.endpoint, httpRequest(basicAuthHeader("admin:guess")))
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := client.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("shutdown tunnel client: %v", err)
+	}
+
+	// Without this the inspector stays empty and a working gate looks like a
+	// broken tunnel.
+	var logged clientdb.Request
+	if err := client.db.Conn.First(&logged).Error; err != nil {
+		t.Fatalf("load persisted request: %v", err)
+	}
+	if logged.ResponseStatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected the rejection to be logged as 401, got %d", logged.ResponseStatusCode)
+	}
+	if strings.Contains(string(logged.Headers), "guess") {
+		t.Fatalf("the attempted credential must be redacted, got %s", logged.Headers)
+	}
+}

--- a/internal/client/ssh/basicauth.go
+++ b/internal/client/ssh/basicauth.go
@@ -1,0 +1,95 @@
+package ssh
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"io"
+	"net/http"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// basicAuthChallenge is the WWW-Authenticate value sent with every 401. Without
+// it browsers never show their credential prompt. It is a constant so it can
+// never be built from request data and smuggle a quote into the header.
+// charset="UTF-8" is the only value RFC 7617 defines and makes modern browsers
+// encode non-ASCII credentials as UTF-8.
+const basicAuthChallenge = `Basic realm="Restricted", charset="UTF-8"`
+
+// basicAuthGate enforces a tunnel's basic_auth credential. A nil gate means the
+// tunnel is unprotected and lets everything through.
+type basicAuthGate struct {
+	expected [sha256.Size]byte
+}
+
+// newBasicAuthGate takes Tunnel.ResolvedBasicAuth's value directly, where an
+// empty credential means the tunnel is unprotected. The credential is hashed
+// once here rather than on every request.
+func newBasicAuthGate(credential string) *basicAuthGate {
+	if credential == "" {
+		return nil
+	}
+
+	return &basicAuthGate{expected: sha256.Sum256([]byte(credential))}
+}
+
+// allow reports whether the request carries the tunnel's credential.
+//
+// The comparison runs over SHA-256 digests rather than the raw strings so it is
+// fixed-width and cannot leak the credential length through timing.
+func (g *basicAuthGate) allow(request *http.Request) bool {
+	if g == nil {
+		return true
+	}
+
+	// request.BasicAuth decodes the header for us; comparing the raw header
+	// would break on legal base64 and whitespace variations.
+	username, password, ok := request.BasicAuth()
+	if !ok {
+		return false
+	}
+
+	// BasicAuth splits on the first colon, so username never contains one and
+	// rejoining reproduces the configured credential exactly. It also means a
+	// credential with no colon can never be reproduced by any request, so a
+	// malformed basic_auth locks the tunnel instead of weakening it.
+	received := sha256.Sum256([]byte(username + ":" + password))
+
+	return subtle.ConstantTimeCompare(received[:], g.expected[:]) == 1
+}
+
+// rejectUnauthorized challenges the caller and records the attempt.
+//
+// The body stays plain text: the pages in internal/utils/error-templates exist
+// to tell the tunnel owner that something is broken, whereas a 401 is the
+// feature working correctly and is shown to a stranger. Browsers only render it
+// if the user dismisses the credential prompt.
+//
+// X-Portr-Error is deliberately not set. A 401 is not a portr failure, and
+// replayFailure treats any unrecognised error reason as a 502.
+func (s *SshClient) rejectUnauthorized(writer http.ResponseWriter, request *http.Request) {
+	header := writer.Header()
+	header.Set("WWW-Authenticate", basicAuthChallenge)
+	header.Set("Content-Type", "text/plain; charset=utf-8")
+	header.Set("X-Content-Type-Options", "nosniff")
+	writer.WriteHeader(http.StatusUnauthorized)
+	_, _ = io.WriteString(writer, "401 Unauthorized\n")
+
+	// Rejected requests never reach the reverse proxy, so without this the
+	// inspector stays empty and a working gate looks like a broken tunnel.
+	// Checked before the clone so unlogged tunnels pay nothing. The guessed
+	// credential is stored redacted: Authorization is in DefaultRedactHeaders.
+	if !s.requestLoggingEnabled() {
+		return
+	}
+
+	s.submitCapture(httpCaptureTask{
+		id:      ulid.Make().String(),
+		request: cloneRequestForLog(request),
+		response: &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Proto:      request.Proto,
+			Header:     header.Clone(),
+		},
+	})
+}

--- a/internal/client/ssh/capture.go
+++ b/internal/client/ssh/capture.go
@@ -226,6 +226,14 @@ type queuedCaptureTask struct {
 	task   captureTask
 }
 
+// cloneRequestForLog snapshots a request for the capture pipeline, which runs
+// after the handler has moved on and must not observe later mutations such as
+// the reverse proxy rewriting Host. Request.Clone already deep-copies Header
+// and URL, so nothing else needs copying by hand.
+func cloneRequestForLog(request *http.Request) *http.Request {
+	return request.Clone(context.Background())
+}
+
 func (s *SshClient) requestLoggingEnabled() bool {
 	return s != nil && s.config.EnableRequestLogging
 }

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -388,6 +388,27 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 	}
 }
 
+// redactHeaderNames returns the redaction list to use for this tunnel's
+// captures. When basic auth is enabled, Authorization is forced into the list
+// so a custom redact_headers list can never persist the tunnel's own
+// credential.
+func (s *SshClient) redactHeaderNames() []string {
+	names := s.config.RedactHeaders
+	// An empty list falls back to DefaultRedactHeaders inside
+	// redactHeaderValues, which already includes Authorization.
+	if len(names) == 0 || s.config.Tunnel.ResolvedBasicAuth() == "" {
+		return names
+	}
+
+	for _, name := range names {
+		if strings.EqualFold(name, "Authorization") {
+			return names
+		}
+	}
+
+	return append(append([]string(nil), names...), "Authorization")
+}
+
 func redactHeaderValues(headers http.Header, redactNames []string) map[string][]string {
 	if len(redactNames) == 0 {
 		redactNames = config.DefaultRedactHeaders
@@ -459,7 +480,7 @@ func (s *SshClient) logHttpRequestSized(
 		isReplayedRequest = true
 	}
 
-	requestHeaders := redactHeaderValues(request.Header, s.config.RedactHeaders)
+	requestHeaders := redactHeaderValues(request.Header, s.redactHeaderNames())
 	delete(requestHeaders, "X-Portr-Replayed-Request-Id")
 
 	requestHeadersBytes, err := json.Marshal(requestHeaders)
@@ -470,7 +491,7 @@ func (s *SshClient) logHttpRequestSized(
 		return
 	}
 
-	responseHeaders := redactHeaderValues(response.Header, s.config.RedactHeaders)
+	responseHeaders := redactHeaderValues(response.Header, s.redactHeaderNames())
 
 	responseHeadersBytes, err := json.Marshal(responseHeaders)
 	if err != nil {

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -257,6 +257,7 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 	proxy.Transport = transport
 
 	hostHeader := s.config.Tunnel.ResolvedHostHeader(localEndpoint)
+	authGate := newBasicAuthGate(s.config.Tunnel.ResolvedBasicAuth())
 
 	defaultDirector := proxy.Director
 	proxy.Director = func(request *http.Request) {
@@ -318,6 +319,18 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 			return
 		}
 
+		// The gate sits above the websocket branch so upgrades are covered by
+		// the same check, and because writer is still an ordinary
+		// ResponseWriter here rather than a hijacked connection.
+		//
+		// Pings stay above the gate on purpose: they never reach the local
+		// server, and the portr server answers them itself whenever it has a
+		// backend, so gating them would only break the reconciliation cron.
+		if !authGate.allow(request) {
+			s.rejectUnauthorized(writer, request)
+			return
+		}
+
 		if isWebSocketUpgrade(request) {
 			hijacker, ok := writer.(http.Hijacker)
 			if !ok {
@@ -340,13 +353,7 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 			return
 		}
 
-		requestForLog := request.Clone(context.Background())
-		requestForLog.Header = request.Header.Clone()
-		requestForLog.Host = request.Host
-		if request.URL != nil {
-			clonedURL := *request.URL
-			requestForLog.URL = &clonedURL
-		}
+		requestForLog := cloneRequestForLog(request)
 
 		requestCapture := &bodyCapture{}
 		if request.Body != nil {

--- a/internal/client/ssh/websocket.go
+++ b/internal/client/ssh/websocket.go
@@ -147,7 +147,7 @@ func (s *SshClient) logWebSocketSessionWithID(sessionID, handshakeRequestID stri
 		return ""
 	}
 
-	requestHeaders := redactHeaderValues(request.Header, s.config.RedactHeaders)
+	requestHeaders := redactHeaderValues(request.Header, s.redactHeaderNames())
 	requestHeadersBytes, err := json.Marshal(requestHeaders)
 	if err != nil {
 		if s.config.Debug {
@@ -156,7 +156,7 @@ func (s *SshClient) logWebSocketSessionWithID(sessionID, handshakeRequestID stri
 		return ""
 	}
 
-	responseHeaders := redactHeaderValues(response.Header, s.config.RedactHeaders)
+	responseHeaders := redactHeaderValues(response.Header, s.redactHeaderNames())
 	responseHeadersBytes, err := json.Marshal(responseHeaders)
 	if err != nil {
 		if s.config.Debug {

--- a/internal/clientconfig/config.go
+++ b/internal/clientconfig/config.go
@@ -27,6 +27,7 @@ type Tunnel struct {
 	RemotePort           int
 	PoolSize             int    `yaml:"pool_size"`
 	HostHeader           string `yaml:"host_header"`
+	BasicAuth            string `yaml:"basic_auth"`
 }
 
 // HostHeaderRewrite sets the outbound Host header to the local address.
@@ -60,6 +61,10 @@ func (t *Tunnel) SetDefaults() {
 func (t *Tunnel) Validate() error {
 	if strings.TrimSpace(t.HostHeader) != "" && t.Type != constants.Http {
 		return fmt.Errorf("host_header is only supported for http tunnels")
+	}
+
+	if err := t.validateBasicAuth(); err != nil {
+		return err
 	}
 
 	if t.Type == constants.Stub && strings.TrimSpace(t.Subdomain) == "" {
@@ -113,6 +118,41 @@ func (t *Tunnel) ResolvedHostHeader(localAddr string) string {
 	default:
 		return value
 	}
+}
+
+// ResolvedBasicAuth returns the user:password credential required to reach the
+// tunnel, or an empty string when the tunnel is unprotected. The credential
+// stays opaque here: only validateBasicAuth needs to look inside it, and the
+// gate compares it whole. Only the outer value is trimmed, so whitespace inside
+// either half survives ("user: pass" is a password with a leading space).
+func (t *Tunnel) ResolvedBasicAuth() string {
+	return strings.TrimSpace(t.BasicAuth)
+}
+
+// validateBasicAuth rejects credentials that look like protection but are not.
+// The split is on the first colon only, matching RFC 7617: a userid cannot
+// contain a colon, a password can.
+func (t *Tunnel) validateBasicAuth() error {
+	value := strings.TrimSpace(t.BasicAuth)
+	if value == "" {
+		return nil
+	}
+
+	if !t.Type.IsHTTPLike() {
+		return fmt.Errorf("basic_auth is not supported for %s tunnels", t.Type)
+	}
+
+	username, password, found := strings.Cut(value, ":")
+	switch {
+	case !found:
+		return fmt.Errorf("basic_auth must be in user:password format")
+	case username == "":
+		return fmt.Errorf("basic_auth username cannot be empty")
+	case password == "":
+		return fmt.Errorf("basic_auth password cannot be empty")
+	}
+
+	return nil
 }
 
 // ResolveServeDir makes a static tunnel's directory absolute, relative to
@@ -404,16 +444,19 @@ func ValidateTemplate(raw string) error {
 	return config.Validate()
 }
 
-// validateTemplateTunnel rejects tunnel settings that name a path on the
-// author's machine. A team template is shared verbatim, so such a path means
-// nothing on a teammate's machine, and the server validating the template has
-// no business resolving it either.
+// validateTemplateTunnel rejects tunnel settings that are wrong when shared
+// verbatim: a path on the author's machine, which means nothing on a
+// teammate's machine and which the server validating the template has no
+// business resolving, or a credential, which a shared plaintext template
+// cannot keep secret.
 func validateTemplateTunnel(tunnel Tunnel) error {
 	switch {
 	case tunnel.Type == constants.Static:
 		return fmt.Errorf("tunnel %q: static tunnels serve a directory on your machine and cannot be shared in a team template", tunnel.Name)
 	case strings.TrimSpace(tunnel.ResponseTemplateFile) != "":
 		return fmt.Errorf("tunnel %q: response_tmpl_file points at a path on your machine; inline the body with response_tmpl instead", tunnel.Name)
+	case strings.TrimSpace(tunnel.BasicAuth) != "":
+		return fmt.Errorf("tunnel %q: basic_auth is a credential and cannot be shared in a team template; set it in your local config or pass --basic-auth", tunnel.Name)
 	}
 
 	return nil

--- a/internal/clientconfig/config_test.go
+++ b/internal/clientconfig/config_test.go
@@ -777,3 +777,76 @@ func TestSetDefaultsEnablesQRCodeUnlessDisabled(t *testing.T) {
 		t.Fatal("expected an explicit false to be respected")
 	}
 }
+
+func TestResolvedBasicAuthEmptyWhenBlank(t *testing.T) {
+	for _, value := range []string{"", "   "} {
+		tunnel := Tunnel{Type: constants.Http, Port: 3000, BasicAuth: value}
+		if credential := tunnel.ResolvedBasicAuth(); credential != "" {
+			t.Fatalf("expected %q to leave the tunnel unprotected, got %q", value, credential)
+		}
+	}
+}
+
+func TestResolvedBasicAuthKeepsInnerWhitespace(t *testing.T) {
+	// Only the outer value is trimmed, so the config and the working credential
+	// cannot disagree about a space inside either half.
+	tunnel := Tunnel{Type: constants.Http, Port: 3000, BasicAuth: "  admin: s3 cret  "}
+	if credential := tunnel.ResolvedBasicAuth(); credential != "admin: s3 cret" {
+		t.Fatalf("expected the inner spacing to survive, got %q", credential)
+	}
+}
+
+func TestValidateRejectsBasicAuthOnTcpTunnel(t *testing.T) {
+	tcp := Tunnel{Type: constants.Tcp, Port: 5432, BasicAuth: "admin:s3cret"}
+	tcp.SetDefaults()
+	err := tcp.Validate()
+	if err == nil || !strings.Contains(err.Error(), "basic_auth is not supported for tcp tunnels") {
+		t.Fatalf("expected tcp rejection, got %v", err)
+	}
+}
+
+func TestValidateAcceptsBasicAuthOnHTTPLikeTunnels(t *testing.T) {
+	// Unlike host_header, basic auth works for every type that reaches the
+	// client's HTTP reverse proxy.
+	tunnels := map[string]Tunnel{
+		"http": {Type: constants.Http, Port: 3000, BasicAuth: "admin:s3cret"},
+		"stub": {
+			Type:             constants.Stub,
+			Subdomain:        "stubby",
+			ResponseFormat:   "application/json",
+			ResponseTemplate: "{}",
+			BasicAuth:        "admin:s3cret",
+		},
+		"static": {Type: constants.Static, Subdomain: "site", Dir: t.TempDir(), BasicAuth: "admin:s3cret"},
+	}
+
+	for name, tunnel := range tunnels {
+		t.Run(name, func(t *testing.T) {
+			tunnel.SetDefaults()
+			if err := tunnel.Validate(); err != nil {
+				t.Fatalf("expected %s to accept basic_auth, got %v", name, err)
+			}
+		})
+	}
+}
+
+func TestValidateRejectsMalformedBasicAuth(t *testing.T) {
+	tests := map[string]string{
+		"nocolon":  "must be in user:password format",
+		":s3cret":  "username cannot be empty",
+		"admin:":   "password cannot be empty",
+		"  :    ":  "username cannot be empty",
+		"admin:  ": "password cannot be empty",
+	}
+
+	for value, contains := range tests {
+		t.Run(value, func(t *testing.T) {
+			tunnel := Tunnel{Type: constants.Http, Port: 3000, BasicAuth: value}
+			tunnel.SetDefaults()
+			err := tunnel.Validate()
+			if err == nil || !strings.Contains(err.Error(), contains) {
+				t.Fatalf("expected %q to mention %q, got %v", value, contains, err)
+			}
+		})
+	}
+}

--- a/internal/clientconfig/template_test.go
+++ b/internal/clientconfig/template_test.go
@@ -143,6 +143,15 @@ groups:
 			template: "tunnels:\n  - name: web\n   port: 3000\n",
 			contains: "yaml",
 		},
+		{
+			name: "basic auth credential",
+			template: `tunnels:
+  - name: web
+    port: 3000
+    basic_auth: admin:s3cret
+`,
+			contains: "basic_auth is a credential and cannot be shared in a team template",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
A tunnel URL is public the moment it starts. This adds an opt-in credential in front of it, so hitting the tunnel produces the browser's native prompt and only authenticated requests reach the local server.

```bash
portr http 9000 --basic-auth admin:s3cret
PORTR_BASIC_AUTH=admin:s3cret portr http 9000   # keeps it out of ps and shell history
```

```yaml
tunnels:
  - name: staging
    subdomain: staging
    port: 9000
    basic_auth: admin:s3cret
```

Works on `http`, `stub` and `static`. Rejected on `tcp`.

## Enforced client-side

The challenge lives in `httpTunnelReverseProxy`'s handler, which every HTTP-like tunnel already funnels through — `serveTransport` dispatches on `WireType()`, and that folds stub/static into http. So one insertion point covers every path that reaches a local app.

The alternative, challenging at the server edge in `Proxy.handleRequest`, rejects unauthorized traffic before it costs tunnel bandwidth, but needs a new column on the connection table with migrations for both sqlite and postgres, a new field on `CreateConnectionInput`, a new method on `TunnelBackend`, a parallel auth map for the SSH path, and it puts user credentials in the server database. Client-side needs none of that.

Ordering is **ping bypass → auth gate → websocket upgrade → proxy**:

- Above the websocket branch, or an `Upgrade` header is a one-line bypass. It also means `writer` is still an ordinary `ResponseWriter`, not yet hijacked.
- Below the ping bypass, which never reaches the local server and which the portr server answers itself — gating it would only break the reconciliation cron.

## Credential comparison

The credential is hashed **whole** and compared with `subtle.ConstantTimeCompare` over the digests, so the comparison is fixed-width and cannot leak length through timing.

Hashing whole rather than per-half is load-bearing, not stylistic. `request.BasicAuth` splits on the first colon, so rejoining reproduces the configured value exactly — and a credential with no colon can never be reproduced by any request. A malformed `basic_auth` therefore locks the tunnel instead of weakening it. Comparing the two halves separately makes `basic_auth: "nocolon"` unlockable by anyone sending `Basic base64("nocolon:")`; there is a regression test pinning this.

## Behaviour worth reviewing

- **`Authorization` is forwarded to the local app, not stripped.** A browser sends one header. An app expecting a *different* value is already broken and stripping doesn't rescue it; an app expecting the *same* value works only if we forward. Caddy's `basic_auth` behaves the same way.
- **Rejected requests are logged as 401** with the credential redacted (`Authorization` is already in `DefaultRedactHeaders`). They never reach the reverse proxy, so without this the inspector stays empty and a working gate looks like a broken tunnel.
- **No `X-Portr-Error` on the 401.** `replayFailure` maps unrecognised error reasons to a 502, and the ping cron reads those headers. A 401 is the feature working, not a portr failure.
- **Plain-text 401 body**, not one of the `error-templates` pages — those are for telling the tunnel owner something is broken and pull Tailwind from a CDN. Browsers only render the body if the user dismisses the prompt.
- **Rejected in team templates.** `team.client_template` is an unencrypted column that every admin can read and every teammate pulls verbatim.

## Known limitation

Replaying a stored request against a protected tunnel returns 401. `replay.Execute` re-issues against the public tunnel URL, and `Authorization` was redacted at capture time, so it forwards the placeholder. Documented, with the replay dialog's header editor and `portr replay --header` as the workaround. The real fix — look the tunnel up by `db.Request.Subdomain` and inject the credential — is ~10 lines across two call sites and left as a follow-up.

Also noted while in here, not fixed: the app-server's `StartTunnelRequest` still does not forward the existing `host_header`.

## Testing

`go build ./...`, `go vet ./...`, `gofmt`, full suite, and `-race` on the changed packages all clean.

New coverage: missing/wrong/correct credentials, `Authorization` forwarded on success, unprotected pass-through, colon in the password, ping bypass, websocket upgrade gated and relayed, the malformed-credential lockout, the 401 inspector record with redaction, config validation and template rejection, and CLI flag registration.

Not run against a live portr server — no server or DNS available in this environment. The gate is exercised end-to-end through the real `httpTunnel` handler with real HTTP parsing.
