### PR TITLE
Accept CLI flags anywhere on the command line

### DIFF
--- a/cmd/portr/args.go
+++ b/cmd/portr/args.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// urfave/cli stops parsing flags at the first positional argument, so in
+// "portr http 8080 --basic-auth admin:admin" the flag would be silently kept
+// as an extra argument and the tunnel would start unprotected. Reorder the
+// raw arguments so flags come before positionals, letting flags appear
+// anywhere on the command line. Commands with subcommands or SkipFlagParsing
+// are left untouched, as is anything after a "--" terminator.
+func reorderArgs(app *cli.App, args []string) []string {
+	cmdIdx := commandIndex(app, args)
+	if cmdIdx == -1 {
+		return args
+	}
+
+	cmd := app.Command(args[cmdIdx])
+	if cmd == nil || cmd.SkipFlagParsing || len(cmd.Subcommands) > 0 {
+		return args
+	}
+
+	rest := args[cmdIdx+1:]
+	var flags, positionals []string
+	for i := 0; i < len(rest); i++ {
+		arg := rest[i]
+		if arg == "--" {
+			positionals = append(positionals, rest[i:]...)
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			positionals = append(positionals, arg)
+			continue
+		}
+		flags = append(flags, arg)
+		name, hasInlineValue := splitFlagToken(arg)
+		if !hasInlineValue && flagTakesValue(cmd.Flags, name) && i+1 < len(rest) {
+			i++
+			flags = append(flags, rest[i])
+		}
+	}
+
+	out := make([]string, 0, len(args))
+	out = append(out, args[:cmdIdx+1]...)
+	out = append(out, flags...)
+	out = append(out, positionals...)
+	return out
+}
+
+// commandIndex returns the index of the command name in args, skipping the
+// program name and any global flags (with their values), or -1 if there is
+// no command.
+func commandIndex(app *cli.App, args []string) int {
+	for i := 1; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return -1
+		}
+		if !strings.HasPrefix(arg, "-") {
+			return i
+		}
+		name, hasInlineValue := splitFlagToken(arg)
+		if !hasInlineValue && flagTakesValue(app.Flags, name) {
+			i++
+		}
+	}
+	return -1
+}
+
+func splitFlagToken(arg string) (name string, hasInlineValue bool) {
+	name, _, hasInlineValue = strings.Cut(strings.TrimLeft(arg, "-"), "=")
+	return name, hasInlineValue
+}
+
+// flagTakesValue reports whether the named flag consumes the next argument as
+// its value. Unknown flags are treated as valueless; they fail flag parsing
+// either way.
+func flagTakesValue(flags []cli.Flag, name string) bool {
+	for _, f := range flags {
+		if slices.Contains(f.Names(), name) {
+			_, isBool := f.(*cli.BoolFlag)
+			return !isBool
+		}
+	}
+	return false
+}

--- a/cmd/portr/args_test.go
+++ b/cmd/portr/args_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestReorderArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			"flags after positional move before it",
+			[]string{"portr", "http", "8080", "--basic-auth", "admin:admin"},
+			[]string{"portr", "http", "--basic-auth", "admin:admin", "8080"},
+		},
+		{
+			"flags before positional stay put",
+			[]string{"portr", "http", "--basic-auth", "admin:admin", "8080"},
+			[]string{"portr", "http", "--basic-auth", "admin:admin", "8080"},
+		},
+		{
+			"mixed flags collect in order",
+			[]string{"portr", "http", "-s", "foo", "8080", "--basic-auth", "admin:admin"},
+			[]string{"portr", "http", "-s", "foo", "--basic-auth", "admin:admin", "8080"},
+		},
+		{
+			"inline value form",
+			[]string{"portr", "serve", "./dist", "--basic-auth=admin:admin"},
+			[]string{"portr", "serve", "--basic-auth=admin:admin", "./dist"},
+		},
+		{
+			"global flags before command are skipped over",
+			[]string{"portr", "-c", "portr.yaml", "http", "8080", "-s", "foo"},
+			[]string{"portr", "-c", "portr.yaml", "http", "-s", "foo", "8080"},
+		},
+		{
+			"everything after -- stays positional",
+			[]string{"portr", "http", "-s", "foo", "8080", "--", "--basic-auth", "x"},
+			[]string{"portr", "http", "-s", "foo", "8080", "--", "--basic-auth", "x"},
+		},
+		{
+			"unknown flag moves alone so parsing fails loudly",
+			[]string{"portr", "tcp", "5432", "--subdomain", "my-postgres"},
+			[]string{"portr", "tcp", "--subdomain", "5432", "my-postgres"},
+		},
+		{
+			"commands with subcommands untouched",
+			[]string{"portr", "config", "edit", "--something"},
+			[]string{"portr", "config", "edit", "--something"},
+		},
+		{
+			"SkipFlagParsing commands untouched",
+			[]string{"portr", "logs", "foo", "--json"},
+			[]string{"portr", "logs", "foo", "--json"},
+		},
+		{
+			"no command untouched",
+			[]string{"portr", "--version"},
+			[]string{"portr", "--version"},
+		},
+	}
+
+	app := buildApp()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reorderArgs(app, tc.in)
+			if !slices.Equal(got, tc.want) {
+				t.Fatalf("reorderArgs(%v)\n got %v\nwant %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// urfave/cli stops parsing flags at the first positional argument, so without
+// reordering, "portr http 8080 --basic-auth admin:admin" would start an
+// unprotected tunnel with no warning. Verify the reordered args parse into
+// flag values end to end.
+func TestReorderedArgsParse(t *testing.T) {
+	var basicAuth, port string
+	app := &cli.App{
+		Commands: []*cli.Command{{
+			Name: "http",
+			Flags: []cli.Flag{
+				&cli.StringFlag{Name: "basic-auth"},
+				&cli.StringFlag{Name: "subdomain", Aliases: []string{"s"}},
+			},
+			Action: func(c *cli.Context) error {
+				basicAuth = c.String("basic-auth")
+				port = c.Args().First()
+				return nil
+			},
+		}},
+	}
+
+	args := reorderArgs(app, []string{"portr", "http", "8080", "--basic-auth", "admin:admin"})
+	if err := app.Run(args); err != nil {
+		t.Fatalf("app.Run failed: %v", err)
+	}
+	if basicAuth != "admin:admin" {
+		t.Fatalf("basic-auth = %q, want %q", basicAuth, "admin:admin")
+	}
+	if port != "8080" {
+		t.Fatalf("port = %q, want %q", port, "8080")
+	}
+}

--- a/cmd/portr/http.go
+++ b/cmd/portr/http.go
@@ -23,11 +23,7 @@ func httpCmd() *cli.Command {
 				Name:  "host-header",
 				Usage: "Host header to send to the local server ('rewrite' to use the local address)",
 			},
-			&cli.StringFlag{
-				Name:    "basic-auth",
-				Usage:   "Protect the tunnel with HTTP basic auth, as user:password",
-				EnvVars: []string{"PORTR_BASIC_AUTH"},
-			},
+			basicAuthFlag(),
 		},
 		Action: func(c *cli.Context) error {
 			portStr := c.Args().First()

--- a/cmd/portr/main.go
+++ b/cmd/portr/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	requestlogs "github.com/amalshaji/portr/internal/client/logs"
 	config "github.com/amalshaji/portr/internal/clientconfig"
@@ -15,8 +14,8 @@ import (
 // Set at build time
 var version = "0.0.0"
 
-func main() {
-	app := &cli.App{
+func buildApp() *cli.App {
+	return &cli.App{
 		Name:    "portr",
 		Usage:   "Expose local ports to the public internet",
 		Version: version,
@@ -43,6 +42,10 @@ func main() {
 			doctorCmd(),
 		},
 	}
+}
+
+func main() {
+	app := buildApp()
 
 	if err := utils.EnsureDirExists(config.DefaultConfigDir); err != nil {
 		fmt.Fprintln(os.Stderr, color.Red(err.Error()))
@@ -56,7 +59,7 @@ func main() {
 	// Load config to check if update checks are disabled
 	cfg, configErr := config.Load(config.DefaultConfigPath)
 	disableUpdateCheck := configErr == nil && cfg.DisableUpdateCheck
-	suppressUpdateNotice := shouldSuppressUpdateNotice(os.Args)
+	suppressUpdateNotice := shouldSuppressUpdateNotice(app, os.Args)
 
 	if !disableUpdateCheck {
 		go func() {
@@ -85,7 +88,7 @@ func main() {
 		}
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	if err := app.Run(reorderArgs(app, os.Args)); err != nil {
 		if err.Error() != "" {
 			fmt.Fprintln(os.Stderr, color.Red(err.Error()))
 		}
@@ -93,51 +96,19 @@ func main() {
 	}
 }
 
-func shouldSuppressUpdateNotice(args []string) bool {
-	logsArgs, ok := commandArgs(args, "logs")
-	if !ok {
-		replayArgs, ok := commandArgs(args, "replay")
-		if !ok {
-			return false
-		}
-
-		if commandWantsHelp(replayArgs) {
-			return true
-		}
-
-		return replayWantsJSON(replayArgs)
+func shouldSuppressUpdateNotice(app *cli.App, args []string) bool {
+	idx := commandIndex(app, args)
+	if idx == -1 {
+		return false
 	}
 
-	if requestlogs.WantsHelp(logsArgs) {
-		return true
+	rest := args[idx+1:]
+	switch args[idx] {
+	case "logs":
+		return requestlogs.WantsHelp(rest) || requestlogs.WantsJSON(rest)
+	case "replay":
+		return commandWantsHelp(rest) || replayWantsJSON(rest)
 	}
 
-	return requestlogs.WantsJSON(logsArgs)
-}
-
-func commandArgs(args []string, command string) ([]string, bool) {
-	for i := 1; i < len(args); i++ {
-		arg := strings.TrimSpace(args[i])
-		if arg == "" {
-			continue
-		}
-
-		switch {
-		case arg == "--config" || arg == "-c":
-			i++
-			continue
-		case strings.HasPrefix(arg, "--config="):
-			continue
-		case strings.HasPrefix(arg, "-"):
-			continue
-		}
-
-		if arg == command {
-			return args[i+1:], true
-		}
-
-		return nil, false
-	}
-
-	return nil, false
+	return false
 }

--- a/cmd/portr/replay_test.go
+++ b/cmd/portr/replay_test.go
@@ -125,13 +125,14 @@ func TestReplayWantsJSONAndHelp(t *testing.T) {
 }
 
 func TestShouldSuppressUpdateNoticeForReplay(t *testing.T) {
-	if !shouldSuppressUpdateNotice([]string{"portr", "replay", "req-1", "--json"}) {
+	app := buildApp()
+	if !shouldSuppressUpdateNotice(app, []string{"portr", "replay", "req-1", "--json"}) {
 		t.Fatal("expected replay json to suppress update notice")
 	}
-	if !shouldSuppressUpdateNotice([]string{"portr", "replay", "--help"}) {
+	if !shouldSuppressUpdateNotice(app, []string{"portr", "replay", "--help"}) {
 		t.Fatal("expected replay help to suppress update notice")
 	}
-	if shouldSuppressUpdateNotice([]string{"portr", "replay", "req-1"}) {
+	if shouldSuppressUpdateNotice(app, []string{"portr", "replay", "req-1"}) {
 		t.Fatal("expected plain replay not to suppress update notice")
 	}
 }

--- a/cmd/portr/serve.go
+++ b/cmd/portr/serve.go
@@ -20,11 +20,7 @@ func serveCmd() *cli.Command {
 				Aliases: []string{"s"},
 				Usage:   "Subdomain to serve the directory from",
 			},
-			&cli.StringFlag{
-				Name:    "basic-auth",
-				Usage:   "Protect the tunnel with HTTP basic auth, as user:password",
-				EnvVars: []string{"PORTR_BASIC_AUTH"},
-			},
+			basicAuthFlag(),
 		},
 		Action: func(c *cli.Context) error {
 			dir := strings.TrimSpace(c.Args().First())

--- a/cmd/portr/start.go
+++ b/cmd/portr/start.go
@@ -15,6 +15,17 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// basicAuthFlag is shared by every command that serves traffic through the
+// client's HTTP reverse proxy. tcp is excluded on purpose: Tunnel.Validate
+// rejects basic_auth there.
+func basicAuthFlag() cli.Flag {
+	return &cli.StringFlag{
+		Name:    "basic-auth",
+		Usage:   "Protect the tunnel with HTTP basic auth, as user:password",
+		EnvVars: []string{"PORTR_BASIC_AUTH"},
+	}
+}
+
 func startTunnels(c *cli.Context, tunnelFromCli *config.Tunnel) error {
 	cfg, err := config.Load(c.String("config"))
 	if err != nil {

--- a/cmd/portr/stub.go
+++ b/cmd/portr/stub.go
@@ -30,11 +30,7 @@ func stubCmd() *cli.Command {
 				Name:  "response-tmpl-file",
 				Usage: "Path to a response template file",
 			},
-			&cli.StringFlag{
-				Name:    "basic-auth",
-				Usage:   "Protect the tunnel with HTTP basic auth, as user:password",
-				EnvVars: []string{"PORTR_BASIC_AUTH"},
-			},
+			basicAuthFlag(),
 		},
 		Action: func(c *cli.Context) error {
 			return startTunnels(c, &config.Tunnel{

--- a/docs-v2/content/docs/client/http-tunnel.mdx
+++ b/docs-v2/content/docs/client/http-tunnel.mdx
@@ -58,6 +58,9 @@ A tunnel URL is public as soon as it starts. `basic_auth` puts HTTP basic auth i
 portr http 9000 --basic-auth admin:s3cret
 ```
 
+Flags can appear anywhere on the command line — before or after the port, in
+any order.
+
 The value is `user:password`, split on the first colon — your password may contain colons, the username may not. Because a credential on the command line is visible in the process table and lands in your shell history, you can pass it through the environment instead:
 
 ```bash

--- a/docs-v2/content/docs/client/tcp-tunnel.mdx
+++ b/docs-v2/content/docs/client/tcp-tunnel.mdx
@@ -37,8 +37,13 @@ TCP tunnels work differently from HTTP tunnels:
 
 ## Configuration
 
-You can specify custom subdomains and ports just like with HTTP tunnels:
+TCP tunnels do not use subdomains — the server assigns a public port from the
+`30001-40001` range and prints the address when the tunnel starts. Define one
+in the config file like any other tunnel:
 
-```bash
-portr tcp 5432 --subdomain my-postgres
+```yaml
+tunnels:
+  - name: postgres
+    type: tcp
+    port: 5432
 ```

--- a/internal/client/appserver/manager.go
+++ b/internal/client/appserver/manager.go
@@ -316,22 +316,11 @@ func (m *Manager) Shutdown(ctx context.Context) {
 }
 
 func (m *Manager) clientConfigForTunnel(tunnel clientcfg.Tunnel) clientcfg.ClientConfig {
-	return clientcfg.ClientConfig{
-		ServerUrl:                       m.baseConfig.ServerUrl,
-		SshUrl:                          m.baseConfig.SshUrl,
-		TunnelUrl:                       m.baseConfig.TunnelUrl,
-		SecretKey:                       m.baseConfig.SecretKey,
-		Tunnel:                          tunnel,
-		UseLocalHost:                    m.baseConfig.UseLocalHost,
-		Debug:                           m.baseConfig.Debug,
-		EnableRequestLogging:            *m.baseConfig.EnableRequestLogging,
-		RedactHeaders:                   append([]string(nil), m.baseConfig.RedactHeaders...),
-		HealthCheckInterval:             m.baseConfig.HealthCheckInterval,
-		HealthCheckMaxRetries:           m.baseConfig.HealthCheckMaxRetries,
-		DisableTUI:                      true,
-		DisableTerminalLogs:             true,
-		InsecureSkipHostKeyVerification: *m.baseConfig.InsecureSkipHostKeyVerification,
-	}
+	cfg := m.baseConfig.ClientConfigForTunnel(tunnel)
+	// The app server runs headless, regardless of what the base config says.
+	cfg.DisableTUI = true
+	cfg.DisableTerminalLogs = true
+	return cfg
 }
 
 func (m *Manager) handleStartFailure(id string, err error) {

--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -131,21 +131,7 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 	}
 
 	for _, tunnel := range tunnels {
-		clientConfigs = append(clientConfigs, config.ClientConfig{
-			ServerUrl:                       c.config.ServerUrl,
-			SshUrl:                          c.config.SshUrl,
-			TunnelUrl:                       c.config.TunnelUrl,
-			SecretKey:                       c.config.SecretKey,
-			Tunnel:                          tunnel,
-			UseLocalHost:                    c.config.UseLocalHost,
-			Debug:                           c.config.Debug,
-			EnableRequestLogging:            *c.config.EnableRequestLogging,
-			RedactHeaders:                   append([]string(nil), c.config.RedactHeaders...),
-			HealthCheckInterval:             c.config.HealthCheckInterval,
-			HealthCheckMaxRetries:           c.config.HealthCheckMaxRetries,
-			DisableTUI:                      c.config.DisableTUI,
-			InsecureSkipHostKeyVerification: *c.config.InsecureSkipHostKeyVerification,
-		})
+		clientConfigs = append(clientConfigs, c.config.ClientConfigForTunnel(tunnel))
 	}
 
 	var err error

--- a/internal/client/ssh/basic_auth_test.go
+++ b/internal/client/ssh/basic_auth_test.go
@@ -280,14 +280,18 @@ func TestRejectedRequestIsLoggedWithRedactedCredential(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			backend := newGatedBackend(t)
 
+			// Built through ClientConfigForTunnel because that is where
+			// Authorization is forced into the redaction list.
+			enabled := true
+			base := clientcfg.Config{
+				EnableRequestLogging:            &enabled,
+				InsecureSkipHostKeyVerification: &enabled,
+				RedactHeaders:                   tt.redactHeaders,
+			}
 			client := &SshClient{
-				config: clientcfg.ClientConfig{
-					EnableRequestLogging: true,
-					RedactHeaders:        tt.redactHeaders,
-					Tunnel: clientcfg.Tunnel{
-						Name: "test", Subdomain: "test", Port: 3000, BasicAuth: "admin:s3cret",
-					},
-				},
+				config: base.ClientConfigForTunnel(clientcfg.Tunnel{
+					Name: "test", Subdomain: "test", Port: 3000, BasicAuth: "admin:s3cret",
+				}),
 				db: newTestRequestStore(t),
 			}
 

--- a/internal/client/ssh/logging_test.go
+++ b/internal/client/ssh/logging_test.go
@@ -43,6 +43,10 @@ func newLoggingTestClient(store *clientdb.Db, enabled bool) *SshClient {
 	return &SshClient{
 		config: clientcfg.ClientConfig{
 			EnableRequestLogging: enabled,
+			// In production Config.SetDefaults materializes this list before
+			// ClientConfigForTunnel copies it over; hand-built configs must do
+			// the same.
+			RedactHeaders: clientcfg.DefaultRedactHeaders,
 			Tunnel: clientcfg.Tunnel{
 				Name:      "test-server",
 				Subdomain: "test-server",

--- a/internal/client/ssh/ssh.go
+++ b/internal/client/ssh/ssh.go
@@ -388,32 +388,9 @@ func (s *SshClient) httpTunnelReverseProxy(src net.Conn, localEndpoint string) {
 	}
 }
 
-// redactHeaderNames returns the redaction list to use for this tunnel's
-// captures. When basic auth is enabled, Authorization is forced into the list
-// so a custom redact_headers list can never persist the tunnel's own
-// credential.
-func (s *SshClient) redactHeaderNames() []string {
-	names := s.config.RedactHeaders
-	// An empty list falls back to DefaultRedactHeaders inside
-	// redactHeaderValues, which already includes Authorization.
-	if len(names) == 0 || s.config.Tunnel.ResolvedBasicAuth() == "" {
-		return names
-	}
-
-	for _, name := range names {
-		if strings.EqualFold(name, "Authorization") {
-			return names
-		}
-	}
-
-	return append(append([]string(nil), names...), "Authorization")
-}
-
+// redactHeaderValues expects the tunnel's resolved redaction list; see
+// Config.ClientConfigForTunnel.
 func redactHeaderValues(headers http.Header, redactNames []string) map[string][]string {
-	if len(redactNames) == 0 {
-		redactNames = config.DefaultRedactHeaders
-	}
-
 	redactSet := make(map[string]struct{}, len(redactNames))
 	for _, name := range redactNames {
 		redactSet[strings.ToLower(name)] = struct{}{}
@@ -480,7 +457,7 @@ func (s *SshClient) logHttpRequestSized(
 		isReplayedRequest = true
 	}
 
-	requestHeaders := redactHeaderValues(request.Header, s.redactHeaderNames())
+	requestHeaders := redactHeaderValues(request.Header, s.config.RedactHeaders)
 	delete(requestHeaders, "X-Portr-Replayed-Request-Id")
 
 	requestHeadersBytes, err := json.Marshal(requestHeaders)
@@ -491,7 +468,7 @@ func (s *SshClient) logHttpRequestSized(
 		return
 	}
 
-	responseHeaders := redactHeaderValues(response.Header, s.redactHeaderNames())
+	responseHeaders := redactHeaderValues(response.Header, s.config.RedactHeaders)
 
 	responseHeadersBytes, err := json.Marshal(responseHeaders)
 	if err != nil {

--- a/internal/client/ssh/websocket.go
+++ b/internal/client/ssh/websocket.go
@@ -147,7 +147,7 @@ func (s *SshClient) logWebSocketSessionWithID(sessionID, handshakeRequestID stri
 		return ""
 	}
 
-	requestHeaders := redactHeaderValues(request.Header, s.redactHeaderNames())
+	requestHeaders := redactHeaderValues(request.Header, s.config.RedactHeaders)
 	requestHeadersBytes, err := json.Marshal(requestHeaders)
 	if err != nil {
 		if s.config.Debug {
@@ -156,7 +156,7 @@ func (s *SshClient) logWebSocketSessionWithID(sessionID, handshakeRequestID stri
 		return ""
 	}
 
-	responseHeaders := redactHeaderValues(response.Header, s.redactHeaderNames())
+	responseHeaders := redactHeaderValues(response.Header, s.config.RedactHeaders)
 	responseHeadersBytes, err := json.Marshal(responseHeaders)
 	if err != nil {
 		if s.config.Debug {

--- a/internal/clientconfig/config.go
+++ b/internal/clientconfig/config.go
@@ -133,7 +133,7 @@ func (t *Tunnel) ResolvedBasicAuth() string {
 // The split is on the first colon only, matching RFC 7617: a userid cannot
 // contain a colon, a password can.
 func (t *Tunnel) validateBasicAuth() error {
-	value := strings.TrimSpace(t.BasicAuth)
+	value := t.ResolvedBasicAuth()
 	if value == "" {
 		return nil
 	}
@@ -560,6 +560,46 @@ type ClientConfig struct {
 	DisableTUI                      bool
 	DisableTerminalLogs             bool
 	InsecureSkipHostKeyVerification bool
+}
+
+// ClientConfigForTunnel builds the per-tunnel config handed to the tunnel
+// client. It expects a loaded Config, i.e. one that went through SetDefaults.
+// The redaction list is resolved here so every consumer inherits the same
+// guarantee: a tunnel that enforces basic auth always redacts Authorization,
+// even when a custom redact_headers list omits it, so captures can never
+// persist the tunnel's own credential.
+func (c *Config) ClientConfigForTunnel(tunnel Tunnel) ClientConfig {
+	return ClientConfig{
+		ServerUrl:                       c.ServerUrl,
+		SshUrl:                          c.SshUrl,
+		TunnelUrl:                       c.TunnelUrl,
+		SecretKey:                       c.SecretKey,
+		Tunnel:                          tunnel,
+		UseLocalHost:                    c.UseLocalHost,
+		Debug:                           c.Debug,
+		EnableRequestLogging:            *c.EnableRequestLogging,
+		RedactHeaders:                   c.redactHeadersForTunnel(tunnel),
+		HealthCheckInterval:             c.HealthCheckInterval,
+		HealthCheckMaxRetries:           c.HealthCheckMaxRetries,
+		DisableTUI:                      c.DisableTUI,
+		InsecureSkipHostKeyVerification: *c.InsecureSkipHostKeyVerification,
+	}
+}
+
+func (c *Config) redactHeadersForTunnel(tunnel Tunnel) []string {
+	names := append([]string(nil), c.RedactHeaders...)
+	if tunnel.ResolvedBasicAuth() == "" {
+		return names
+	}
+
+	hasAuthorization := slices.ContainsFunc(names, func(name string) bool {
+		return strings.EqualFold(name, "Authorization")
+	})
+	if hasAuthorization {
+		return names
+	}
+
+	return append(names, "Authorization")
 }
 
 const DefaultDashboardPort = 7777


### PR DESCRIPTION
## What

`portr http 8080 --basic-auth admin:admin` now works. Previously urfave/cli stopped flag parsing at the first positional argument, so a flag placed after the port was silently kept as an extra argument — in the basic-auth case that meant starting an **unprotected** tunnel with no warning.

## How

- New `reorderArgs` preprocesses `os.Args` before `app.Run`: flags (with their values) move ahead of positionals within the command's scope, then urfave parses normally.
  - Knows which flags take values from the command's own flag definitions; handles `--flag value`, `--flag=value`, aliases, and global flags before the command name.
  - Commands with subcommands (`config`, `auth`, `admin`) and `SkipFlagParsing` commands (`logs`, `replay`) are left untouched; everything after `--` stays positional.
  - Unknown flags now fail loudly (`flag provided but not defined`) instead of being ignored, e.g. `portr tcp 5432 --subdomain x`.
- The update-notice command detection reuses the same walker instead of a second hand-rolled one, and `buildApp()` is extracted so tests run against the real app wiring.

## Refactor (second commit)

- Redaction policy resolved in one place: new `Config.ClientConfigForTunnel` constructor builds the per-tunnel config for both the CLI client and the app server, forcing `Authorization` into the redact list when the tunnel enforces basic auth. Removes the per-log-call `redactHeaderNames` layering in the ssh package and the dead empty-list fallback. App-server tunnels now get the same guarantee through the same path.
- `--basic-auth` flag definition shared across `http`/`serve`/`stub` instead of three inline copies.

## Docs

- `http-tunnel.mdx`: examples restored to the natural `portr http 9000 --flag` form, with a note that flags can appear anywhere.
- `tcp-tunnel.mdx`: removed a `--subdomain` example the tcp command never supported.

## Testing

- `args_test.go`: 10 reorder cases + end-to-end parse test.
- `basic_auth_test.go` redaction test now routes through `ClientConfigForTunnel`, so the property "a custom redact_headers list cannot expose the gate credential" is tested against the production path.
- Full `go test ./...` passes; binary smoke-tested (`portr http 8080 --basic-auth nocolon` reaches credential validation).