### PR TITLE
docs(server): add custom reverse proxy guide

### DIFF
--- a/docs-v2/content/docs/server/cloudflare-api-token.mdx
+++ b/docs-v2/content/docs/server/cloudflare-api-token.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'fumadocs-ui/components/steps';
   If you're using Route53 instead of Cloudflare, check out the [Route53 guide](/docs/resources/route53).
 </Callout>
 
-The Cloudflare API token is required by Caddy for provisioning SSL certificates for wildcard subdomains.
+The Cloudflare API token is required by the bundled Caddy service for provisioning SSL certificates for wildcard subdomains. If you manage certificates yourself or run your own reverse proxy, see the [Custom Reverse Proxy guide](/docs/server/custom-reverse-proxy) instead.
 
 ## Setup Process
 

--- a/docs-v2/content/docs/server/custom-reverse-proxy.mdx
+++ b/docs-v2/content/docs/server/custom-reverse-proxy.mdx
@@ -89,6 +89,8 @@ server {
     location / {
         proxy_pass http://localhost:8000;
         proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto https;
     }
 }
@@ -106,8 +108,11 @@ server {
         proxy_set_header Host $host;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto https;
         proxy_buffering off;
+        proxy_request_buffering off;
         proxy_read_timeout 300s;
         client_max_body_size 0;
     }
@@ -122,7 +127,7 @@ Whatever proxy you use, on the wildcard vhost:
 - **Pass websocket upgrades through** (`Upgrade` / `Connection` headers).
 - **Don't buffer responses** — streaming responses and server-sent events depend on it.
 - **Don't intercept error responses or add proxy-level authentication.** Portr's health checks rely on its own 404 responses and `X-Portr-*` headers reaching clients unmodified, and the `Authorization` header is passed end to end to your local service.
-- **Set `X-Forwarded-Proto: https`** so tunneled applications generate correct absolute URLs.
+- **Set `X-Forwarded-Proto: https` and overwrite `X-Forwarded-For` from the real client address** so tunneled applications generate correct absolute URLs and can't be fed spoofed client IPs.
 - The tunnel proxy speaks HTTP/1.1 only.
 
 The admin dashboard must be served from the root of the apex domain — it cannot be mounted under a path prefix.
@@ -148,7 +153,7 @@ Firewall rules:
 | 80/443 | Allow (your proxy) |
 | 2222 | Allow (SSH tunnel ingress) |
 | 30001-40001 | Allow if you use TCP tunnels |
-| 8000, 8001 | Block from the internet (only your proxy needs them) |
+| 5432, 8000, 8001 | Block from the internet (postgres and portr only need local access) |
 | 20000-30000 | Block from the internet |
 
 <Callout type="warn">

--- a/docs-v2/content/docs/server/custom-reverse-proxy.mdx
+++ b/docs-v2/content/docs/server/custom-reverse-proxy.mdx
@@ -1,0 +1,165 @@
+---
+title: Custom Reverse Proxy
+description: Run Portr behind your own reverse proxy such as Caddy or nginx with manually managed TLS certificates, instead of the bundled Caddy service.
+---
+
+The production compose file bundles a Caddy service that provisions wildcard certificates via DNS-01 (Cloudflare or Route53) and proxies traffic to Portr. This is a convenience, not a requirement — Portr has no dependency on Caddy and never terminates TLS itself. If you already run a reverse proxy on your server, or your DNS provider doesn't support automated DNS-01 validation, you can bring your own proxy and certificates.
+
+## How traffic is routed
+
+Portr listens on plain HTTP/TCP behind the proxy:
+
+| Port | Purpose |
+|------|---------|
+| `8000` | Admin dashboard and API, serves `example.com` |
+| `8001` | Tunnel proxy, serves `*.example.com` |
+| `2222` | SSH ingress for tunnel clients (raw TCP, never proxied) |
+
+Your reverse proxy needs exactly two HTTPS vhosts: the apex domain to port 8000 and the wildcard to port 8001. Per-subdomain routing happens inside Portr based on the `Host` header.
+
+<Callout type="info">
+  TLS must terminate at your proxy. Portr assumes it is served over HTTPS in
+  production — session cookies are marked `Secure` and tunnel URLs are
+  generated with `https://`.
+</Callout>
+
+## Remove the bundled Caddy
+
+Remove the `caddy` service, the `labels` block, and the `caddy_data` volume from `docker-compose.prod.yaml`:
+
+```diff title="docker-compose.prod.yaml"
+ services:
+-  caddy:
+-    image: ghcr.io/amalshaji/caddy-docker-proxy:main
+-    volumes:
+-      - /var/run/docker.sock:/var/run/docker.sock
+-      - caddy_data:/data
+-    restart: unless-stopped
+-    network_mode: "host"
+-
+   server:
+     ...
+-    labels:
+-      caddy_0: $PORTR_DOMAIN
+-      caddy_0.reverse_proxy: "{{upstreams http 8000}}"
+-      caddy_0.encode: gzip
+-      caddy_1: "*.$PORTR_DOMAIN"
+-      caddy_1.reverse_proxy: "{{upstreams http 8001}}"
+-      caddy_1.tls.dns: "cloudflare $CLOUDFLARE_API_TOKEN"
+-      caddy_1.encode: gzip
+```
+
+You can also drop `CLOUDFLARE_API_TOKEN` from your `.env` file — it is only consumed by the Caddy labels.
+
+The `server` service uses `network_mode: "host"`, so ports 8000, 8001, and 2222 are bound directly on the host and reachable at `localhost` from your proxy.
+
+## Example: Caddy with your own certificates
+
+If you already run Caddy, add two site blocks. The `tls` directive with certificate paths disables automatic provisioning — no DNS plugin or API token needed:
+
+```txt title="Caddyfile"
+example.com {
+    tls /etc/certs/wildcard.crt /etc/certs/wildcard.key
+    encode gzip
+    reverse_proxy localhost:8000
+}
+
+*.example.com {
+    tls /etc/certs/wildcard.crt /etc/certs/wildcard.key
+    encode gzip
+    reverse_proxy localhost:8001
+}
+```
+
+## Example: nginx
+
+```nginx title="/etc/nginx/conf.d/portr.conf"
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name example.com;
+
+    ssl_certificate /etc/certs/wildcard.crt;
+    ssl_certificate_key /etc/certs/wildcard.key;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto https;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name *.example.com;
+
+    ssl_certificate /etc/certs/wildcard.crt;
+    ssl_certificate_key /etc/certs/wildcard.key;
+
+    location / {
+        proxy_pass http://localhost:8001;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_buffering off;
+        proxy_read_timeout 300s;
+        client_max_body_size 0;
+    }
+}
+```
+
+## Proxy requirements
+
+Whatever proxy you use, on the wildcard vhost:
+
+- **Forward the `Host` header verbatim, without a port.** Portr routes to tunnels by extracting the subdomain from `Host`; forwarding `sub.example.com:443` results in a 404.
+- **Pass websocket upgrades through** (`Upgrade` / `Connection` headers).
+- **Don't buffer responses** — streaming responses and server-sent events depend on it.
+- **Don't intercept error responses or add proxy-level authentication.** Portr's health checks rely on its own 404 responses and `X-Portr-*` headers reaching clients unmodified, and the `Authorization` header is passed end to end to your local service.
+- **Set `X-Forwarded-Proto: https`** so tunneled applications generate correct absolute URLs.
+- The tunnel proxy speaks HTTP/1.1 only.
+
+The admin dashboard must be served from the root of the apex domain — it cannot be mounted under a path prefix.
+
+## Certificates
+
+- The certificates must cover both `example.com` and `*.example.com` (a single cert with both SANs, or one per vhost).
+- Use certificates from a trusted CA. The Portr client verifies TLS when talking to the server (`portr auth set`, request replay), and the server's own health checks dial `https://<subdomain>.<domain>` — self-signed certificates break these.
+
+## DNS and firewall
+
+DNS records must point directly at the server. Don't route them through a proxying CDN — tunnel clients connect to port 2222 over raw TCP:
+
+| Type | Name | Value |
+|------|------|-------|
+| A    | @    | your-server-ipv4 |
+| A    | *    | your-server-ipv4 |
+
+Firewall rules:
+
+| Port | Action |
+|------|--------|
+| 80/443 | Allow (your proxy) |
+| 2222 | Allow (SSH tunnel ingress) |
+| 30001-40001 | Allow if you use TCP tunnels |
+| 8000, 8001 | Block from the internet (only your proxy needs them) |
+| 20000-30000 | Block from the internet |
+
+<Callout type="warn">
+  Ports 20000-30000 are used internally for HTTP tunnel connections and bind
+  on all interfaces. If left open, tunnel traffic can be reached directly over
+  plain HTTP, bypassing your proxy and TLS. Make sure your firewall blocks
+  them.
+</Callout>
+
+## Troubleshooting
+
+1. **404 with an `X-Portr-Error` header on tunnel URLs**: the `Host` header is being rewritten or forwarded with a port. Forward it verbatim.
+2. **Login loop on the admin dashboard**: the dashboard is being served over plain HTTP. The session cookie is `Secure`-only; serve it over HTTPS.
+3. **Websockets disconnect after ~60 seconds**: your proxy's read timeout is closing idle connections. Increase it (e.g. `proxy_read_timeout` in nginx).

--- a/docs-v2/content/docs/server/index.mdx
+++ b/docs-v2/content/docs/server/index.mdx
@@ -10,7 +10,7 @@ Before setting up your Portr server, ensure you have:
 
 - **A virtual machine** with Docker installed (Hetzner 4GB 2 vCPU is recommended and cost-effective)
 - **DNS records** configured for your domain
-- **Cloudflare API token** for wildcard subdomain SSL setup (or Route53)
+- **Cloudflare API token** for wildcard subdomain SSL setup (or Route53, or [bring your own certificates](/docs/server/custom-reverse-proxy))
 - **GitHub OAuth app credentials** for admin dashboard login (optional)
 - **Required ports** open on the server
 
@@ -36,6 +36,9 @@ Configure the following DNS records for your domain:
   </Card>
   <Card title="Cloudflare API Token" href="/docs/server/cloudflare-api-token">
     Set up Cloudflare API token for SSL certificates.
+  </Card>
+  <Card title="Custom Reverse Proxy" href="/docs/server/custom-reverse-proxy">
+    Use your own reverse proxy and manually managed TLS certificates.
   </Card>
   <Card title="GitHub OAuth App" href="/docs/server/github-oauth-app">
     Configure GitHub OAuth for admin dashboard login.

--- a/docs-v2/content/docs/server/meta.json
+++ b/docs-v2/content/docs/server/meta.json
@@ -6,6 +6,7 @@
     "sqlite-backups",
     "reserved-subdomains",
     "cloudflare-api-token",
+    "custom-reverse-proxy",
     "github-oauth-app"
   ]
 }

--- a/docs-v2/content/docs/server/start-the-tunnel-server.mdx
+++ b/docs-v2/content/docs/server/start-the-tunnel-server.mdx
@@ -68,9 +68,11 @@ POSTGRES_DB=postgres
 | `PORTR_ADMIN_GITHUB_CLIENT_SECRET` | GitHub OAuth client secret | Optional |
 | `PORTR_RESERVED_SUBDOMAIN_LIMIT` | Maximum reserved subdomains per team membership; use `0` to disable new reservations | `3` |
 | `PORTR_AUTO_MIGRATE` | Auto-run database migrations | `false` |
-| `CLOUDFLARE_API_TOKEN` | Cloudflare API token for SSL | Required |
+| `CLOUDFLARE_API_TOKEN` | Cloudflare API token for SSL | Required (bundled Caddy) |
 
 If you run on SQLite instead of PostgreSQL, see [SQLite Backups](/docs/server/sqlite-backups) for the `LITESTREAM_*` variables that replicate the database to object storage.
+
+If you already run a reverse proxy or manage TLS certificates manually, see [Custom Reverse Proxy](/docs/server/custom-reverse-proxy) — the Cloudflare token is only needed by the bundled Caddy service.
 
 ### Generate SSH Host Key
 


### PR DESCRIPTION
## Summary

Adds a new server docs page, **Custom Reverse Proxy** (`/docs/server/custom-reverse-proxy`), covering how to run portr behind a user-managed reverse proxy with manually issued wildcard certificates instead of the bundled caddy service. Addresses the questions in #308.

The page covers:

- Traffic layout: apex → `:8000` (admin), `*.domain` → `:8001` (tunnel proxy), `:2222` raw TCP (never proxied)
- Removing the bundled caddy service and labels from `docker-compose.prod.yaml`
- Example configs: existing Caddy with `tls <cert> <key>` (no DNS plugin/API token needed) and nginx (websocket upgrade, no buffering, HTTP/1.1, `client_max_body_size 0`)
- Proxy requirements: forward `Host` verbatim without a port, pass `X-Portr-*` headers and `Authorization` through, no proxy-level error pages/auth on the wildcard vhost, set `X-Forwarded-Proto`
- Certificate constraints: must cover apex + wildcard, must be from a trusted CA (client CLI and the server health-check cron verify TLS)
- Firewall guidance, including blocking 20000-30000 (HTTP tunnel forwards bind 0.0.0.0 and would bypass TLS if left open)
- Troubleshooting: Host-rewrite 404s, Secure-cookie login loop, proxy read-timeout websocket drops

Also softens existing docs that presented `CLOUDFLARE_API_TOKEN` as a hard requirement — it's only consumed by the bundled caddy labels — and cross-links the new page from the server index, deployment guide, and Cloudflare token page.

## Verification

- `bun run build` in `docs-v2/` passes (page compiles, nav renders from `meta.json`)