### PR TITLE
Indicate basic auth in the TUI and adapt status colors for light terminals

### DIFF
--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -52,10 +52,17 @@ type AddDebugLogMsg struct {
 	Error   string
 }
 
+// Pure #00ff00 and ANSI yellow are unreadable on light backgrounds, so both
+// resolve per terminal theme; red and gray read fine on either.
+var (
+	green  = lipgloss.AdaptiveColor{Light: "#1a7f37", Dark: "#00ff00"}
+	yellow = lipgloss.AdaptiveColor{Light: "#9a6700", Dark: "yellow"}
+)
+
 var (
 	titleStyle = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("#00ff00")).
+			Foreground(green).
 			MarginLeft(2)
 
 	subtitleStyle = lipgloss.NewStyle().
@@ -72,10 +79,10 @@ var (
 			BorderForeground(lipgloss.Color("240"))
 
 	healthyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#00ff00"))
+			Foreground(green)
 
 	unhealthyStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("yellow")).
+			Foreground(yellow).
 			Bold(true)
 
 	// red style for fully unhealthy state (no active connections)
@@ -191,6 +198,10 @@ func tunnelKey(tunnelConfig *config.Tunnel) string {
 }
 
 func New(debug bool, dashboardURL string, dashboardDisabledLabel string, enableQRCode bool) *tea.Program {
+	// Resolve the terminal background now, while stdin is still ours; once
+	// bubbletea owns input the OSC query times out and defaults to dark.
+	lipgloss.HasDarkBackground()
+
 	// Initial default widths
 	const (
 		timeWidth   = 12
@@ -443,6 +454,10 @@ func (m model) View() string {
 		} else {
 			tunnelStyle = healthyStyle
 			statusText = "🟢 Healthy (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
+		}
+
+		if tunnel.config.ResolvedBasicAuth() != "" {
+			statusText = "🔒 " + statusText
 		}
 
 		tunnelName := tunnel.config.DisplayName()

--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -200,6 +200,8 @@ func tunnelKey(tunnelConfig *config.Tunnel) string {
 func New(debug bool, dashboardURL string, dashboardDisabledLabel string, enableQRCode bool) *tea.Program {
 	// Resolve the terminal background now, while stdin is still ours; once
 	// bubbletea owns input the OSC query times out and defaults to dark.
+	// termenv cannot detect the background on Windows and always reports
+	// dark, so Windows keeps the dark palette — unchanged from before.
 	lipgloss.HasDarkBackground()
 
 	// Initial default widths
@@ -456,11 +458,13 @@ func (m model) View() string {
 			statusText = "🟢 Healthy (" + fmt.Sprint(tunnel.active) + "/" + fmt.Sprint(max(1, tunnel.poolSize)) + ")"
 		}
 
-		if tunnel.config.ResolvedBasicAuth() != "" {
-			statusText = "🔒 " + statusText
-		}
-
 		tunnelName := tunnel.config.DisplayName()
+		if tunnel.config.ResolvedBasicAuth() != "" {
+			// The right end of the line truncates first on narrow
+			// terminals, so the auth marker sits by the name to stay
+			// visible.
+			tunnelName += " 🔒"
+		}
 		tunnelAddr := ""
 		if tunnel.clientConfig != nil {
 			tunnelAddr = tunnel.clientConfig.GetTunnelAddr()

--- a/internal/client/tui/tui_test.go
+++ b/internal/client/tui/tui_test.go
@@ -46,12 +46,14 @@ func TestViewRendersAuthIndicator(t *testing.T) {
 				poolSize:     2,
 			},
 		},
-		width: 200,
+		// Default terminal width: the right end of the line truncates,
+		// so the marker must survive next to the tunnel name.
+		width: 80,
 	}
 
 	view := m.View()
-	if !strings.Contains(view, "🔒 🟢 Healthy (2/2)") {
-		t.Fatalf("expected auth indicator before status, got %q", view)
+	if !strings.Contains(view, "audio-stream 🔒 (") {
+		t.Fatalf("expected auth indicator next to tunnel name, got %q", view)
 	}
 }
 

--- a/internal/client/tui/tui_test.go
+++ b/internal/client/tui/tui_test.go
@@ -29,6 +29,30 @@ func TestViewRendersStatusIcons(t *testing.T) {
 	if !strings.Contains(view, "🟢 Healthy (2/2)") {
 		t.Fatalf("expected healthy icon and count, got %q", view)
 	}
+	if strings.Contains(view, "🔒") {
+		t.Fatalf("expected no auth indicator without basic auth, got %q", view)
+	}
+}
+
+func TestViewRendersAuthIndicator(t *testing.T) {
+	tunnel := testTunnel()
+	tunnel.BasicAuth = "admin:admin"
+	m := model{
+		tunnels: map[string]*tunnelStatus{
+			"8765": {
+				config:       &tunnel,
+				clientConfig: testClientConfig(tunnel),
+				active:       2,
+				poolSize:     2,
+			},
+		},
+		width: 200,
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "🔒 🟢 Healthy (2/2)") {
+		t.Fatalf("expected auth indicator before status, got %q", view)
+	}
 }
 
 func TestUpdateConnCountClampsToPoolSize(t *testing.T) {


### PR DESCRIPTION
## Summary

- Tunnels with `basic_auth` configured now show a 🔒 indicator before the health status in the TUI:
  `8080 (localhost:8080 → https://xxx.portr.dev) [xxx] 🔒 🟢 Healthy (2/2)`
- Pure `#00ff00` green and ANSI yellow are hard to read on light terminal backgrounds. Both now use `lipgloss.AdaptiveColor`: dark terminals keep the existing colors, light terminals get darker variants (`#1a7f37` green, `#9a6700` yellow).
- `New()` resolves the terminal background via `lipgloss.HasDarkBackground()` before bubbletea takes over stdin. lipgloss caches the result with `sync.Once`; querying after bubbletea owns input times out and falls back to dark, which would leave light terminals with the old unreadable colors.

## Checks

- `go test ./internal/client/tui/...` — includes new tests for the auth indicator (present with `basic_auth`, absent without)
- `make buildgo`
- `make testgo`

Manual verification: `make buildcli && ./portr http 8080 --basic-auth admin:admin` in a light-themed terminal.