### PR TITLE
fix(client): report TUI health against effective worker count

### DIFF
--- a/internal/client/client/client.go
+++ b/internal/client/client/client.go
@@ -167,7 +167,10 @@ func (c *Client) Start(ctx context.Context, services ...string) error {
 			}
 		}
 
+		// The TUI sizes its Healthy/Partial threshold from Tunnel.PoolSize, so hand
+		// every worker the effective count rather than the configured one.
 		workers := desiredWorkers(clientConfig, poolingSupported)
+		clientConfig.Tunnel.PoolSize = workers
 
 		if clientConfig.Tunnel.Type == constants.Http && workers > 1 && clientConfig.ConnectionID == "" {
 			connID, err := sshclient.CreateNewConnectionWithContext(ctx, clientConfig)

--- a/internal/client/client/client_lifecycle_test.go
+++ b/internal/client/client/client_lifecycle_test.go
@@ -1,10 +1,14 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 	"time"
+
+	clientcfg "github.com/amalshaji/portr/internal/clientconfig"
+	"github.com/amalshaji/portr/internal/constants"
 )
 
 func TestReportFatalPublishesFirstErrorOnce(t *testing.T) {
@@ -51,5 +55,40 @@ func TestRunFatalWorkerRecoversPanic(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for panic error")
+	}
+}
+
+func TestStartHandsWorkersEffectivePoolSize(t *testing.T) {
+	cfg := clientcfg.Config{
+		ServerUrl:    "127.0.0.1:1",
+		UseLocalHost: true,
+		DisableTUI:   true,
+		Tunnels: []clientcfg.Tunnel{
+			{Name: "tcp-test", Type: constants.Tcp, Port: 4321},
+		},
+	}
+	cfg.SetDefaults()
+
+	c := &Client{config: &cfg, exitCh: make(chan error, 1)}
+	t.Cleanup(func() {
+		c.Shutdown(context.Background())
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := c.Start(ctx); err != nil {
+		t.Fatalf("Start returned error: %v", err)
+	}
+
+	if len(c.sshcs) != 1 {
+		t.Fatalf("expected 1 ssh client, got %d", len(c.sshcs))
+	}
+
+	// Pins the call site in Start: the TUI reads PoolSize off the config
+	// handed to each worker, so the effective count must be stamped onto
+	// clientConfig before sshclient.New, not left as the raw configured value.
+	if got := c.sshcs[0].ConfigSnapshot().Tunnel.PoolSize; got != 1 {
+		t.Fatalf("expected worker to receive effective pool size 1, got %d", got)
 	}
 }

--- a/internal/client/tui/tui_test.go
+++ b/internal/client/tui/tui_test.go
@@ -162,6 +162,33 @@ func TestViewRendersStaticTunnelWithoutLocalPort(t *testing.T) {
 	}
 }
 
+func TestViewRendersTcpTunnelHealthyWithSingleWorker(t *testing.T) {
+	// A TCP tunnel runs exactly one worker regardless of pool_size. The client
+	// hands the TUI the effective count, so one active connection is Healthy,
+	// not Partial (1/2).
+	tunnel := config.Tunnel{
+		Name:     "tcp-test",
+		Type:     constants.Tcp,
+		Host:     "localhost",
+		Port:     4321,
+		PoolSize: 1,
+	}
+	m := model{tunnels: map[string]*tunnelStatus{}, width: 200}
+
+	updated, _ := m.Update(AddTunnelMsg{Config: &tunnel, ClientConfig: testClientConfig(tunnel), Healthy: true})
+	m = updated.(model)
+	updated, _ = m.Update(UpdateConnCountMsg{Port: tunnel.StatusKey(), Delta: 1})
+	m = updated.(model)
+
+	view := m.View()
+	if !strings.Contains(view, "🟢 Healthy (1/1)") {
+		t.Fatalf("expected healthy 1/1 status, got %q", view)
+	}
+	if strings.Contains(view, "Partial") {
+		t.Fatalf("expected no partial status, got %q", view)
+	}
+}
+
 func TestTunnelKeyDistinguishesStaticTunnelsSharingLocalPort(t *testing.T) {
 	// Every static tunnel is served from one responder port, so a port-based
 	// key would collapse them into a single row with a wrong health count.


### PR DESCRIPTION
Closes #314

## Problem

`portr tcp 4321` starts one SSH worker but the TUI renders `🟡 Partial (1/2)` for a perfectly healthy tunnel. `Tunnel.SetDefaults` gives every non-stub/static tunnel `pool_size: 2`, `desiredWorkers()` clamps that to 1 for anything that is not HTTP (and for HTTP against a pre-v1 server), but the TUI never saw the clamped number. Each worker sends `AddTunnelMsg{ClientConfig: &cfg}` and the TUI derives its Healthy/Partial threshold from `cfg.Tunnel.PoolSize`, which was still the raw configured value.

## Change

In `Client.Start`, after computing the effective worker count, stamp it onto the `ClientConfig` handed to each worker:

```go
workers := desiredWorkers(clientConfig, poolingSupported)
clientConfig.Tunnel.PoolSize = workers
```

This is the same contract `prepareStubTunnels` and `prepareStaticTunnels` already follow when they set `PoolSize = 1`. No other consumer reads `Tunnel.PoolSize` after `Start`; the app-server manager has its own worker resolution and no TUI.

Result: TCP renders `🟢 Healthy (1/1)`, HTTP with `pool_size: 4` on a v1+ server still renders `Healthy (4/4)`, HTTP against a pre-v1 server renders `Healthy (1/1)`.

## Tests

- `TestStartHandsWorkersEffectivePoolSize` drives `Client.Start` with a TCP tunnel and a pre-cancelled context (no network), then asserts the config handed to the worker carries `PoolSize == 1`. It fails with `got 2` if the call-site line is reverted. Clean under `-race -count=20`.
- `TestViewRendersTcpTunnelHealthyWithSingleWorker` drives the TUI through `AddTunnelMsg` and `UpdateConnCountMsg` and asserts `🟢 Healthy (1/1)`.

## Verification

`gofmt`, `go vet ./internal/client/...`, `go build ./...`, `go test ./internal/client/... -count=1`.